### PR TITLE
Stateless Reset Token API that supports multiple generation of keys

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -214,7 +214,7 @@ typedef struct st_quicly_packet_allocator_t {
  */
 typedef struct st_quicly_cid_encryptor_t {
     /**
-     * encrypts CID and/or generates a stateless reset token
+     * encrypts CID and optionally generates a stateless reset token
      */
     void (*encrypt_cid)(struct st_quicly_cid_encryptor_t *self, quicly_cid_t *encrypted, void *stateless_reset_token,
                         const quicly_cid_plaintext_t *plaintext);
@@ -226,6 +226,10 @@ typedef struct st_quicly_cid_encryptor_t {
      */
     size_t (*decrypt_cid)(struct st_quicly_cid_encryptor_t *self, quicly_cid_plaintext_t *plaintext, const void *encrypted,
                           size_t len);
+    /**
+     * generates a stateless reset token (returns if generated)
+     */
+    int (*generate_stateless_reset_token)(struct st_quicly_cid_encryptor_t *self, void *token, const void *cid);
 } quicly_cid_encryptor_t;
 
 /**
@@ -747,8 +751,7 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
 /**
  *
  */
-quicly_datagram_t *quicly_send_stateless_reset(quicly_context_t *ctx, struct sockaddr *sa, socklen_t salen,
-                                               const quicly_cid_plaintext_t *cid);
+quicly_datagram_t *quicly_send_stateless_reset(quicly_context_t *ctx, struct sockaddr *sa, socklen_t salen, const void *cid);
 /**
  *
  */

--- a/src/cli.c
+++ b/src/cli.c
@@ -607,7 +607,7 @@ static int run_server(struct sockaddr *sa, socklen_t salen)
                      * because loop is prevented by authenticating the CID (by checking node_id and thread_id). If the peer is also
                      * sending a reset, then the next CID is highly likely to contain a non-authenticating CID, ... */
                     if (packet.cid.dest.plaintext.node_id == 0 && packet.cid.dest.plaintext.thread_id == 0) {
-                        quicly_datagram_t *dgram = quicly_send_stateless_reset(&ctx, &sa, salen, &packet.cid.dest.plaintext);
+                        quicly_datagram_t *dgram = quicly_send_stateless_reset(&ctx, &sa, salen, packet.cid.dest.encrypted.base);
                         if (send_one(fd, dgram) == -1)
                             perror("sendmsg failed");
                     }


### PR DESCRIPTION
Introduces API for generating stateless reset token that takes the encrypted CID as an argument, so that the CID encryption key can be determined. Also changes the scheme from HMAC(plaintext_cid) to HMAC(encrypted_cid).