### PR TITLE
Recognize ACK for a packet sent upon loss without any data.

### DIFF
--- a/t/ack.c
+++ b/t/ack.c
@@ -51,7 +51,7 @@ void test_ack(void)
     for (at = 0; at < 10; ++at)
         for (i = 1; i <= 5; ++i)
             for (j = 0; j < 3; ++j)
-                quicly_acks_allocate(&acks, at * 5 + i, at, on_acked);
+                quicly_acks_allocate(&acks, at * 5 + i, at, on_acked, 0);
 
     /* check all acks */
     quicly_acks_iter_t iter;


### PR DESCRIPTION
Quicly sends a packet that only contains an empty CRYPTO frame or a PADDING frame when it sees a loss event and there is nothing to send. However, in case of sending a PADDING frame, it is not registering the on_ack handler for the CRYPTO frame (see `_do_prepare_packet`).

That lead to the ACK for that sent packet being ignored, because quicly has assumed the existence of on_ack_stream callback in the inflight ACK map for legitimate ACKs against Initial, Handshake packets (see `ack_is_handshake_flow` that is removed by this commit).

This commit fixes the issue by introducing `ack_epoch` as a member of `quicly_ack_t` and using that to check the epoch of the ACK being received.