### PR TITLE
fat callback objects

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -173,22 +173,22 @@ typedef struct st_quicly_conn_t quicly_conn_t;
 typedef struct st_quicly_stream_t quicly_stream_t;
 
 #define QUICLY_CALLBACK_TYPE0(ret, name)                                                                                           \
-    typedef struct st_quicly_##name##_cb {                                                                                         \
-        ret (*cb)(struct st_quicly_##name##_cb * self);                                                                            \
-    } quicly_##name##_cb
+    typedef struct st_quicly_##name##_t {                                                                                          \
+        ret (*cb)(struct st_quicly_##name##_t * self);                                                                             \
+    } quicly_##name##_t
 
 #define QUICLY_CALLBACK_TYPE(ret, name, ...)                                                                                       \
-    typedef struct st_quicly_##name##_cb {                                                                                         \
-        ret (*cb)(struct st_quicly_##name##_cb * self, __VA_ARGS__);                                                               \
-    } quicly_##name##_cb
+    typedef struct st_quicly_##name##_t {                                                                                          \
+        ret (*cb)(struct st_quicly_##name##_t * self, __VA_ARGS__);                                                                \
+    } quicly_##name##_t
 
 /**
  * allocates a packet buffer
  */
-typedef struct st_quicly_packet_allocator_cb {
-    quicly_datagram_t *(*alloc_packet)(struct st_quicly_packet_allocator_cb *self, socklen_t salen, size_t payloadsize);
-    void (*free_packet)(struct st_quicly_packet_allocator_cb *self, quicly_datagram_t *packet);
-} quicly_packet_allocator_cb;
+typedef struct st_quicly_packet_allocator_t {
+    quicly_datagram_t *(*alloc_packet)(struct st_quicly_packet_allocator_t *self, socklen_t salen, size_t payloadsize);
+    void (*free_packet)(struct st_quicly_packet_allocator_t *self, quicly_datagram_t *packet);
+} quicly_packet_allocator_t;
 
 /**
  * CID encryption
@@ -225,7 +225,8 @@ QUICLY_CALLBACK_TYPE0(int64_t, now);
 /**
  * for event logging
  */
