### PR TITLE
Adds adapter for quic-trace

### DIFF
--- a/quictrace-adapter.py
+++ b/quictrace-adapter.py
@@ -3,11 +3,6 @@ import json
 import base64
 from pprint import pprint
 
-fields = {"streamId": "stream-id",
-          "fin": "fin",
-          "length": "len",
-          }
-
 def transform(inf, outf):
     start = -1
     cid = -1
@@ -102,6 +97,7 @@ def transform(inf, outf):
         packet["frames"] = rframes
         qtr["events"].append(packet)
 
+    # finished processing
     json.dump(qtr, outf)
 
 

--- a/quictrace-adapter.py
+++ b/quictrace-adapter.py
@@ -3,6 +3,8 @@ import json
 import base64
 from pprint import pprint
 
+epoch = ["ENCRYPTION_INITIAL", "ENCRYPTION_0RTT", "ENCRYPTION_UNKNOWN", "ENCRYPTION_1RTT"]
+
 def transform(inf, outf):
     start = -1
     cid = -1
@@ -40,7 +42,7 @@ def transform(inf, outf):
             packet["timeUs"] = str((trace["time"] - start) * 1000)
             packet["packetNumber"] = str(trace["pn"])
             packet["packetSize"] = str(trace["len"])
-            packet["encryptionLevel"] = "ENCRYPTION_1RTT"
+            packet["encryptionLevel"] = epoch[trace["packet-type"]]
             packet["frames"] = sframes
             qtr["events"].append(packet)
             sframes = []  # empty sent frames list

--- a/quictrace-adapter.py
+++ b/quictrace-adapter.py
@@ -1,0 +1,74 @@
+import sys
+import json
+from pprint import pprint
+
+fields = {"streamId": "stream-id",
+          "fin": "fin",
+          "length": "len",
+          }
+
+def transform(inf, outf):
+    start = -1
+    qtr = {}
+    qtr["protocolVersion"] = "AAAA"
+    qtr["events"] = []
+    frames = []
+    for line in inf:
+        trace = json.loads(line)
+        if trace["type"][:9] != "quictrace": continue
+
+        # Use first connection that is seen as the CID for the trace.
+        # TODO: Make this a cmdline parameter if multiple CIDs in trace.
+        if cid == -1: 
+            cid = trace["conn"]
+            qtr["destinationConnectionId"] = str(cid)
+
+        # Packet sent
+        if trace["type"] == "quictrace-sent":
+            packet = {}
+            packet["eventType"] = "PACKET_SENT"
+            if start == -1: start = trace["time"]
+            packet["timeUs"] = str((trace["time"] - start) * 1000)
+            packet["packetNumber"] = str(trace["pn"])
+            packet["packetSize"] = str(trace["len"])
+            packet["encryptionLevel"] = "ENCRYPTION_1RTT"
+            packet["frames"] = frames
+            qtr["events"].append(packet)
+            frames = []  # empty frames list
+
+        # Stream frame sent
+        if trace["type"] == "quictrace-send-stream":
+            info = {}
+            info["streamId"] = str(trace["stream-id"])
+            if (trace["stream-id"] < 0):
+                info["streamId"] = str(31337 + trace["stream-id"])
+            if trace["fin"] == 0:
+                info["fin"] = False
+            else:
+                info["fin"] = True
+            info["length"] = str(trace["len"])
+            info["offset"] = str(trace["off"])
+            # Create and populate new frame
+            frame = {}
+            frame["frameType"] = "STREAM"
+            frame["streamFrameInfo"] = info
+            frames.append(frame)
+
+    json.dump(qtr, outf)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print "Usage: python adapter.py inTrace outTrace"
+        sys.exit(1)
+        
+    inf = open(sys.argv[1], 'r')
+    outf = open(sys.argv[2], 'w')
+    transform(inf, outf)
+    inf.close()
+    outf.close()
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
This PR adds an adapter that maps sent packets and received acks from quicly logs to a format usable by quic-trace. In this PR, the following mappings are provided: outgoing STREAM frame, outgoing packet, incoming ACK frame, incoming packet.