### PR TITLE
Rewrite congestion controller

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "deps/picotest"]
 	path = deps/picotest
 	url = https://github.com/kazuho/picotest.git
-[submodule "deps/dcc"]
-	path = deps/dcc
-	url = https://github.com/h2o/daemons-cc.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ IF (OPENSSL_FOUND AND (OPENSSL_VERSION VERSION_LESS "1.0.2"))
 ENDIF ()
 
 SET(CMAKE_C_FLAGS "-std=c99 -Wall -O2 -g ${CC_WARNING_FLAGS} ${CMAKE_C_FLAGS}")
-INCLUDE_DIRECTORIES(${OPENSSL_INCLUDE_DIR} deps/dcc deps/klib deps/picotls/include deps/picotest include)
+INCLUDE_DIRECTORIES(${OPENSSL_INCLUDE_DIR} deps/klib deps/picotls/include deps/picotest include)
 
 SET(PICOTLS_OPENSSL_FILES
     deps/picotls/lib/openssl.c
@@ -17,9 +17,6 @@ SET(PICOTLS_OPENSSL_FILES
     deps/picotls/lib/picotls.c)
 
 SET(QUICLY_LIBRARY_FILES
-    deps/dcc/cc.c
-    deps/dcc/cc_cubic.c
-    deps/dcc/cc_newreno.c
     lib/frame.c
     lib/loss.c
     lib/cc-reno.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ ADD_CUSTOM_TARGET(check env BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove --exec 
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS cli test.t)
 
+ADD_CUSTOM_TARGET(format clang-format -i `git ls-files include lib src t | egrep '\\.[ch]$$'`)
+
 IF (CMAKE_SYSTEM_NAME STREQUAL "Linux")
      SET(CMAKE_C_FLAGS "-D_GNU_SOURCE -pthread ${CMAKE_C_FLAGS}")
 ENDIF ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ SET(QUICLY_LIBRARY_FILES
     deps/dcc/cc_newreno.c
     lib/frame.c
     lib/loss.c
+    lib/cc-reno.c
     lib/quicly.c
     lib/ranges.c
     lib/recvstate.c

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -1,13 +1,35 @@
+/*
+ * Copyright (c) 2019 Fastly, Janardhan Iyengar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
 /* Interface definition for quicly's congestion controller.
  */
 
 #ifndef quicly_cc_h
 #define quicly_cc_h
 
-#include "quicly/constants.h"
 #include <assert.h>
 #include <stdint.h>
 #include <string.h>
+#include "quicly/constants.h"
 
 typedef struct st_quicly_cc_t {
     uint32_t cwnd;
@@ -18,20 +40,24 @@ typedef struct st_quicly_cc_t {
 
 void quicly_cc_init(quicly_cc_t *cc);
 
-/* Called to query the controller whether data can be sent. Returns 1 if yes, 0 otherwise.
+/**
+ * Called to query the controller whether data can be sent. Returns 1 if yes, 0 otherwise.
  */
 int quicly_cc_can_send(quicly_cc_t *cc, uint32_t inflight);
 
-/* Called when a packet is newly acknowledged.
+/**
+ * Called when a packet is newly acknowledged.
  */
 void quicly_cc_on_acked(quicly_cc_t *cc, uint32_t bytes, uint64_t largest_acked, uint32_t inflight);
 
-/* Called when a packet is detected as lost. |next_pn| is the next unsent packet number,
+/**
+ * Called when a packet is detected as lost. |next_pn| is the next unsent packet number,
  * used for setting the recovery window.
  */
 void quicly_cc_on_lost(quicly_cc_t *cc, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn);
 
-/* Called when persistent congestion is observed.
+/**
+ * Called when persistent congestion is observed.
  */
 void quicly_cc_on_persistent_congestion(quicly_cc_t *cc);
 

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -1,0 +1,43 @@
+/* Interface definition for quicly's congestion controller.
+ */
+
+#ifndef quicly_cc_h
+#define quicly_cc_h
+
+#include "quicly/constants.h"
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+struct ccstate {
+    uint32_t cwnd;
+    uint32_t ssthresh;
+    uint32_t inflight;
+    uint32_t stash;
+    uint8_t recovery_end;
+};
+
+void cc_init2(struct ccstate *ccs);
+
+/* Called to query the controller whether data can be sent. Returns 1 if yes, 0 otherwise.
+ */
+int cc_can_send(struct ccstate *ccs);
+
+/* Called after a packet is sent, to inform the controller about sent data.
+ */
+void cc_on_sent(struct ccstate *ccs, uint32_t bytes);
+
+/* Called when a packet is newly acknowledged.
+ */
+void cc_on_acked(struct ccstate *ccs, uint32_t bytes, uint64_t acked_pn);
+
+/* Called when a packet is detected as lost. |next_pn| is the next unsent packet number,
+ * used for setting the recovery window.
+ */
+void cc_on_lost(struct ccstate *ccs, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn);
+
+/* Called when persistent congestion is observed.
+ */
+void cc_on_persistent_congestion(struct ccstate *ccs);
+
+#endif

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -12,7 +12,6 @@
 struct ccstate {
     uint32_t cwnd;
     uint32_t ssthresh;
-    uint32_t inflight;
     uint32_t stash;
     uint8_t recovery_end;
 };
@@ -21,15 +20,11 @@ void cc_init2(struct ccstate *ccs);
 
 /* Called to query the controller whether data can be sent. Returns 1 if yes, 0 otherwise.
  */
-int cc_can_send(struct ccstate *ccs);
-
-/* Called after a packet is sent, to inform the controller about sent data.
- */
-void cc_on_sent(struct ccstate *ccs, uint32_t bytes);
+int cc_can_send(struct ccstate *ccs, uint32_t inflight);
 
 /* Called when a packet is newly acknowledged.
  */
-void cc_on_acked(struct ccstate *ccs, uint32_t bytes, uint64_t acked_pn);
+void cc_on_acked(struct ccstate *ccs, uint32_t bytes, uint64_t largest_acked, uint32_t inflight);
 
 /* Called when a packet is detected as lost. |next_pn| is the next unsent packet number,
  * used for setting the recovery window.

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -9,30 +9,30 @@
 #include <stdint.h>
 #include <string.h>
 
-struct ccstate {
+typedef struct st_quicly_cc_t {
     uint32_t cwnd;
     uint32_t ssthresh;
     uint32_t stash;
-    uint8_t recovery_end;
-};
+    uint64_t recovery_end;
+} quicly_cc_t;
 
-void cc_init2(struct ccstate *ccs);
+void quicly_cc_init(quicly_cc_t *cc);
 
 /* Called to query the controller whether data can be sent. Returns 1 if yes, 0 otherwise.
  */
-int cc_can_send(struct ccstate *ccs, uint32_t inflight);
+int quicly_cc_can_send(quicly_cc_t *cc, uint32_t inflight);
 
 /* Called when a packet is newly acknowledged.
  */
-void cc_on_acked(struct ccstate *ccs, uint32_t bytes, uint64_t largest_acked, uint32_t inflight);
+void quicly_cc_on_acked(quicly_cc_t *cc, uint32_t bytes, uint64_t largest_acked, uint32_t inflight);
 
 /* Called when a packet is detected as lost. |next_pn| is the next unsent packet number,
  * used for setting the recovery window.
  */
-void cc_on_lost(struct ccstate *ccs, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn);
+void quicly_cc_on_lost(quicly_cc_t *cc, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn);
 
 /* Called when persistent congestion is observed.
  */
-void cc_on_persistent_congestion(struct ccstate *ccs);
+void quicly_cc_on_persistent_congestion(quicly_cc_t *cc);
 
 #endif

--- a/include/quicly/constants.h
+++ b/include/quicly/constants.h
@@ -27,6 +27,8 @@
 
 #define QUICLY_NUM_PACKETS_BEFORE_ACK 2
 #define QUICLY_DELAYED_ACK_TIMEOUT 25 /* milliseconds */
+#define QUICLY_MAX_PACKET_SIZE 1280 /* must be >= 1200 bytes */
+#define QUICLY_AEAD_TAG_SIZE 16
 
 /* coexists with picotls error codes, assuming that int is at least 32-bits */
 #define QUICLY_ERROR_IS_QUIC(e) (((e) & ~0x1ffff) == 0x20000)

--- a/include/quicly/constants.h
+++ b/include/quicly/constants.h
@@ -27,7 +27,7 @@
 
 #define QUICLY_NUM_PACKETS_BEFORE_ACK 2
 #define QUICLY_DELAYED_ACK_TIMEOUT 25 /* milliseconds */
-#define QUICLY_MAX_PACKET_SIZE 1280 /* must be >= 1200 bytes */
+#define QUICLY_MAX_PACKET_SIZE 1280   /* must be >= 1200 bytes */
 #define QUICLY_AEAD_TAG_SIZE 16
 
 /* coexists with picotls error codes, assuming that int is at least 32-bits */

--- a/include/quicly/sentmap.h
+++ b/include/quicly/sentmap.h
@@ -120,8 +120,8 @@ struct st_quicly_sent_block_t {
  * 1. call quicly_sentmap_init_iter
  * 2. call quicly_sentmap_get to obtain the packet header that the iterator points to
  * 3. call quicly_sentmap_update to update the states of the packet that the iterator points to (as well as the state of the frames
- *    that were part of the packet) and move the iterator to the next packet header.  The function is also used for discarding entries
- *    from the sent map.
+ *    that were part of the packet) and move the iterator to the next packet header.  The function is also used for discarding
+ * entries from the sent map.
  * 4. call quicly_sentmap_skip to move the iterator to the next packet header
  *
  * Note that quicly_sentmap_update and quicly_sentmap_skip move the iterator to the next packet header.

--- a/include/quicly/sentmap.h
+++ b/include/quicly/sentmap.h
@@ -120,10 +120,11 @@ struct st_quicly_sent_block_t {
  * 1. call quicly_sentmap_init_iter
  * 2. call quicly_sentmap_get to obtain the packet header that the iterator points to
  * 3. call quicly_sentmap_update to update the states of the packet that the iterator points to (as well as the state of the frames
- *    that were part of the packet).  The function is also used for discarding entries from the sent map.
+ *    that were part of the packet) and move the iterator to the next packet header.  The function is also used for discarding entries
+ *    from the sent map.
  * 4. call quicly_sentmap_skip to move the iterator to the next packet header
  *
- * Note that quicly_sentmap_update also moves the iterator to the next packet header.
+ * Note that quicly_sentmap_update and quicly_sentmap_skip move the iterator to the next packet header.
  */
 typedef struct st_quicly_sentmap_t {
     /**

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -26,18 +26,21 @@
 #define QUICLY_MIN_CWND 2
 #define QUICLY_RENO_BETA 0.8
 
-void quicly_cc_init(quicly_cc_t *cc) {
+void quicly_cc_init(quicly_cc_t *cc)
+{
     memset(cc, 0, sizeof(quicly_cc_t));
     cc->cwnd = QUICLY_INITIAL_WINDOW * QUICLY_MAX_PACKET_SIZE;
     cc->ssthresh = UINT32_MAX;
 }
 
-int quicly_cc_can_send(quicly_cc_t *cc, uint32_t inflight) {
+int quicly_cc_can_send(quicly_cc_t *cc, uint32_t inflight)
+{
     return inflight < cc->cwnd;
 }
 
 // TODO: Avoid increase if sender was application limited
-void quicly_cc_on_acked(quicly_cc_t *cc, uint32_t bytes, uint64_t largest_acked, uint32_t inflight) {
+void quicly_cc_on_acked(quicly_cc_t *cc, uint32_t bytes, uint64_t largest_acked, uint32_t inflight)
+{
     assert(inflight >= bytes);
     // no increases while in recovery
     if (largest_acked < cc->recovery_end)
@@ -55,10 +58,11 @@ void quicly_cc_on_acked(quicly_cc_t *cc, uint32_t bytes, uint64_t largest_acked,
     // increase cwnd by 1 MSS per cwnd acked
     uint32_t count = cc->stash / cc->cwnd;
     cc->stash -= count * cc->cwnd;
-    cc->cwnd +=  count * QUICLY_MAX_PACKET_SIZE;
+    cc->cwnd += count * QUICLY_MAX_PACKET_SIZE;
 }
 
-void quicly_cc_on_lost(quicly_cc_t *cc, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn) {
+void quicly_cc_on_lost(quicly_cc_t *cc, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn)
+{
     // nothing to do if loss is in recovery window
     if (lost_pn < cc->recovery_end)
         return;
@@ -70,6 +74,7 @@ void quicly_cc_on_lost(quicly_cc_t *cc, uint32_t bytes, uint64_t lost_pn, uint64
     cc->ssthresh = cc->cwnd;
 }
 
-void quicly_cc_on_persistent_congestion(quicly_cc_t *cc) {
+void quicly_cc_on_persistent_congestion(quicly_cc_t *cc)
+{
     // TODO
 }

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -44,7 +44,7 @@ void cc_on_acked(struct ccstate *ccs, uint32_t bytes, uint64_t largest_acked, ui
         return;
 
     // slow start
-    if (inflight > ccs->ssthresh) {
+    if (ccs->cwnd < ccs->ssthresh) {
         ccs->cwnd += bytes;
         return;
     }

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017 Fastly, Janardhan Iyengar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "quicly/cc.h"
+
+#define QUICLY_INITIAL_WINDOW 10
+#define QUICLY_MIN_CWND 2
+#define QUICLY_RENO_BETA 0.8
+
+void cc_init2(struct ccstate *ccs) {
+    memset(ccs, 0, sizeof(struct ccstate));
+    ccs->cwnd = QUICLY_INITIAL_WINDOW * QUICLY_MAX_PACKET_SIZE;
+    ccs->ssthresh = UINT32_MAX;
+}
+
+int cc_can_send(struct ccstate *ccs) {
+    return ccs->inflight < ccs->cwnd;
+}
+
+void cc_on_sent(struct ccstate *ccs, uint32_t bytes) {
+    ccs->inflight += bytes;
+}
+
+// TODO: Avoid increase if sender was application limited
+void cc_on_acked(struct ccstate *ccs, uint32_t bytes, uint64_t acked_pn) {
+    assert(ccs->inflight >= bytes);
+    if (acked_pn < ccs->recovery_end) {
+        // no increases while in recovery
+        ccs->inflight -= bytes;
+        return;
+    }
+
+    // slow start
+    if (ccs->inflight > ccs->ssthresh)
+        ccs->cwnd += bytes;
+    else {
+        // congestion avoidance
+        ccs->stash += bytes;
+        if (ccs->stash >= ccs->cwnd) {
+            // increase cwnd by 1 MSS per cwnd acked
+            uint32_t count = ccs->stash / ccs->cwnd;
+            ccs->stash -= count * ccs->cwnd;
+            ccs->cwnd +=  count * QUICLY_MAX_PACKET_SIZE;
+        }
+    }
+    ccs->inflight -= bytes;
+}
+
+void cc_on_lost(struct ccstate *ccs, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn) {
+    assert(ccs->inflight >= bytes);
+    ccs->inflight -= bytes;
+    // nothing to do if loss is in recovery window
+    if (lost_pn < ccs->recovery_end)
+        return;
+    // set end of recovery window
+    ccs->recovery_end = next_pn;
+    ccs->cwnd *= QUICLY_RENO_BETA;
+    if (ccs->cwnd < QUICLY_MIN_CWND * QUICLY_MAX_PACKET_SIZE)
+        ccs->cwnd = QUICLY_MIN_CWND * QUICLY_MAX_PACKET_SIZE;
+    ccs->ssthresh = ccs->cwnd;
+}
+
+void cc_on_persistent_congestion(struct ccstate *ccs) {
+    // TODO
+}

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -37,6 +37,8 @@
 #include "quicly/streambuf.h"
 #include "quicly/cc.h"
 
+#define NEWCC 0
+
 #define QUICLY_QUIC_BIT 0x40
 #define QUICLY_LONG_HEADER_RESERVED_BITS 0xc
 #define QUICLY_SHORT_HEADER_RESERVED_BITS 0x18
@@ -1135,7 +1137,8 @@ void quicly_free(quicly_conn_t *conn)
         conn->egress.path_challenge.head = pending->next;
         free(pending);
     }
-    cc_destroy(&conn->egress.cc.ccv);
+    if (!NEWCC)
+        cc_destroy(&conn->egress.cc.ccv);
     quicly_sentmap_dispose(&conn->egress.sentmap);
 
     kh_destroy(quicly_stream_t, conn->streams);
@@ -1501,11 +1504,13 @@ static quicly_conn_t *create_connection(quicly_context_t *ctx, const char *serve
     init_max_streams(&conn->_.egress.max_streams.bidi);
     conn->_.egress.path_challenge.tail_ref = &conn->_.egress.path_challenge.head;
     conn->_.egress.send_ack_at = INT64_MAX;
-    // cc-remove
-    cc_init(&conn->_.egress.cc.ccv, &newreno_cc_algo, 1280 * 8, 1280);
-    conn->_.egress.cc.ccv.ccvc.ccv.snd_scale = 14; /* FIXME */
-    conn->_.egress.cc.end_of_recovery = UINT64_MAX;
-    cc_init2(&conn->_.egress.ccs);
+    if (!NEWCC) {
+        cc_init(&conn->_.egress.cc.ccv, &newreno_cc_algo, 1280 * 8, 1280);
+        conn->_.egress.cc.ccv.ccvc.ccv.snd_scale = 14; /* FIXME */
+        conn->_.egress.cc.end_of_recovery = UINT64_MAX;
+    } else {
+        cc_init2(&conn->_.egress.ccs);
+    }
     conn->_.crypto.tls = tls;
     if (handshake_properties != NULL) {
         assert(handshake_properties->additional_extensions == NULL);
@@ -1976,8 +1981,9 @@ static ssize_t round_send_window(ssize_t window)
 
 int64_t quicly_get_first_timeout(quicly_conn_t *conn)
 {
-    // if (cc_can_send(ccs)) {
-    if (round_send_window((ssize_t)cc_get_cwnd(&conn->egress.cc.ccv) - (ssize_t)conn->egress.sentmap.bytes_in_flight) > 0) {
+    if ((!NEWCC &&
+         (round_send_window((ssize_t)cc_get_cwnd(&conn->egress.cc.ccv) - (ssize_t)conn->egress.sentmap.bytes_in_flight) > 0)) ||
+        (NEWCC && cc_can_send(&conn->egress.ccs, conn->egress.sentmap.bytes_in_flight))) {
         if (conn->crypto.pending_flows != 0 || quicly_linklist_is_linked(&conn->pending_link.control) ||
             quicly_linklist_is_linked(&conn->pending_link.stream_fin_only) ||
             quicly_linklist_is_linked(&conn->pending_link.stream_with_payload))
@@ -2584,7 +2590,6 @@ static int do_detect_loss(quicly_loss_t *ld, uint64_t largest_pn, uint32_t delay
             if (sent->packet_number != largest_newly_lost_pn) {
                 ++conn->super.num_packets.lost;
                 largest_newly_lost_pn = sent->packet_number;
-                // kazuho: does this sentmap entry have the bytes in flight for the entire packet?
                 cc_on_lost(&conn->egress.ccs, sent->bytes_in_flight, sent->packet_number, conn->egress.packet_number);
                 LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_LOST, INT_EVENT_ATTR(PACKET_NUMBER, largest_newly_lost_pn));
                 LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_PACKET_LOST, INT_EVENT_ATTR(PACKET_NUMBER, largest_newly_lost_pn));
@@ -2599,19 +2604,28 @@ static int do_detect_loss(quicly_loss_t *ld, uint64_t largest_pn, uint32_t delay
     if (largest_newly_lost_pn != UINT64_MAX) {
         conn->egress.max_lost_pn = largest_newly_lost_pn + 1;
         conn->egress.cc.end_of_recovery = conn->egress.packet_number - 1;
-        if (is_loss && conn->egress.loss.rto_count == 0) {
-            cc_cong_signal(&conn->egress.cc.ccv, CC_ECN, (uint32_t)conn->egress.sentmap.bytes_in_flight);
-            LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_CC_CONGESTION, INT_EVENT_ATTR(MAX_LOST_PN, conn->egress.max_lost_pn),
-                                 INT_EVENT_ATTR(END_OF_RECOVERY, conn->egress.cc.end_of_recovery),
-                                 INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight),
-                                 INT_EVENT_ATTR(CWND, cc_get_cwnd(&conn->egress.cc.ccv)));
+        if (!NEWCC) {
+            if (is_loss && conn->egress.loss.rto_count == 0) {
+                cc_cong_signal(&conn->egress.cc.ccv, CC_ECN, (uint32_t)conn->egress.sentmap.bytes_in_flight);
+                LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_CC_LOST,
+                                     INT_EVENT_ATTR(MIN_RTT, conn->egress.loss.rtt.minimum),
+                                     INT_EVENT_ATTR(SMOOTHED_RTT, conn->egress.loss.rtt.smoothed),
+                                     INT_EVENT_ATTR(LATEST_RTT, conn->egress.loss.rtt.latest),
+                                     INT_EVENT_ATTR(CWND, cc_get_cwnd(&conn->egress.cc.ccv)),
+                                     INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight));
+            }
+        } else {
+            LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_CC_LOST,
+                                 INT_EVENT_ATTR(MIN_RTT, conn->egress.loss.rtt.minimum),
+                                 INT_EVENT_ATTR(SMOOTHED_RTT, conn->egress.loss.rtt.smoothed),
+                                 INT_EVENT_ATTR(LATEST_RTT, conn->egress.loss.rtt.latest),
+                                 INT_EVENT_ATTR(CWND, conn->egress.ccs.cwnd),
+                                 INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight));
         }
-        LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_CC_LOST,
-                             INT_EVENT_ATTR(MIN_RTT, conn->egress.loss.rtt.minimum),
-                             INT_EVENT_ATTR(SMOOTHED_RTT, conn->egress.loss.rtt.smoothed),
-                             INT_EVENT_ATTR(LATEST_RTT, conn->egress.loss.rtt.latest),
-                             INT_EVENT_ATTR(CWND, cc_get_cwnd(&conn->egress.cc.ccv)),
-                             INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight));
+        LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_CC_CONGESTION, INT_EVENT_ATTR(MAX_LOST_PN, conn->egress.max_lost_pn),
+                             INT_EVENT_ATTR(END_OF_RECOVERY, conn->egress.cc.end_of_recovery),
+                             INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight),
+                             INT_EVENT_ATTR(CWND, cc_get_cwnd(&conn->egress.cc.ccv)));
     }
 
     /* schedule early retransmit alarm if there is a packet outstanding that is smaller than largest_pn */
@@ -3035,10 +3049,12 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
             break;
         case 2: /* RTO */ {
             uint32_t cc_type = 0;
-            if (!conn->egress.cc.in_first_rto) {
-                cc_type = CC_FIRST_RTO;
-                cc_cong_signal(&conn->egress.cc.ccv, cc_type, (uint32_t)conn->egress.sentmap.bytes_in_flight);
-                conn->egress.cc.in_first_rto = 1;
+            if (!NEWCC) {
+                if (!conn->egress.cc.in_first_rto) {
+                    cc_type = CC_FIRST_RTO;
+                    cc_cong_signal(&conn->egress.cc.ccv, cc_type, (uint32_t)conn->egress.sentmap.bytes_in_flight);
+                    conn->egress.cc.in_first_rto = 1;
+                }
             }
             LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_CC_RTO, INT_EVENT_ATTR(CC_TYPE, cc_type),
                                  INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight),
@@ -3051,8 +3067,9 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
         }
     }
 
+    // TODO (jri): The following two blocks not need to be done. Extend the CC API to allow additional packets when TLP or RTO fires.
     { /* calculate send window */
-        uint32_t cwnd = cc_get_cwnd(&conn->egress.cc.ccv);
+        uint32_t cwnd = NEWCC ? conn->egress.ccs.cwnd : cc_get_cwnd(&conn->egress.cc.ccv);
         if (conn->egress.sentmap.bytes_in_flight < cwnd)
             s.send_window = cwnd - conn->egress.sentmap.bytes_in_flight;
     }
@@ -3413,26 +3430,45 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
             conn->egress.cc.in_first_rto = 0;
         }
     }
