### PR TITLE
cumulative acks

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -178,6 +178,10 @@ typedef struct st_quicly_transport_parameters_t {
      *
      */
     uint8_t ack_delay_exponent;
+    /**
+     * in milliseconds
+     */
+    uint8_t max_ack_delay;
 } quicly_transport_parameters_t;
 
 typedef struct st_quicly_cid_t {

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -197,7 +197,7 @@ typedef struct st_quicly_stop_sending_frame_t {
 static int quicly_decode_stop_sending_frame(const uint8_t **src, const uint8_t *end, quicly_stop_sending_frame_t *frame);
 
 #define QUICLY_ENCODE_ACK_MAX_BLOCKS 63 /* exclusive, see encode_ack_frame */
-uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, uint64_t largest_pn, uint64_t ack_delay, quicly_ranges_t *ranges);
+uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t *ranges, uint64_t ack_delay);
 
 typedef struct st_quicly_ack_frame_t {
     uint64_t largest_acknowledged;

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -196,8 +196,8 @@ typedef struct st_quicly_stop_sending_frame_t {
 
 static int quicly_decode_stop_sending_frame(const uint8_t **src, const uint8_t *end, quicly_stop_sending_frame_t *frame);
 
-uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, uint64_t largest_pn, uint64_t ack_delay, quicly_ranges_t *ranges,
-                                 size_t *range_index);
+#define QUICLY_ENCODE_ACK_MAX_BLOCKS 63 /* exclusive, see encode_ack_frame */
+uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, uint64_t largest_pn, uint64_t ack_delay, quicly_ranges_t *ranges);
 
 typedef struct st_quicly_ack_frame_t {
     uint64_t largest_acknowledged;

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -145,11 +145,21 @@ inline void quicly_rtt_init(quicly_rtt_t *rtt, const quicly_loss_conf_t *conf, u
 inline void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t _latest_rtt, uint32_t ack_delay)
 {
     rtt->latest = _latest_rtt != 0 ? _latest_rtt : 1; /* set minimum to 1 to avoid special cases */
+
+    /* update minimum */
     if (rtt->latest < rtt->minimum)
         rtt->minimum = rtt->latest;
-    if (rtt->latest > rtt->minimum && rtt->latest - rtt->minimum > ack_delay) {
+
+    /* rtt->latest = max(rtt->minimum, rtt->latest - ack_delay) */
+    if (rtt->latest > ack_delay) {
         rtt->latest -= ack_delay;
+    } else {
+        rtt->latest = 0;
     }
+    if (rtt->latest < rtt->minimum)
+        rtt->latest = rtt->minimum;
+
+    /* smoothed and variance */
     if (rtt->smoothed == 0) {
         rtt->smoothed = rtt->latest;
     } else {

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -64,17 +64,20 @@ typedef struct quicly_rtt_t {
     uint32_t smoothed;
     uint32_t variance;
     uint32_t latest;
-    uint32_t max_ack_delay;
 } quicly_rtt_t;
 
 static void quicly_rtt_init(quicly_rtt_t *rtt, const quicly_loss_conf_t *conf, uint32_t initial_rtt);
-static void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t latest_rtt, uint32_t ack_delay, int is_ack_only);
+static void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t latest_rtt, uint32_t ack_delay);
 
 typedef struct quicly_loss_t {
     /**
      * configuration
      */
     const quicly_loss_conf_t *conf;
+    /**
+     * pointer to transport parameter containing max_ack_delay
+     */
+    uint8_t *max_ack_delay;
     /**
      * The number of times a tail loss probe has been sent without receiving an ack.
      */
@@ -115,7 +118,7 @@ typedef struct quicly_loss_t {
 
 typedef int (*quicly_loss_do_detect_cb)(quicly_loss_t *r, uint64_t largest_acked, uint32_t delay_until_lost, int64_t *loss_time);
 
-static void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt);
+static void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, uint8_t *max_ack_delay);
 static void quicly_loss_update_alarm(quicly_loss_t *r, uint64_t now, int has_outstanding);
 
 /* called every time a is received for congestion control and loss recovery.
@@ -137,18 +140,15 @@ inline void quicly_rtt_init(quicly_rtt_t *rtt, const quicly_loss_conf_t *conf, u
     rtt->latest = initial_rtt;
     rtt->smoothed = 0;
     rtt->variance = 0;
-    rtt->max_ack_delay = 0;
 }
 
-inline void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t _latest_rtt, uint32_t ack_delay, int is_ack_only)
+inline void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t _latest_rtt, uint32_t ack_delay)
 {
     rtt->latest = _latest_rtt != 0 ? _latest_rtt : 1; /* set minimum to 1 to avoid special cases */
     if (rtt->latest < rtt->minimum)
         rtt->minimum = rtt->latest;
     if (rtt->latest > rtt->minimum && rtt->latest - rtt->minimum > ack_delay) {
         rtt->latest -= ack_delay;
-        if (!is_ack_only && rtt->max_ack_delay < ack_delay)
-            rtt->max_ack_delay = ack_delay;
     }
     if (rtt->smoothed == 0) {
         rtt->smoothed = rtt->latest;
@@ -160,9 +160,9 @@ inline void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t _latest_rtt, uint32_t 
     assert(rtt->smoothed != 0);
 }
 
-inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt)
+inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, uint8_t *max_ack_delay)
 {
-    *r = (quicly_loss_t){.conf = conf, .loss_time = INT64_MAX, .alarm_at = INT64_MAX};
+    *r = (quicly_loss_t){.conf = conf, .max_ack_delay = max_ack_delay, .loss_time = INT64_MAX, .alarm_at = INT64_MAX};
     quicly_rtt_init(&r->rtt, conf, initial_rtt);
 }
 
