### PR TITLE
discards non-1-RTT contexts

### DIFF
--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -211,6 +211,7 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
         }
     } else {
         r->alarm_at = INT64_MAX;
+        r->loss_time = INT64_MAX;
     }
 }
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1760,9 +1760,7 @@ static int on_ack_ack(quicly_conn_t *conn, const quicly_sent_packet_t *packet, q
 {
     /* TODO log */
 
-    switch (event) {
-    case QUICLY_SENTMAP_EVENT_ACKED:
-    case QUICLY_SENTMAP_EVENT_EXPIRED: {
+    if (event == QUICLY_SENTMAP_EVENT_ACKED) {
         /* find the pn space */
         struct st_quicly_pn_space_t *space;
         switch (packet->ack_epoch) {
@@ -1785,9 +1783,6 @@ static int on_ack_ack(quicly_conn_t *conn, const quicly_sent_packet_t *packet, q
                 space->unacked_count = 0;
             }
         }
-    } break;
-    default:
-        break;
     }
 
     return 0;

--- a/t/loss.c
+++ b/t/loss.c
@@ -153,7 +153,7 @@ static void test_even(void)
     /* server resends the contents of all the packets (in cleartext) */
     ret = transmit_cond(server, client, &num_sent, &num_received, cond_even_down, 0);
     ok(ret == 0);
-    ok(num_sent == 2);
+    ok(num_sent == 1);
     ok(num_received == 1);
 
     ok(quicly_get_state(client) == QUICLY_STATE_CONNECTED);

--- a/t/sentmap.c
+++ b/t/sentmap.c
@@ -24,10 +24,11 @@
 
 static int on_acked_callcnt, on_acked_ackcnt;
 
-static int on_acked(struct st_quicly_conn_t *conn, int is_ack, const quicly_sent_packet_t *packet, quicly_sent_t *sent)
+static int on_acked(struct st_quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent,
+                    quicly_sentmap_event_t event)
 {
     ++on_acked_callcnt;
-    if (is_ack)
+    if (event == QUICLY_SENTMAP_EVENT_ACKED)
         ++on_acked_ackcnt;
     return 0;
 }
@@ -84,7 +85,7 @@ void test_sentmap(void)
         quicly_sentmap_skip(&iter);
     assert(quicly_sentmap_get(&iter)->packet_number == 11);
     while (quicly_sentmap_get(&iter)->packet_number <= 40)
-        quicly_sentmap_update(&map, &iter, QUICLY_SENTMAP_UPDATE_LOST | QUICLY_SENTMAP_UPDATE_DISCARD, NULL);
+        quicly_sentmap_update(&map, &iter, QUICLY_SENTMAP_EVENT_EXPIRED, NULL);
     ok(on_acked_callcnt == 30 * 2);
     ok(on_acked_ackcnt == 0);
 


### PR DESCRIPTION
* discards the Initial context
  * as a client, when sending the first Handshake packet
  * as a server, when receiving the first Handshake packet
* discards the Handshake context
  * when TLS handshake is complete (i.e. either emitted or received ClientFinished) and when there is nothing in the send buffer
* discards the 0-RTT secrets
  * as a server, when Handshake context is discarded
  * (note: as a client, we have been discarding the secrets when we obtain 1-RTT write secrets)