-    if (cc_type != 0)
-        cc_cong_signal(&conn->egress.cc.ccv, cc_type, (uint32_t)(conn->egress.sentmap.bytes_in_flight + bytes_acked));
-    int exit_recovery = frame->largest_acknowledged >= conn->egress.cc.end_of_recovery;
-    cc_ack_received(&conn->egress.cc.ccv, CC_ACK, (uint32_t)(conn->egress.sentmap.bytes_in_flight + bytes_acked),
-                    (uint16_t)segs_acked, (uint32_t)bytes_acked,
-                    conn->egress.loss.rtt.smoothed / 10 /* TODO better way of converting to cc_ticks */, exit_recovery);
+
+    int exit_recovery = 0;
+    if (!NEWCC) {
+        if (cc_type != 0)
+            cc_cong_signal(&conn->egress.cc.ccv, cc_type, (uint32_t)(conn->egress.sentmap.bytes_in_flight + bytes_acked));
+        exit_recovery = frame->largest_acknowledged >= conn->egress.cc.end_of_recovery;
+        cc_ack_received(&conn->egress.cc.ccv, CC_ACK, (uint32_t)(conn->egress.sentmap.bytes_in_flight + bytes_acked),
+                        (uint16_t)segs_acked, (uint32_t)bytes_acked,
+                        conn->egress.loss.rtt.smoothed / 10 /* TODO better way of converting to cc_ticks */, exit_recovery);
+        LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_CC_ACK,
+                             INT_EVENT_ATTR(MIN_RTT, conn->egress.loss.rtt.minimum),
+                             INT_EVENT_ATTR(SMOOTHED_RTT, conn->egress.loss.rtt.smoothed),
+                             INT_EVENT_ATTR(LATEST_RTT, conn->egress.loss.rtt.latest),
+                             INT_EVENT_ATTR(CWND, cc_get_cwnd(&conn->egress.cc.ccv)),
+                             INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight));
+
+    } else {
+        if (bytes_acked > 0) {
+            cc_on_acked(&conn->egress.ccs, (uint32_t)bytes_acked, frame->largest_acknowledged, conn->egress.sentmap.bytes_in_flight);
+            LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_CC_ACK,
+                                 INT_EVENT_ATTR(MIN_RTT, conn->egress.loss.rtt.minimum),
+                                 INT_EVENT_ATTR(SMOOTHED_RTT, conn->egress.loss.rtt.smoothed),
+                                 INT_EVENT_ATTR(LATEST_RTT, conn->egress.loss.rtt.latest),
+                                 INT_EVENT_ATTR(CWND, conn->egress.ccs.cwnd),
+                                 INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight));
+        }
+
+    }
+
     LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_CC_ACK_RECEIVED, INT_EVENT_ATTR(PACKET_NUMBER, frame->largest_acknowledged),
                          INT_EVENT_ATTR(ACKED_PACKETS, segs_acked), INT_EVENT_ATTR(ACKED_BYTES, bytes_acked),
                          INT_EVENT_ATTR(CC_TYPE, cc_type), INT_EVENT_ATTR(CC_EXIT_RECOVERY, exit_recovery),
                          INT_EVENT_ATTR(CWND, cc_get_cwnd(&conn->egress.cc.ccv)),
                          INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight));
