### PR TITLE
use int32_t to express the stream error state

### DIFF
--- a/include/quicly/constants.h
+++ b/include/quicly/constants.h
@@ -51,8 +51,12 @@
 #define QUICLY_ERROR_CONNECTION_CLOSED 0xff04
 #define QUICLY_ERROR_TOO_MANY_OPEN_STREAMS 0xff05
 
-/* application error codes */
-#define QUICLY_APPLICATION_ERROR_STOPPING 0
+/* application error codes returned by  */
+#define QUICLY_STREAM_ERROR_IS_OPEN -1
+#define QUICLY_STREAM_ERROR_FIN_CLOSED -2
+#define QUICLY_STREAM_ERROR_STOPPED 0
+
+typedef int32_t quicly_stream_error_t;
 
 #define QUICLY_BUILD_ASSERT(condition) ((void)sizeof(char[2 * !!(!__builtin_constant_p(condition) || (condition)) - 1]))
 

--- a/include/quicly/sendbuf.h
+++ b/include/quicly/sendbuf.h
@@ -46,9 +46,9 @@ struct st_quicly_sendbuf_t {
      */
     uint64_t eos;
     /**
-     * the reason peer requested stop (or ERROR_FIN_CLOSED)
+     * the reason peer requested stop (or open, or fin-closed)
      */
-    uint16_t stop_reason;
+    quicly_stream_error_t error_code;
     /**
      * callback
      */
@@ -67,6 +67,7 @@ typedef struct st_quicly_sendbuf_dataiter_t {
 
 void quicly_sendbuf_init(quicly_sendbuf_t *buf, quicly_sendbuf_change_cb on_change);
 void quicly_sendbuf_dispose(quicly_sendbuf_t *buf);
+static quicly_stream_error_t quicly_sendbuf_get_error(quicly_sendbuf_t *buf);
 static int quicly_sendbuf_transfer_complete(quicly_sendbuf_t *buf);
 int quicly_sendbuf_write(quicly_sendbuf_t *buf, const void *p, size_t len, quicly_buffer_free_cb free_cb);
 int quicly_sendbuf_shutdown(quicly_sendbuf_t *buf);
@@ -78,6 +79,11 @@ static void quicly_sendbuf_init_dataiter(quicly_sendbuf_t *buf, quicly_sendbuf_d
 static void quicly_sendbuf_advance_dataiter(quicly_sendbuf_dataiter_t *iter, size_t nbytes);
 
 /* inline definitions */
+
+inline quicly_stream_error_t quicly_sendbuf_get_error(quicly_sendbuf_t *buf)
+{
+    return buf->error_code;
+}
 
 inline int quicly_sendbuf_transfer_complete(quicly_sendbuf_t *buf)
 {

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2852,9 +2852,9 @@ static int handle_stop_sending_frame(quicly_conn_t *conn, quicly_stop_sending_fr
     if ((ret = get_stream_or_open_if_new(conn, frame->stream_id, &stream)) != 0 || stream == NULL)
         return ret;
 
-    if (stream->sendbuf.stop_reason == QUICLY_ERROR_FIN_CLOSED)
-        stream->sendbuf.stop_reason = frame->app_error_code;
-    quicly_reset_stream(stream, QUICLY_APPLICATION_ERROR_STOPPING);
+    if (stream->sendbuf.error_code == QUICLY_STREAM_ERROR_IS_OPEN)
+        stream->sendbuf.error_code = frame->app_error_code;
+    quicly_reset_stream(stream, 0 /* STOPPING */);
     return 0;
 }
 
@@ -3231,6 +3231,7 @@ void quicly_request_stop(quicly_stream_t *stream, uint16_t error_code)
 
     /* send STOP_SENDING if the incoming side of the stream is still open */
     if (stream->recvbuf.eos == UINT64_MAX && stream->_send_aux.stop_sending.sender_state == QUICLY_SENDER_STATE_NONE) {
+        stream->recvbuf._error_code = QUICLY_STREAM_ERROR_STOPPED;
         stream->_send_aux.stop_sending.sender_state = QUICLY_SENDER_STATE_SEND;
         stream->_send_aux.stop_sending.error_code = error_code;
         sched_stream_control(stream);

--- a/lib/recvbuf.c
+++ b/lib/recvbuf.c
@@ -28,7 +28,7 @@ void quicly_recvbuf_init(quicly_recvbuf_t *buf, quicly_recvbuf_change_cb on_chan
     quicly_buffer_init(&buf->data);
     buf->data_off = 0;
     buf->eos = UINT64_MAX;
-    buf->error_code = QUICLY_ERROR_FIN_CLOSED;
+    buf->_error_code = QUICLY_STREAM_ERROR_FIN_CLOSED; /* see get_error; the value is not returned until all the data is read */
     buf->on_change = on_change;
 }
 
@@ -79,7 +79,10 @@ int quicly_recvbuf_reset(quicly_recvbuf_t *buf, uint16_t error_code, uint64_t eo
         goto Exit;
     quicly_buffer_init(&buf->data);
     buf->data_off = eos_at;
-    buf->error_code = error_code;
+
+    /* the code will be set to STOPPED if we have sent STOP_SENDING */
+    if (buf->_error_code != QUICLY_STREAM_ERROR_STOPPED)
+        buf->_error_code = error_code;
 
 Exit:
     return ret;

--- a/lib/sendbuf.c
+++ b/lib/sendbuf.c
@@ -32,7 +32,7 @@ void quicly_sendbuf_init(quicly_sendbuf_t *buf, quicly_sendbuf_change_cb on_chan
     quicly_ranges_init(&buf->pending);
     quicly_buffer_init(&buf->data);
     buf->eos = UINT64_MAX;
-    buf->stop_reason = QUICLY_ERROR_FIN_CLOSED;
+    buf->error_code = QUICLY_STREAM_ERROR_IS_OPEN;
     buf->on_change = on_change;
 }
 
@@ -70,6 +70,7 @@ int quicly_sendbuf_shutdown(quicly_sendbuf_t *buf)
     buf->eos = buf->acked.ranges[0].end + buf->data.len;
     if ((ret = quicly_ranges_add(&buf->pending, buf->eos, buf->eos + 1)) != 0)
         goto Exit;
+    buf->error_code = QUICLY_STREAM_ERROR_FIN_CLOSED;
 
     buf->on_change(buf);
 Exit:

--- a/src/cli.c
+++ b/src/cli.c
@@ -170,7 +170,7 @@ static int on_resp_receive(quicly_stream_t *stream)
         quicly_recvbuf_shift(&stream->recvbuf, input.len);
     }
 
-    if (quicly_recvbuf_is_shutdown(&stream->recvbuf, NULL)) {
+    if (quicly_recvbuf_get_error(&stream->recvbuf) != QUICLY_STREAM_ERROR_IS_OPEN) {
         static size_t num_resp_received;
         ++num_resp_received;
         if (req_paths[num_resp_received] == NULL) {

--- a/t/simple.c
+++ b/t/simple.c
@@ -83,7 +83,7 @@ static void simple_http(void)
     server_stream = quicly_get_stream(server, client_stream->stream_id);
     ok(server_stream != NULL);
     ok(recvbuf_is(&server_stream->recvbuf, req));
-    ok(quicly_recvbuf_is_shutdown(&server_stream->recvbuf, NULL));
+    ok(quicly_recvbuf_get_error(&server_stream->recvbuf) == QUICLY_STREAM_ERROR_FIN_CLOSED);
     quicly_sendbuf_write(&server_stream->sendbuf, resp, strlen(resp), NULL);
     quicly_sendbuf_shutdown(&server_stream->sendbuf);
     ok(quicly_num_streams(server) == 2);
@@ -91,7 +91,7 @@ static void simple_http(void)
     transmit(server, client);
 
     ok(recvbuf_is(&client_stream->recvbuf, resp));
-    ok(quicly_recvbuf_is_shutdown(&client_stream->recvbuf, NULL));
+    ok(quicly_recvbuf_get_error(&client_stream->recvbuf) == QUICLY_STREAM_ERROR_FIN_CLOSED);
     quicly_close_stream(client_stream);
     ok(quicly_num_streams(client) == 1);
     assert(!quicly_stream_is_closable(server_stream));
@@ -183,7 +183,7 @@ static void tiny_stream_window(void)
 
     ok(recvbuf_is(&server_stream->recvbuf, "orld"));
     ok(server_stream->recvbuf.data.len == 0);
-    ok(quicly_recvbuf_is_shutdown(&server_stream->recvbuf, NULL));
+    ok(quicly_recvbuf_get_error(&server_stream->recvbuf) == QUICLY_STREAM_ERROR_FIN_CLOSED);
 
     quicly_request_stop(client_stream, 12345);
 
@@ -252,7 +252,7 @@ static void test_rst_during_loss(void)
     quicly_reset_stream(client_stream, 12345);
     transmit(client, server);
 
-    ok(quicly_recvbuf_is_shutdown(&server_stream->recvbuf, NULL));
+    ok(quicly_recvbuf_get_error(&server_stream->recvbuf) == 12345);
     quicly_reset_stream(server_stream, 12345);
 
     quicly_get_max_data(client, NULL, &tmp, NULL);
@@ -272,7 +272,7 @@ static void test_rst_during_loss(void)
 
     /* RST_STREAM for downstream is sent */
     transmit(server, client);
-    ok(quicly_recvbuf_is_shutdown(&client_stream->recvbuf, NULL));
+    ok(quicly_recvbuf_get_error(&client_stream->recvbuf) != QUICLY_STREAM_ERROR_IS_OPEN);
     ok(quicly_stream_is_closable(client_stream));
     quicly_close_stream(client_stream);
     ok(quicly_num_streams(client) == 1);


### PR DESCRIPTION
including the 16-bit error code and non-error states (e.g., open, fin-closed, stopped).