### PR TITLE
loss alarm should be set solely based on the current state

### DIFF
--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -204,11 +204,9 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
                     alarm_duration = tlp_alarm_duration;
             }
         }
-        if (r->alarm_at > last_retransmittable_sent_at + alarm_duration) {
-            r->alarm_at = last_retransmittable_sent_at + alarm_duration;
-            if (r->alarm_at < now)
-                r->alarm_at = now;
-        }
+        r->alarm_at = last_retransmittable_sent_at + alarm_duration;
+        if (r->alarm_at < now)
+            r->alarm_at = now;
     } else {
         r->alarm_at = INT64_MAX;
         r->loss_time = INT64_MAX;


### PR DESCRIPTION
The `quicly_loss_update_alarm` function implements `SetLossDetectionTimer`.

In contrary to what the recovery draft has been suggesting (IIUC from the very beginning), we have been updating the timer only when the value calculated by the most recent state is smaller than the current value of the loss detection alarm.

This PR fixes the issue.