### PR TITLE
implement stateless reset

### DIFF
--- a/include/quicly/constants.h
+++ b/include/quicly/constants.h
@@ -55,6 +55,7 @@
 #define QUICLY_ERROR_PACKET_IGNORED 0xff01
 #define QUICLY_ERROR_SENDBUF_FULL 0xff02    /* internal use only; the error code is never exposed to the application */
 #define QUICLY_ERROR_FREE_CONNECTION 0xff03 /* returned by quicly_send when the connection is freeable */
+#define QUICLY_ERROR_RECEIVED_STATELESS_RESET 0xff04
 
 #define QUICLY_BUILD_ASSERT(condition) ((void)sizeof(char[2 * !!(!__builtin_constant_p(condition) || (condition)) - 1]))
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3086,6 +3086,7 @@ quicly_datagram_t *quicly_send_stateless_reset(quicly_context_t *ctx, struct soc
     dgram->data.base[0] = QUICLY_QUIC_BIT | (dgram->data.base[0] & ~QUICLY_LONG_HEADER_RESERVED_BITS);
     ctx->encrypt_cid->cb(ctx->encrypt_cid, NULL,
                          dgram->data.base + QUICLY_STATELESS_RESET_PACKET_MIN_LEN - QUICLY_STATELESS_RESET_TOKEN_LEN, cid);
+    dgram->data.len = QUICLY_STATELESS_RESET_PACKET_MIN_LEN;
 
     return dgram;
 }
@@ -4182,7 +4183,7 @@ static void default_encrypt_cid(quicly_encrypt_cid_cb *_self, quicly_cid_t *encr
     /* generate stateless reset token if requested */
     if (stateless_reset_token != NULL) {
         uint8_t md[PTLS_MAX_DIGEST_SIZE];
-        self->stateless_reset_token_ctx->update(self->stateless_reset_token_ctx, p - 1, p - 1 - buf); /* exclude path_id */
+        self->stateless_reset_token_ctx->update(self->stateless_reset_token_ctx, buf, p - 1 - buf); /* exclude path_id */
         self->stateless_reset_token_ctx->final(self->stateless_reset_token_ctx, md, PTLS_HASH_FINAL_MODE_RESET);
         memcpy(stateless_reset_token, md, QUICLY_STATELESS_RESET_TOKEN_LEN);
     }

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -62,6 +62,30 @@ subtest "0-rtt" => sub {
     like $events, qr/"type":"cc-ack-received".*"pn":1,/m, "pn 1 acked";
 };
 
+subtest "stateless-reset" => sub {
+    my $guard = spawn_server(qw(-C deadbeef));
+    my $pid = fork;
+    die "fork failed:$!"
+        unless defined $pid;
+    if ($pid == 0) {
+        # child process
+        open STDOUT, '>', '/dev/null'
+            or die "failed to redirect stdout to /dev/null:$!";
+        exec $cli, '-e', "$tempdir/events", qw(-i 3000 127.0.0.1), $port;
+        die "failed to exec $cli:$!";
+    }
+    # parent process, let the client fetch the first response, then kill respawn the server using same CID encryption key
+    sleep 1;
+    undef $guard;
+    $guard = spawn_server(qw(-C deadbeef));
+    # wait for the child to die
+    while (waitpid($pid, 0) != $pid) {
+    }
+    # check that the stateless reset is logged
+    my $events = slurp_file("$tempdir/events");
+    like $events, qr/"type":"stateless-reset-receive",/m;
+};
+
 done_testing;
 
 sub spawn_server {

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -24,7 +24,7 @@ subtest "hello" => sub {
     is $resp, "hello world\n";
     subtest "events" => sub {
         my $events = slurp_file("$tempdir/events");
-        ok +($events =~ /"type":"close-send",.*?"type":"([^\"]*)",.*?"type":"([^\"]*)",.*?"type":"([^\"]*)",.*?"type":"([^\"]*)"/s
+        ok +($events =~ /"type":"transport-close-send",.*?"type":"([^\"]*)",.*?"type":"([^\"]*)",.*?"type":"([^\"]*)",.*?"type":"([^\"]*)"/s
              and $1 eq "packet-commit" and $2 eq "quictrace-sent" and $3 eq "send" and $4 eq "free");
     };
 };


### PR DESCRIPTION
To be merged after #86.

This PR does the following:
* generate stateless reset token based on the plaintext CID
* send the stateless reset token to the peer
* recognize the stateless reset token, and tear down the connection state immediately