-    LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_CC_ACK,
-                         INT_EVENT_ATTR(MIN_RTT, conn->egress.loss.rtt.minimum),
-                         INT_EVENT_ATTR(SMOOTHED_RTT, conn->egress.loss.rtt.smoothed),
-                         INT_EVENT_ATTR(LATEST_RTT, conn->egress.loss.rtt.latest),
-                         INT_EVENT_ATTR(CWND, cc_get_cwnd(&conn->egress.cc.ccv)),
-                         INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight));
 
-    if (exit_recovery)
-        conn->egress.cc.end_of_recovery = UINT64_MAX;
+    if (!NEWCC) {
+        if (exit_recovery)
+            conn->egress.cc.end_of_recovery = UINT64_MAX;
+    }
 
     /* loss-detection  */
     quicly_loss_detect_loss(&conn->egress.loss, frame->largest_acknowledged, do_detect_loss);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -29,7 +29,6 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/time.h>
-#include "cc.h"
 #include "khash.h"
 #include "quicly.h"
 #include "quicly/sentmap.h"

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -37,7 +37,7 @@
 #include "quicly/streambuf.h"
 #include "quicly/cc.h"
 
-#define NEWCC 0
+#define NEWCC 1
 
 #define QUICLY_QUIC_BIT 0x40
 #define QUICLY_LONG_HEADER_RESERVED_BITS 0xc
