### PR TITLE
Fix failing assert in send_stream_data

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2424,7 +2424,9 @@ static int send_stream_data(quicly_stream_t *stream, struct st_quicly_send_conte
         }
     }
     { /* cap the capacity to the current range */
-        uint64_t range_capacity = stream->sendstate.pending.ranges[0].end - !stream->sendstate.is_open - off;
+        uint64_t range_capacity = stream->sendstate.pending.ranges[0].end - off;
+        if (stream->sendstate.pending.num_ranges == 1)
+            range_capacity -= !stream->sendstate.is_open;
         if (capacity > range_capacity)
             capacity = range_capacity;
     }


### PR DESCRIPTION
Hello,

When trying to send a large file with Quicly (using the provided cli and simply replacing assets/main.jpg by a 256MB file), I noticed a crash where the assert in quicly.c:2433 fails. This PR fixes it in my tests (and does not break the included tests).