### PR TITLE
avoid confusion between loss and expire events

### DIFF
--- a/t/sentmap.c
+++ b/t/sentmap.c
@@ -86,7 +86,7 @@ void test_sentmap(void)
     assert(quicly_sentmap_get(&iter)->packet_number == 11);
     while (quicly_sentmap_get(&iter)->packet_number <= 40)
         quicly_sentmap_update(&map, &iter, QUICLY_SENTMAP_EVENT_EXPIRED, NULL);
-    ok(on_acked_callcnt == 30 * 2);
+    ok(on_acked_callcnt == 30 * 4);
     ok(on_acked_ackcnt == 0);
 
     size_t cnt = 0;


### PR DESCRIPTION
We need to discard the information from sentmap by epochs (also at the same time calling them as lost), for example when 0-RTT is rejected by the server, or when responding to a retry. We would like to use that for connection termination as well.

OTOH, we simply mark some as "lost" when we send a probe, in order to find what to retransmit.

amends #68.