@@ -3448,7 +3448,8 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
 
     } else {
         if (bytes_acked > 0) {
-            cc_on_acked(&conn->egress.ccs, (uint32_t)bytes_acked, frame->largest_acknowledged, conn->egress.sentmap.bytes_in_flight);
+            cc_on_acked(&conn->egress.ccs, (uint32_t)bytes_acked, frame->largest_acknowledged, 
+                        conn->egress.sentmap.bytes_in_flight + bytes_acked);
             LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_CC_ACK,
                                  INT_EVENT_ATTR(MIN_RTT, conn->egress.loss.rtt.minimum),
                                  INT_EVENT_ATTR(SMOOTHED_RTT, conn->egress.loss.rtt.smoothed),

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2580,11 +2580,9 @@ static int do_detect_loss(quicly_loss_t *ld, uint64_t largest_pn, uint32_t delay
     }
     if (largest_newly_lost_pn != UINT64_MAX) {
         conn->egress.max_lost_pn = largest_newly_lost_pn + 1;
-        LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_CC_LOST,
-                             INT_EVENT_ATTR(MIN_RTT, conn->egress.loss.rtt.minimum),
+        LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_CC_LOST, INT_EVENT_ATTR(MIN_RTT, conn->egress.loss.rtt.minimum),
                              INT_EVENT_ATTR(SMOOTHED_RTT, conn->egress.loss.rtt.smoothed),
-                             INT_EVENT_ATTR(LATEST_RTT, conn->egress.loss.rtt.latest),
-                             INT_EVENT_ATTR(CWND, conn->egress.cc.cwnd),
+                             INT_EVENT_ATTR(LATEST_RTT, conn->egress.loss.rtt.latest), INT_EVENT_ATTR(CWND, conn->egress.cc.cwnd),
                              INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight));
         LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_CC_CONGESTION, INT_EVENT_ATTR(MAX_LOST_PN, conn->egress.max_lost_pn),
                              INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight),