@@ -181,13 +181,13 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, uint64_t now, int has_out
             alarm_duration <<= r->tlp_count;
         } else {
             /* RTO or TLP alarm (FIXME observe and use max_ack_delay) */
-            alarm_duration = r->rtt.smoothed + 4 * r->rtt.variance + r->rtt.max_ack_delay;
+            alarm_duration = r->rtt.smoothed + 4 * r->rtt.variance + *r->max_ack_delay;
             if (alarm_duration < r->conf->min_rto_timeout)
                 alarm_duration = r->conf->min_rto_timeout;
             alarm_duration <<= r->rto_count < QUICLY_LOSS_MAX_RTO_COUNT ? r->rto_count : QUICLY_LOSS_MAX_RTO_COUNT;
             if (r->tlp_count < r->conf->max_tlps) {
                 /* Tail Loss Probe */
-                int64_t tlp_alarm_duration = r->rtt.smoothed * 3 / 2 + r->rtt.max_ack_delay;
+                int64_t tlp_alarm_duration = r->rtt.smoothed * 3 / 2 + *r->max_ack_delay;
                 if (tlp_alarm_duration < r->conf->min_tlp_timeout)
                     tlp_alarm_duration = r->conf->min_tlp_timeout;
                 if (tlp_alarm_duration < alarm_duration)
@@ -215,7 +215,7 @@ inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_acked
     if (r->largest_acked_packet < largest_acked)
         r->largest_acked_packet = largest_acked;
     if (latest_rtt != UINT32_MAX)
-        quicly_rtt_update(&r->rtt, latest_rtt, ack_delay, is_ack_only);
+        quicly_rtt_update(&r->rtt, latest_rtt, ack_delay);
 }
 
 /* This function updates the early retransmit timer and indicates to the caller how many packets should be sent.

--- a/include/quicly/ranges.h
+++ b/include/quicly/ranges.h
@@ -26,15 +26,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-struct st_quicly_range_t {
+typedef struct st_quicly_range_t {
     uint64_t start;
     uint64_t end; /* non-inclusive */
-};
+} quicly_range_t;
 
 typedef struct st_quicly_ranges_t {
-    struct st_quicly_range_t *ranges;
+    quicly_range_t *ranges;
     size_t num_ranges, capacity;
-    struct st_quicly_range_t _initial;
+    quicly_range_t _initial;
 } quicly_ranges_t;
 
 static void quicly_ranges_init(quicly_ranges_t *ranges);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2144,8 +2144,8 @@ static int send_ack(quicly_conn_t *conn, struct st_quicly_pn_space_t *space, str
         /* save what's inflight */
         for (; range != range_index; --range) {
             quicly_ack_t *ack;
-            if ((ack = quicly_acks_allocate(&conn->egress.acks, conn->egress.packet_number, now, on_ack_ack,
-                                            *s->target.ack_epoch, 0)) == NULL)
+            if ((ack = quicly_acks_allocate(&conn->egress.acks, conn->egress.packet_number, now, on_ack_ack, *s->target.ack_epoch,
+                                            0)) == NULL)
                 return PTLS_ERROR_NO_MEMORY;
             ack->data.ack.range = space->ack_queue.ranges[range];
         }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2449,7 +2449,8 @@ static int do_detect_loss(quicly_loss_t *ld, uint64_t largest_pn, uint32_t delay
 
 static void update_loss_alarm(quicly_conn_t *conn)
 {
-    quicly_loss_update_alarm(&conn->egress.loss, conn->egress.last_retransmittable_sent_at, conn->egress.acks.num_in_flight != 0);
+    quicly_loss_update_alarm(&conn->egress.loss, now, conn->egress.last_retransmittable_sent_at,
+                             conn->egress.acks.num_in_flight != 0);
 }
 
 static void open_id_blocked_streams(quicly_conn_t *conn, int uni)

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2136,8 +2136,9 @@ static int send_ack(quicly_conn_t *conn, struct st_quicly_pn_space_t *space, str
     range_index = space->ack_queue.num_ranges - 1;
     largest_pn = space->ack_queue.ranges[range_index].end - 1;
     if (space->largest_pn_received_at < now) {
-        QUICLY_BUILD_ASSERT(QUICLY_ACK_DELAY_EXPONENT == 10); /* ack_delay in milliseconds! */
-        ack_delay = now - space->largest_pn_received_at;
+        /* We underreport ack_delay up to 1 milliseconds assuming that QUICLY_ACK_DELAY_EXPONENT is 10. It's considered a non-issue
+         * because our time measurement is at millisecond granurality anyways. */
+        ack_delay = ((now - space->largest_pn_received_at) * 1000) >> QUICLY_ACK_DELAY_EXPONENT;
     } else {
         ack_delay = 0;
     }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2809,7 +2809,7 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
                 /* piggyback an ack if a packet is under construction.
                  * TODO: This may cause a second packet to be emitted. Check for packet size before piggybacking ack.
                  */
-                if (conn->application->cipher.egress_1rtt.aead != NULL &&
+                if (conn->application->cipher.egress_1rtt.aead != NULL && conn->application->super.unacked_count != 0 &&
                     (ret = send_ack(conn, &conn->application->super, &s)) != 0)
                     goto Exit;
             }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -115,7 +115,10 @@ struct st_quicly_pn_space_t {
     /**
      * time at when the largest pn in the ack_queue has been received (or INT64_MAX if none)
      */
-    int64_t largest_pn_received_at;
+    struct {
+        uint64_t next_pn;
+        int64_t at;
+    } largest_pn_received;
     /**
      *
      */
@@ -780,7 +783,8 @@ static struct st_quicly_pn_space_t *alloc_pn_space(size_t sz)
         return NULL;
 
     quicly_ranges_init(&space->ack_queue);
-    space->largest_pn_received_at = INT64_MAX;
+    space->largest_pn_received.next_pn = 0;
+    space->largest_pn_received.at = INT64_MAX;
     space->next_expected_packet_number = 0;
     space->send_ack_at = INT64_MAX;
     space->unacked_count = 0;
@@ -806,9 +810,9 @@ static int record_receipt(struct st_quicly_pn_space_t *space, uint64_t pn, int i
         assert(space->ack_queue.num_ranges == QUICLY_ENCODE_ACK_MAX_BLOCKS);
         quicly_ranges_shrink(&space->ack_queue, 0, 1);
     }
-    if (space->ack_queue.ranges[space->ack_queue.num_ranges - 1].end == pn + 1) {
-        /* FIXME implement deduplication at an earlier moment? */
-        space->largest_pn_received_at = now;
+    if (space->largest_pn_received.next_pn <= pn) {
+        space->largest_pn_received.next_pn = pn + 1;
+        space->largest_pn_received.at = now;
     }
     /* TODO (jri): If not ack-only packet, then maintain count of such packets that are received.
      * Send ack immediately when this number exceeds the threshold.
@@ -1683,11 +1687,8 @@ static int on_ack_ack(quicly_conn_t *conn, int acked, quicly_ack_t *ack)
         }
         if (space != NULL) {
             quicly_ranges_subtract(&space->ack_queue, ack->data.ack.range.start, ack->data.ack.range.end);
-            if (space->ack_queue.num_ranges == 0) {
-                space->largest_pn_received_at = INT64_MAX;
-                space->send_ack_at = INT64_MAX;
+            if (space->ack_queue.num_ranges == 0)
                 space->unacked_count = 0;
-            }
         }
     }
 
@@ -2130,10 +2131,10 @@ static int send_ack(quicly_conn_t *conn, struct st_quicly_pn_space_t *space, str
         return 0;
 
     /* calc ack_delay */
-    if (space->largest_pn_received_at < now) {
+    if (space->largest_pn_received.at < now) {
         /* We underreport ack_delay up to 1 milliseconds assuming that QUICLY_ACK_DELAY_EXPONENT is 10. It's considered a non-issue
          * because our time measurement is at millisecond granurality anyways. */
-        ack_delay = ((now - space->largest_pn_received_at) * 1000) >> QUICLY_ACK_DELAY_EXPONENT;
+        ack_delay = ((now - space->largest_pn_received.at) * 1000) >> QUICLY_ACK_DELAY_EXPONENT;
     } else {
         ack_delay = 0;
     }
@@ -2142,8 +2143,8 @@ static int send_ack(quicly_conn_t *conn, struct st_quicly_pn_space_t *space, str
 Emit:
     if ((ret = prepare_packet(conn, s, QUICLY_ACK_FRAME_CAPACITY)) != 0)
         return ret;
-    uint8_t *new_dst = quicly_encode_ack_frame(s->dst, s->dst_end, space->ack_queue.ranges[space->ack_queue.num_ranges - 1].end - 1,
-                                               ack_delay, &space->ack_queue);
+    uint8_t *new_dst =
+        quicly_encode_ack_frame(s->dst, s->dst_end, space->largest_pn_received.next_pn - 1, ack_delay, &space->ack_queue);
     if (new_dst == NULL) {
         /* no space, retry with new MTU-sized packet */
         if ((ret = commit_send_packet(conn, s, 0)) != 0)

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -314,7 +314,7 @@ const quicly_context_t quicly_default_context = {
     {0, NULL}, /* event_log */
 };
 
-static const quicly_transport_parameters_t transport_params_before_handshake = {{16384, 16384, 16384}, 16384, 10, 60};
+static const quicly_transport_parameters_t transport_params_before_handshake = {{0, 0, 0}, 0, 0, 0, 0, 3};
 
 static __thread int64_t now;
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2142,8 +2142,7 @@ static int send_ack(quicly_conn_t *conn, struct st_quicly_pn_space_t *space, str
 Emit:
     if ((ret = prepare_packet(conn, s, QUICLY_ACK_FRAME_CAPACITY)) != 0)
         return ret;
-    uint8_t *new_dst = quicly_encode_ack_frame(s->dst, s->dst_end, space->ack_queue.ranges[space->ack_queue.num_ranges - 1].end - 1,
-                                               ack_delay, &space->ack_queue);
+    uint8_t *new_dst = quicly_encode_ack_frame(s->dst, s->dst_end, &space->ack_queue, ack_delay);
     if (new_dst == NULL) {
         /* no space, retry with new MTU-sized packet */
         if ((ret = commit_send_packet(conn, s, 0)) != 0)

--- a/lib/ranges.c
+++ b/lib/ranges.c
@@ -28,20 +28,20 @@
     do {                                                                                                                           \
         size_t _n = (n);                                                                                                           \
         if (_n != 0)                                                                                                               \
-            memcpy((dst), (src), sizeof(struct st_quicly_range_t) * _n);                                                           \
+            memcpy((dst), (src), sizeof(quicly_range_t) * _n);                                                                     \
     } while (0)
 #define MOVE(dst, src, n)                                                                                                          \
     do {                                                                                                                           \
         size_t _n = (n);                                                                                                           \
         if (_n != 0)                                                                                                               \
-            memmove((dst), (src), sizeof(struct st_quicly_range_t) * _n);                                                          \
+            memmove((dst), (src), sizeof(quicly_range_t) * _n);                                                                    \
     } while (0)
 
 static int insert_at(quicly_ranges_t *ranges, uint64_t start, uint64_t end, size_t slot)
 {
     if (ranges->num_ranges == ranges->capacity) {
         size_t new_capacity = ranges->capacity < 4 ? 4 : ranges->capacity * 2;
-        struct st_quicly_range_t *new_ranges = malloc(new_capacity * sizeof(*new_ranges));
+        quicly_range_t *new_ranges = malloc(new_capacity * sizeof(*new_ranges));
         if (new_ranges == NULL)
             return -1;
         COPY(new_ranges, ranges->ranges, slot);
@@ -53,7 +53,7 @@ static int insert_at(quicly_ranges_t *ranges, uint64_t start, uint64_t end, size
     } else {
         MOVE(ranges->ranges + slot + 1, ranges->ranges + slot, ranges->num_ranges - slot);
     }
-    ranges->ranges[slot] = (struct st_quicly_range_t){start, end};
+    ranges->ranges[slot] = (quicly_range_t){start, end};
     ++ranges->num_ranges;
     return 0;
 }
@@ -185,7 +185,7 @@ void quicly_ranges_shrink(quicly_ranges_t *ranges, size_t start, size_t end)
     ranges->num_ranges -= end - start;
     if (ranges->capacity > 4 && ranges->num_ranges * 3 <= ranges->capacity) {
         size_t new_capacity = ranges->capacity / 2;
-        struct st_quicly_range_t *new_ranges = realloc(ranges->ranges, new_capacity * sizeof(*new_ranges));
+        quicly_range_t *new_ranges = realloc(ranges->ranges, new_capacity * sizeof(*new_ranges));
         if (new_ranges != NULL) {
             ranges->ranges = new_ranges;
             ranges->capacity = new_capacity;

--- a/t/ack.c
+++ b/t/ack.c
@@ -51,7 +51,7 @@ void test_ack(void)
     for (at = 0; at < 10; ++at)
         for (i = 1; i <= 5; ++i)
             for (j = 0; j < 3; ++j)
-                quicly_acks_allocate(&acks, at * 5 + i, at, on_acked, 0);
+                quicly_acks_allocate(&acks, at * 5 + i, at, on_acked, 0, 1);
 
     /* check all acks */
     quicly_acks_iter_t iter;

--- a/t/frame.c
+++ b/t/frame.c
@@ -103,7 +103,7 @@ static void test_ack_encode(void)
     quicly_ranges_add(&ranges, 0x12, 0x14);
 
     /* encode */
-    end = quicly_encode_ack_frame(buf, buf + sizeof(buf), 0x13, 63, &ranges);
+    end = quicly_encode_ack_frame(buf, buf + sizeof(buf), &ranges, 63);
     ok(end - buf == 5);
     /* decode */
     src = buf + 1;
@@ -114,20 +114,10 @@ static void test_ack_encode(void)
     ok(decoded.largest_acknowledged == 0x13);
     ok(decoded.ack_block_lengths[0] == 2);
 
-    /* encode */
-    end = quicly_encode_ack_frame(buf, buf + sizeof(buf), 0x14, 63, &ranges);
-    ok(end - buf == 5);
-    /* decode */
-    src = buf + 1;
-    ok(quicly_decode_ack_frame(&src, end, &decoded, 0) == 0);
-    ok(src == end);
-    ok(decoded.ack_delay == 63);
-    ok(decoded.num_gaps == 0);
-    ok(decoded.largest_acknowledged == 0x14);
-    ok(decoded.ack_block_lengths[0] == 3);
+    quicly_ranges_add(&ranges, 0x10, 0x11);
 
     /* encode */
-    end = quicly_encode_ack_frame(buf, buf + sizeof(buf), 0x15, 63, &ranges);
+    end = quicly_encode_ack_frame(buf, buf + sizeof(buf), &ranges, 63);
     ok(end - buf == 7);
     /* decode */
     src = buf + 1;
@@ -135,28 +125,10 @@ static void test_ack_encode(void)
     ok(src == end);
     ok(decoded.ack_delay == 63);
     ok(decoded.num_gaps == 1);
-    ok(decoded.largest_acknowledged == 0x15);
-    ok(decoded.ack_block_lengths[0] == 1);
+    ok(decoded.largest_acknowledged == 0x13);
+    ok(decoded.ack_block_lengths[0] == 2);
     ok(decoded.gaps[0] == 1);
-    ok(decoded.ack_block_lengths[1] == 2);
-
-    quicly_ranges_add(&ranges, 0x10, 0x11);
-
-    /* encode */
-    end = quicly_encode_ack_frame(buf, buf + sizeof(buf), 0x15, 63, &ranges);
-    ok(end - buf == 9);
-    /* decode */
-    src = buf + 1;
-    ok(quicly_decode_ack_frame(&src, end, &decoded, 0) == 0);
-    ok(src == end);
-    ok(decoded.ack_delay == 63);
-    ok(decoded.num_gaps == 2);
-    ok(decoded.largest_acknowledged == 0x15);
-    ok(decoded.ack_block_lengths[0] == 1);
-    ok(decoded.gaps[0] == 1);
-    ok(decoded.ack_block_lengths[1] == 2);
-    ok(decoded.gaps[1] == 1);
-    ok(decoded.ack_block_lengths[2] == 1);
+    ok(decoded.ack_block_lengths[1] == 1);
 
     quicly_ranges_dispose(&ranges);
 }

--- a/t/frame.c
+++ b/t/frame.c
@@ -95,29 +95,70 @@ static void test_ack_decode(void)
 static void test_ack_encode(void)
 {
     quicly_ranges_t ranges;
-    size_t range_index;
     uint8_t buf[256], *end;
     const uint8_t *src;
     quicly_ack_frame_t decoded;
 
     quicly_ranges_init(&ranges);
-    quicly_ranges_add(&ranges, 0x12, 0x13);
+    quicly_ranges_add(&ranges, 0x12, 0x14);
 
-    range_index = 0;
-    end = quicly_encode_ack_frame(buf, buf + sizeof(buf), ranges.ranges[ranges.num_ranges - 1].end - 1, 63, &ranges, &range_index);
+    /* encode */
+    end = quicly_encode_ack_frame(buf, buf + sizeof(buf), 0x13, 63, &ranges);
     ok(end - buf == 5);
-
-    quicly_ranges_dispose(&ranges);
-
+    /* decode */
     src = buf + 1;
     ok(quicly_decode_ack_frame(&src, end, &decoded, 0) == 0);
     ok(src == end);
     ok(decoded.ack_delay == 63);
     ok(decoded.num_gaps == 0);
-    ok(decoded.largest_acknowledged == 0x12);
-    ok(decoded.ack_block_lengths[0] == 1);
+    ok(decoded.largest_acknowledged == 0x13);
+    ok(decoded.ack_block_lengths[0] == 2);
 
-    /* TODO add more */
+    /* encode */
+    end = quicly_encode_ack_frame(buf, buf + sizeof(buf), 0x14, 63, &ranges);
+    ok(end - buf == 5);
+    /* decode */
+    src = buf + 1;
+    ok(quicly_decode_ack_frame(&src, end, &decoded, 0) == 0);
+    ok(src == end);
+    ok(decoded.ack_delay == 63);
+    ok(decoded.num_gaps == 0);
+    ok(decoded.largest_acknowledged == 0x14);
+    ok(decoded.ack_block_lengths[0] == 3);
+
+    /* encode */
+    end = quicly_encode_ack_frame(buf, buf + sizeof(buf), 0x15, 63, &ranges);
+    ok(end - buf == 7);
+    /* decode */
+    src = buf + 1;
+    ok(quicly_decode_ack_frame(&src, end, &decoded, 0) == 0);
+    ok(src == end);
+    ok(decoded.ack_delay == 63);
+    ok(decoded.num_gaps == 1);
+    ok(decoded.largest_acknowledged == 0x15);
+    ok(decoded.ack_block_lengths[0] == 1);
+    ok(decoded.gaps[0] == 1);
+    ok(decoded.ack_block_lengths[1] == 2);
+
+    quicly_ranges_add(&ranges, 0x10, 0x11);
+
+    /* encode */
+    end = quicly_encode_ack_frame(buf, buf + sizeof(buf), 0x15, 63, &ranges);
+    ok(end - buf == 9);
+    /* decode */
+    src = buf + 1;
+    ok(quicly_decode_ack_frame(&src, end, &decoded, 0) == 0);
+    ok(src == end);
+    ok(decoded.ack_delay == 63);
+    ok(decoded.num_gaps == 2);
+    ok(decoded.largest_acknowledged == 0x15);
+    ok(decoded.ack_block_lengths[0] == 1);
+    ok(decoded.gaps[0] == 1);
+    ok(decoded.ack_block_lengths[1] == 2);
+    ok(decoded.gaps[1] == 1);
+    ok(decoded.ack_block_lengths[2] == 1);
+
+    quicly_ranges_dispose(&ranges);
 }
 
 static void test_mozquic(void)

--- a/t/simple.c
+++ b/t/simple.c
@@ -310,10 +310,6 @@ static void tiny_connection_window(void)
 
         ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, NULL);
         ok(ret == 0);
-        ret = quicly_open_stream(client, &client_stream, 0);
-        ok(ret == 0);
-        for (i = 0; i < 16; ++i)
-            quicly_sendbuf_write(&client_stream->sendbuf, testdata, 1024, NULL);
         num_packets = 1;
         ret = quicly_send(client, &raw, &num_packets);
         ok(ret == 0);
@@ -329,6 +325,11 @@ static void tiny_connection_window(void)
     transmit(server, client);
     ok(quicly_get_state(client) == QUICLY_STATE_CONNECTED);
     ok(quicly_connection_is_ready(client));
+
+    ret = quicly_open_stream(client, &client_stream, 0);
+    ok(ret == 0);
+    for (i = 0; i < 16; ++i)
+        quicly_sendbuf_write(&client_stream->sendbuf, testdata, 1024, NULL);
 
     transmit(client, server);
 


### PR DESCRIPTION
ToDo:
* [x] cap the size of `ack_queue`
* [x] send ACK either when we need to, or when there's new information
* [x] report ack_delay accurately (instead of over-reporting at the rate of 1024/1000)
* [x] ~~preserve `largest_pn_received` along with `largest_pn_received_at` and use it for building ACK. Otherwise, we will report incorrect ack_delay if ACK of `largest_pn_received` gets ACKed before a PN that is smaller (happens when there is reorder).~~