-QUICLY_CALLBACK_TYPE(void, event_log, quicly_event_type_t type, const quicly_event_attribute_t *attributes, size_t num_attributes);
+QUICLY_CALLBACK_TYPE(void, event_logger, quicly_event_type_t type, const quicly_event_attribute_t *attributes,
+                     size_t num_attributes);
 
 typedef struct st_quicly_max_stream_data_t {
     uint64_t bidi_local, bidi_remote, uni;
@@ -328,7 +329,7 @@ struct st_quicly_context_t {
     /**
      * callback for allocating memory for raw packet
      */
-    quicly_packet_allocator_cb *packet_allocator;
+    quicly_packet_allocator_t *packet_allocator;
     /**
      *
      */
@@ -336,15 +337,15 @@ struct st_quicly_context_t {
     /**
      * callback called when a new stream is opened by peer
      */
-    quicly_stream_open_cb *stream_open;
+    quicly_stream_open_t *stream_open;
     /**
      * callback called when a connection is closed by peer
      */
-    quicly_closed_by_peer_cb *closed_by_peer;
+    quicly_closed_by_peer_t *closed_by_peer;
     /**
      * returns current time in milliseconds
      */
-    quicly_now_cb *now;
+    quicly_now_t *now;
     /**
      * optional callback for debug logging
      */
@@ -357,7 +358,7 @@ struct st_quicly_context_t {
          * The callback. The value MUST be non-NULL when mask is set to non-zero. quicly_default_event_log is a functor provided by
          * by quicly that logs the events in JSON streaming format.
          */
-        quicly_event_log_cb *cb;
+        quicly_event_logger_t *cb;
     } event_log;
 };
 
@@ -797,28 +798,28 @@ static int quicly_stream_is_self_initiated(quicly_stream_t *stream);
 /**
  *
  */
-extern quicly_packet_allocator_cb quicly_default_packet_allocator;
+extern quicly_packet_allocator_t quicly_default_packet_allocator;
 /**
  *
  */
-quicly_cid_encryptor_t *quicly_new_default_encrypt_cid_cb(ptls_cipher_algorithm_t *cipher, ptls_hash_algorithm_t *hash,
-                                                          ptls_iovec_t key);
+quicly_cid_encryptor_t *quicly_new_default_cid_encryptor(ptls_cipher_algorithm_t *cipher, ptls_hash_algorithm_t *hash,
+                                                         ptls_iovec_t key);
 /**
  *
  */
-void quicly_free_default_encrypt_cid_cb(quicly_cid_encryptor_t *self);
+void quicly_free_default_cid_enncryptor(quicly_cid_encryptor_t *self);
 /**
  *
  */
-extern quicly_now_cb quicly_default_now_cb;
+extern quicly_now_t quicly_default_now;
 /**
  *
  */
-quicly_event_log_cb *quicly_new_default_event_log_cb(FILE *fp);
+quicly_event_logger_t *quicly_new_default_event_logger(FILE *fp);
 /**
  *
  */
-void quicly_free_default_event_log_cb(quicly_event_log_cb *self);
+void quicly_free_default_event_logger(quicly_event_logger_t *self);
 /**
  *
  */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -185,11 +185,11 @@ typedef struct st_quicly_stream_t quicly_stream_t;
 /**
  * allocates a packet buffer
  */
-QUICLY_CALLBACK_TYPE(quicly_datagram_t *, alloc_packet, socklen_t salen, size_t payloadsize);
-/**
- * frees a packet buffer
- */
-QUICLY_CALLBACK_TYPE(void, free_packet, quicly_datagram_t *packet);
+typedef struct st_quicly_packet_allocator_cb {
+    quicly_datagram_t *(*alloc_packet)(struct st_quicly_packet_allocator_cb *self, socklen_t salen, size_t payloadsize);
+    void (*free_packet)(struct st_quicly_packet_allocator_cb *self, quicly_datagram_t *packet);
+} quicly_packet_allocator_cb;
+
 /**
  * CID encryption
  */
@@ -328,11 +328,7 @@ struct st_quicly_context_t {
     /**
      * callback for allocating memory for raw packet
      */
-    quicly_alloc_packet_cb *alloc_packet;
-    /**
-     * callback for freeing memory allocated by alloc_packet
-     */
-    quicly_free_packet_cb *free_packet;
+    quicly_packet_allocator_cb *packet_allocator;
     /**
      *
      */
@@ -801,11 +797,7 @@ static int quicly_stream_is_self_initiated(quicly_stream_t *stream);
 /**
  *
  */
-extern quicly_alloc_packet_cb quicly_default_alloc_packet_cb;
-/**
- *
- */
-extern quicly_free_packet_cb quicly_default_free_packet_cb;
+extern quicly_packet_allocator_cb quicly_default_packet_allocator;
 /**
  *
  */

--- a/src/cli.c
+++ b/src/cli.c
@@ -857,8 +857,6 @@ int main(int argc, char **argv)
         }
         ctx.encrypt_cid =
             quicly_new_default_encrypt_cid_cb(&ptls_openssl_bfecb, &ptls_openssl_sha256, ptls_iovec_init(cid_key, strlen(cid_key)));
-        ctx.decrypt_cid =
-            quicly_new_default_decrypt_cid_cb(&ptls_openssl_bfecb, &ptls_openssl_sha256, ptls_iovec_init(cid_key, strlen(cid_key)));
     } else {
         /* client */
         if (ticket_file != NULL)

--- a/src/cli.c
+++ b/src/cli.c
@@ -254,7 +254,7 @@ static int client_on_receive(quicly_stream_t *stream, size_t off, const void *sr
     return 0;
 }
 
-static int on_stream_open(quicly_stream_open_cb *self, quicly_stream_t *stream)
+static int on_stream_open(quicly_stream_open_t *self, quicly_stream_t *stream)
 {
     int ret;
 
@@ -264,9 +264,9 @@ static int on_stream_open(quicly_stream_open_cb *self, quicly_stream_t *stream)
     return 0;
 }
 
-static quicly_stream_open_cb stream_open = {&on_stream_open};
+static quicly_stream_open_t stream_open = {&on_stream_open};
 
-static void on_closed_by_peer(quicly_closed_by_peer_cb *self, quicly_conn_t *conn, int err, uint64_t frame_type, const char *reason,
+static void on_closed_by_peer(quicly_closed_by_peer_t *self, quicly_conn_t *conn, int err, uint64_t frame_type, const char *reason,
                               size_t reason_len)
 {
     if (QUICLY_ERROR_IS_QUIC_TRANSPORT(err)) {
@@ -282,7 +282,7 @@ static void on_closed_by_peer(quicly_closed_by_peer_cb *self, quicly_conn_t *con
     }
 }
 
-static quicly_closed_by_peer_cb closed_by_peer = {&on_closed_by_peer};
+static quicly_closed_by_peer_t closed_by_peer = {&on_closed_by_peer};
 
 static int send_one(int fd, quicly_datagram_t *p)
 {
@@ -316,7 +316,7 @@ static int send_pending(int fd, quicly_conn_t *conn)
                 if ((ret = send_one(fd, packets[i])) == -1)
                     perror("sendmsg failed");
                 ret = 0;
-                quicly_packet_allocator_cb *pa = quicly_get_context(conn)->packet_allocator;
+                quicly_packet_allocator_t *pa = quicly_get_context(conn)->packet_allocator;
                 pa->free_packet(pa, packets[i]);
             }
         }
@@ -767,7 +767,7 @@ int main(int argc, char **argv)
             }
             setvbuf(fp, NULL, _IONBF, 0);
             ctx.event_log.mask = UINT64_MAX;
-            ctx.event_log.cb = quicly_new_default_event_log_cb(fp);
+            ctx.event_log.cb = quicly_new_default_event_logger(fp);
         } break;
         case 'i':
             if (sscanf(optarg, "%" PRId64, &request_interval) != 1) {
@@ -857,7 +857,7 @@ int main(int argc, char **argv)
             cid_key = random_key;
         }
         ctx.encrypt_cid =
-            quicly_new_default_encrypt_cid_cb(&ptls_openssl_bfecb, &ptls_openssl_sha256, ptls_iovec_init(cid_key, strlen(cid_key)));
+            quicly_new_default_cid_encryptor(&ptls_openssl_bfecb, &ptls_openssl_sha256, ptls_iovec_init(cid_key, strlen(cid_key)));
     } else {
         /* client */
         if (ticket_file != NULL)

--- a/src/cli.c
+++ b/src/cli.c
@@ -316,7 +316,8 @@ static int send_pending(int fd, quicly_conn_t *conn)
                 if ((ret = send_one(fd, packets[i])) == -1)
                     perror("sendmsg failed");
                 ret = 0;
-                quicly_default_free_packet_cb.cb(&quicly_default_free_packet_cb, packets[i]);
+                quicly_packet_allocator_cb *pa = quicly_get_context(conn)->packet_allocator;
+                pa->free_packet(pa, packets[i]);
             }
         }
     } while (ret == 0 && num_packets == sizeof(packets) / sizeof(packets[0]));

