### PR TITLE
Log traffic secrets for use with Wireshark

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2882,13 +2882,21 @@ static int send_connection_close(quicly_conn_t *conn, struct st_quicly_send_cont
 static int update_traffic_key_cb(ptls_update_traffic_key_t *self, ptls_t *_tls, int is_enc, size_t epoch, const void *secret)
 {
     quicly_conn_t *conn = *ptls_get_data_ptr(_tls);
+    ptls_context_t *ctx = ptls_get_context(_tls);
     ptls_cipher_suite_t *cipher = ptls_get_cipher(conn->crypto.tls);
     ptls_cipher_context_t **hp_slot;
     ptls_aead_context_t **aead_slot;
     int ret;
+    static const char *log_labels[2][4] = {
+        {NULL, "QUIC_CLIENT_EARLY_TRAFFIC_SECRET", "QUIC_CLIENT_HANDSHAKE_TRAFFIC_SECRET", "QUIC_CLIENT_TRAFFIC_SECRET_0"},
+        {NULL, NULL, "QUIC_SERVER_HANDSHAKE_TRAFFIC_SECRET", "QUIC_SERVER_TRAFFIC_SECRET_0"}};
 
     LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_CRYPTO_UPDATE_SECRET, INT_EVENT_ATTR(IS_ENC, is_enc),
                          INT_EVENT_ATTR(EPOCH, epoch));
+
+    if (ctx->log_secret != NULL)
+        ctx->log_secret->cb(ctx->log_secret, _tls, log_labels[ptls_is_server(_tls) == is_enc][epoch],
+                            ptls_iovec_init(secret, cipher->hash->digest_size));
 
 #define SELECT_CIPHER_CONTEXT(p)                                                                                                   \
     do {                                                                                                                           \


### PR DESCRIPTION
picotls's `setup_traffic_protection` logs `CLIENT_*` and `SERVER_*` if secret
logging is enabled, except if a traffic key callback is specified.

We can leverage this to log the secrets on the quicly side with a QUIC_
prefix, allowing full decoding with Wireshark's HEAD version.