### PR TITLE
Fix packet number decoding

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1641,7 +1641,7 @@ static ptls_iovec_t decrypt_packet(ptls_cipher_context_t *header_protection, ptl
     }
 
     /* AEAD */
-    *pn = quicly_determine_packet_number(pnbits, (uint32_t)UINT32_MAX >> (4 - pnlen), *next_expected_pn);
+    *pn = quicly_determine_packet_number(pnbits, (uint32_t)UINT32_MAX >> ((4 - pnlen) * 8), *next_expected_pn);
     size_t aead_off = packet->encrypted_off + pnlen, ptlen;
     if ((ptlen = ptls_aead_decrypt(aead[aead_index], packet->octets.base + aead_off, packet->octets.base + aead_off,
                                    packet->octets.len - aead_off, *pn, packet->octets.base, aead_off)) == SIZE_MAX) {


### PR DESCRIPTION
Hello,

In decrypt_packet, the computation of the mask used to compute the actual packet number was invalid, which caused the packet number to be incorrectly decoded for all packets with a packet number greater than 65536. As a result it was impossible to send more than 65535 packets or ~80MB in a single connection. This PR fixes this issue.