### PR TITLE
fix g++ compile error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ IF (OPENSSL_FOUND AND (OPENSSL_VERSION VERSION_LESS "1.0.2"))
     MESSAGE(FATAL "OpenSSL 1.0.2 or above is missing")
 ENDIF ()
 
+add_compile_options(-fPIC)
+
 SET(CMAKE_C_FLAGS "-std=c99 -Wall -O2 -g ${CC_WARNING_FLAGS} ${CMAKE_C_FLAGS}")
 INCLUDE_DIRECTORIES(${OPENSSL_INCLUDE_DIR} deps/dcc deps/klib deps/picotls/include deps/picotest include)
 

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -352,6 +352,10 @@ struct st_quicly_stream_t {
      */
     quicly_stream_id_t stream_id;
     /**
+     * host cid
+     */
+    quicly_cid_t *host_cid;
+    /**
      * send buffer
      */
     quicly_sendbuf_t sendbuf;

--- a/include/quicly/ack.h
+++ b/include/quicly/ack.h
@@ -178,7 +178,7 @@ inline void quicly_acks_init_iter(quicly_acks_t *acks, quicly_acks_iter_t *iter)
             ;
         iter->count = acks->head->alive;
     } else {
-        iter->p = (void *)&quicly_acks__end_iter;
+        iter->p = (quicly_ack_t *)&quicly_acks__end_iter;
         iter->count = 0;
     }
 }