@@ -3023,7 +3021,8 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
         }
     }
 
-    // TODO (jri): The following two blocks not need to be done. Extend the CC API to allow additional packets when TLP or RTO fires.
+    // TODO (jri): The following two blocks not need to be done. Extend the CC API to allow additional packets when TLP or RTO
+    // fires.
     { /* calculate send window */
         uint32_t cwnd = conn->egress.cc.cwnd;
         if (conn->egress.sentmap.bytes_in_flight < cwnd)
@@ -3378,15 +3377,13 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
      * quicly_loss_on_packet_acked is NOT OnPacketAcked */
     if (smallest_newly_acked != UINT64_MAX)
         quicly_loss_on_packet_acked(&conn->egress.loss, smallest_newly_acked);
-    
+
     if (bytes_acked > 0) {
-        quicly_cc_on_acked(&conn->egress.cc, (uint32_t)bytes_acked, frame->largest_acknowledged, 
-                    conn->egress.sentmap.bytes_in_flight + bytes_acked);
-        LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_CC_ACK,
-                             INT_EVENT_ATTR(MIN_RTT, conn->egress.loss.rtt.minimum),
+        quicly_cc_on_acked(&conn->egress.cc, (uint32_t)bytes_acked, frame->largest_acknowledged,
+                           conn->egress.sentmap.bytes_in_flight + bytes_acked);
+        LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_CC_ACK, INT_EVENT_ATTR(MIN_RTT, conn->egress.loss.rtt.minimum),
                              INT_EVENT_ATTR(SMOOTHED_RTT, conn->egress.loss.rtt.smoothed),
-                             INT_EVENT_ATTR(LATEST_RTT, conn->egress.loss.rtt.latest),
-                             INT_EVENT_ATTR(CWND, conn->egress.cc.cwnd),
+                             INT_EVENT_ATTR(LATEST_RTT, conn->egress.loss.rtt.latest), INT_EVENT_ATTR(CWND, conn->egress.cc.cwnd),
                              INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight));
     }
 


### PR DESCRIPTION
This PR removes use of the TCP-based congestion controller with a newer simpler one that is written for QUIC.

A few caveats: (1)  I've spot tested with simulations, but need to write new tests in t, (2) persistent congestion is not yet handled, and (3) app-limited periods are not yet handled.

(This is based off PR #100, so I would recommend diff-ing against that, if github doesn't automagically do it.)