--- a/t/simple.c
+++ b/t/simple.c
@@ -393,7 +393,7 @@ static void test_rst_during_loss(void)
 
 static uint16_t test_close_error_code;
 
-static void test_closeed_by_peer(quicly_closed_by_peer_cb *self, quicly_conn_t *conn, int err, uint64_t frame_type,
+static void test_closeed_by_peer(quicly_closed_by_peer_t *self, quicly_conn_t *conn, int err, uint64_t frame_type,
                                  const char *reason, size_t reason_len)
 {
     ok(QUICLY_ERROR_IS_QUIC_APPLICATION(err));
@@ -405,7 +405,7 @@ static void test_closeed_by_peer(quicly_closed_by_peer_cb *self, quicly_conn_t *
 
 static void test_close(void)
 {
-    quicly_closed_by_peer_cb closed_by_peer = {test_closeed_by_peer}, *orig_closed_by_peer = quic_ctx.closed_by_peer;
+    quicly_closed_by_peer_t closed_by_peer = {test_closeed_by_peer}, *orig_closed_by_peer = quic_ctx.closed_by_peer;
     quicly_datagram_t *datagram;
     size_t num_datagrams;
     int64_t client_timeout, server_timeout;

--- a/t/test.c
+++ b/t/test.c
@@ -92,12 +92,12 @@ quicly_stream_callbacks_t stream_callbacks = {on_destroy,     quicly_streambuf_e
                                               on_egress_stop, quicly_streambuf_ingress_receive, on_ingress_reset};
 size_t on_destroy_callcnt;
 
-static int64_t get_now(quicly_now_cb *self)
+static int64_t get_now_cb(quicly_now_t *self)
 {
     return quic_now;
 }
 
-static quicly_now_cb get_now_cb = {get_now};
+static quicly_now_t get_now = {get_now_cb};
 
 void on_destroy(quicly_stream_t *stream)
 {
@@ -129,7 +129,7 @@ const quicly_cid_plaintext_t *new_master_id(void)
     return &master;
 }
 
-static int on_stream_open(quicly_stream_open_cb *self, quicly_stream_t *stream)
+static int on_stream_open(quicly_stream_open_t *self, quicly_stream_t *stream)
 {
     test_streambuf_t *sbuf;
     int ret;
@@ -144,7 +144,7 @@ static int on_stream_open(quicly_stream_open_cb *self, quicly_stream_t *stream)
     return 0;
 }
 
-quicly_stream_open_cb stream_open = {on_stream_open};
+quicly_stream_open_t stream_open = {on_stream_open};
 
 static void test_vector(void)
 {
@@ -340,7 +340,7 @@ int main(int argc, char **argv)
     quic_ctx.tls = &tlsctx;
     quic_ctx.transport_params.max_streams_bidi = 10;
     quic_ctx.stream_open = &stream_open;
-    quic_ctx.now = &get_now_cb;
+    quic_ctx.now = &get_now;
 
     ERR_load_crypto_strings();
     OpenSSL_add_all_algorithms();

--- a/t/test.c
+++ b/t/test.c
@@ -243,7 +243,7 @@ void free_packets(quicly_datagram_t **packets, size_t cnt)
 {
     size_t i;
     for (i = 0; i != cnt; ++i)
-        quicly_default_free_packet_cb.cb(&quicly_default_free_packet_cb, packets[i]);
+        quic_ctx.packet_allocator->free_packet(quic_ctx.packet_allocator, packets[i]);
 }
 
 size_t decode_packets(quicly_decoded_packet_t *decoded, quicly_datagram_t **raw, size_t cnt)

--- a/t/test.h
+++ b/t/test.h
@@ -41,7 +41,7 @@ extern quicly_stream_callbacks_t stream_callbacks;
 extern size_t on_destroy_callcnt;
 
 const quicly_cid_plaintext_t *new_master_id(void);
-extern quicly_stream_open_cb stream_open;
+extern quicly_stream_open_t stream_open;
 void free_packets(quicly_datagram_t **packets, size_t cnt);
 size_t decode_packets(quicly_decoded_packet_t *decoded, quicly_datagram_t **raw, size_t cnt);
 int buffer_is(ptls_buffer_t *buf, const char *s);


### PR DESCRIPTION
It is illogical to define callbacks that work as a group as separate objects (e.g., alloc_packet and free_packet, encrypt_cid and decrypt_cid).

This PR merges them into one object, as well as changing the `_cb` suffix to `_t` reflect the fact that they are not just functors after all (by having multiple function pointers).

amends #86