@@ -193,7 +193,7 @@ inline void quicly_acks_next(quicly_acks_iter_t *iter)
     if (--iter->count != 0) {
         ++iter->p;
     } else if (*(iter->ref = &(*iter->ref)->next) == NULL) {
-        iter->p = (void *)&quicly_acks__end_iter;
+        iter->p = (quicly_ack_t *)&quicly_acks__end_iter;
         iter->count = 0;
         return;
     } else {

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -618,9 +618,10 @@ inline int quicly_decode_stream_id_blocked_frame(const uint8_t **src, const uint
 
 inline int quicly_decode_new_connection_id_frame(const uint8_t **src, const uint8_t *end, quicly_new_connection_id_frame_t *frame)
 {
+    uint8_t cid_len;
     if (end - *src < 1)
         goto Fail;
-    uint8_t cid_len = *(*src)++;
+    cid_len = *(*src)++;
     if ((frame->sequence = quicly_decodev(src, end)) == UINT64_MAX)
         goto Fail;
     if (cid_len == 0) {
@@ -679,7 +680,7 @@ inline int quicly_decode_new_token_frame(const uint8_t **src, const uint8_t *end
     uint64_t token_len;
     if ((token_len = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
-    if (end - *src < token_len)
+    if ((uint64_t)(end - *src) < token_len)
         goto Error;
     frame->token = ptls_iovec_init(*src, (size_t)token_len);
     *src += frame->token.len;

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -252,7 +252,7 @@ inline uint64_t quicly_decodev(const uint8_t **src, const uint8_t *end)
 
     /* multi-byte */
     size_t len = 1 << (**src >> 6);
-    if (end - *src < len)
+    if (end - *src < 0 || (size_t)(end - *src) < len)
         return UINT64_MAX;
     uint64_t v = *(*src)++ & 0x3f;
     --len;
@@ -401,7 +401,7 @@ inline int quicly_decode_stream_frame(uint8_t type_flags, const uint8_t **src, c
         uint64_t len;
         if ((len = quicly_decodev(src, end)) == UINT64_MAX)
             goto Error;
-        if (end - *src < len)
+        if (end - *src < 0 || (uint64_t)(end - *src) < len)
             goto Error;
         frame->data = ptls_iovec_init(*src, len);
         *src += len;
@@ -453,7 +453,7 @@ inline int quicly_decode_crypto_frame(const uint8_t **src, const uint8_t *end, q
         goto Error;
     if ((len = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
-    if (end - *src < len)
+    if (end - *src < 0 || (uint64_t)(end - *src) < len)
         goto Error;
     frame->data = ptls_iovec_init(*src, len);
     *src += len;
@@ -494,7 +494,7 @@ inline int quicly_decode_application_close_frame(const uint8_t **src, const uint
     frame->error_code = quicly_decode16(src);
     if ((reason_len = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
-    if (end - *src < reason_len)
+    if ((uint64_t)(end - *src) < reason_len)
         goto Error;
     frame->reason_phrase = ptls_iovec_init(*src, reason_len);
     *src += reason_len;
@@ -514,7 +514,7 @@ inline int quicly_decode_connection_close_frame(const uint8_t **src, const uint8
         goto Error;
     if ((reason_len = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
-    if (end - *src < reason_len)
+    if ((uint64_t)(end - *src) < reason_len)
         goto Error;
     frame->reason_phrase = ptls_iovec_init(*src, reason_len);
     *src += reason_len;
@@ -680,7 +680,7 @@ inline int quicly_decode_new_token_frame(const uint8_t **src, const uint8_t *end
     uint64_t token_len;
     if ((token_len = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
-    if (end - *src < 1 || (uint64_t)(end - *src) < token_len)
+    if (end - *src < 0 || (uint64_t)(end - *src) < token_len)
         goto Error;
     frame->token = ptls_iovec_init(*src, (size_t)token_len);
     *src += frame->token.len;

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -680,7 +680,7 @@ inline int quicly_decode_new_token_frame(const uint8_t **src, const uint8_t *end
     uint64_t token_len;
     if ((token_len = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
-    if ((uint64_t)(end - *src) < token_len)
+    if (end - *src < 1 || (uint64_t)(end - *src) < token_len)
         goto Error;
     frame->token = ptls_iovec_init(*src, (size_t)token_len);
     *src += frame->token.len;

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -175,7 +175,7 @@ inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, u
     *r = (quicly_loss_t){.conf = conf, .max_ack_delay = max_ack_delay,
         .tlp_count = 0, .rto_count = 0, .largest_sent_before_rto = 0,
         .time_of_last_packet_sent = 0, .largest_acked_packet = 0, .loss_time = INT64_MAX,
-        .alarm_at = INT64_MAX}; quicly_rtt_init(&r->rtt, conf, initial_rtt);
+        .alarm_at = INT64_MAX};
     quicly_rtt_init(&r->rtt, conf, initial_rtt);
 }
 

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -172,7 +172,10 @@ inline void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t _latest_rtt, uint32_t 
 
 inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, uint8_t *max_ack_delay)
 {
-    *r = (quicly_loss_t){.conf = conf, .max_ack_delay = max_ack_delay, .loss_time = INT64_MAX, .alarm_at = INT64_MAX};
+    *r = (quicly_loss_t){.conf = conf, .max_ack_delay = max_ack_delay,
+        .tlp_count = 0, .rto_count = 0, .largest_sent_before_rto = 0,
+        .time_of_last_packet_sent = 0, .largest_acked_packet = 0, .loss_time = INT64_MAX,
+        .alarm_at = INT64_MAX}; quicly_rtt_init(&r->rtt, conf, initial_rtt);
     quicly_rtt_init(&r->rtt, conf, initial_rtt);
 }
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -694,7 +694,7 @@ static quicly_stream_t *open_stream(quicly_conn_t *conn, uint64_t stream_id, uin
         return NULL;
     stream->conn = conn;
     stream->stream_id = stream_id;
-    stream->host_cid = &(conn->super.host.cid);
+    stream->host_cid = &conn->super.host.cid;
 
     int r;
     khiter_t iter = kh_put(quicly_stream_t, conn->streams, stream_id, &r);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1614,7 +1614,7 @@ int quicly_accept(quicly_conn_t **_conn, quicly_context_t *ctx, struct sockaddr 
     /* TODO let the app set host cid after successful return from quicly_accept / quicly_connect */
     ctx->tls->random_bytes(conn->super.host.cid.cid, 8);
     conn->super.host.cid.len = 8;
-    set_cid(&conn->super.host.offered_cid, packet->cid.dest);
+    set_cid(&conn->super.host.cid, packet->cid.dest);
     if ((ret = setup_handshake_space_and_flow(conn, 0)) != 0)
         goto Exit;
     conn->initial->cipher.ingress = ingress_cipher;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -694,6 +694,7 @@ static quicly_stream_t *open_stream(quicly_conn_t *conn, uint64_t stream_id, uin
         return NULL;
     stream->conn = conn;
     stream->stream_id = stream_id;
+    stream->host_cid = &(conn->super.host.cid);
 
     int r;
     khiter_t iter = kh_put(quicly_stream_t, conn->streams, stream_id, &r);


### PR DESCRIPTION
1.fix g++ compile error and many warnings
2.add compile option for static library, otherwise will got a error "Bad value"

3.change quicly_accept packet->cid.dest from host offered cid to host cid
 we can use this cid to add conn to hashmap, because another packet->cid.dest is host cid,src/cli check all connections, it's too slow

4.add quicly_stream_t->host_cid
host_cid is useful because it can be used to find conn, in some callback, only have stream, we can use stream->host_cid to find conn