### PR TITLE
do not busy loop when capped by MAX_DATA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - sudo apt-get update --yes
         - sudo apt-get install --yes -f gcc-6 g++-6
         - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-6
-        - sudo apt-get install libscope-guard-perl libtest-tcp-perl
+        - sudo apt-get install libjson-perl libscope-guard-perl libtest-tcp-perl
       script:
         # Cmake 2.8.12
         - curl -O https://cmake.org/files/v2.8/cmake-2.8.12.1.tar.gz
@@ -42,7 +42,8 @@ matrix:
         - label=osx/x86-64
       before_install: &bs_osx
         - curl -L https://cpanmin.us | sudo perl - App::cpanminus
-        - sudo cpanm --totest Scope::Guard
+        - sudo cpanm --notest JSON
+        - sudo cpanm --notest Scope::Guard
         - sudo cpanm --notest Test::TCP
       script:
         - cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl .

--- a/include/quicly/sendstate.h
+++ b/include/quicly/sendstate.h
@@ -26,21 +26,23 @@
 
 typedef struct st_quicly_sendstate_t {
     /**
-     * ranges that have been acked (guaranteed to be non-empty; i.e., acked.ranges[0].end == contiguous_acked_offset)
+     * ranges that have been acked (guaranteed to be non-empty; i.e., acked.ranges[0].end == contiguous_acked_offset).  Offset may
+     * include the EOS position.
      */
     quicly_ranges_t acked;
     /**
-     * ranges that needs to be sent
+     * ranges that needs to be sent.  Offset may include the EOS position.
      */
     quicly_ranges_t pending;
     /**
-     * number's of bytes being committed; i.e. max(end) that's been inserted into pending
+     * number of bytes that have been inflight (regardless of acked or not). Used for capping max_data, therefore does not include
+     * eos.
      */
-    uint64_t size_committed : 63;
+    uint64_t size_inflight;
     /**
-     *
+     * UINT64_MAX until closed.  Does not include the EOS position.
      */
-    uint64_t is_open : 1;
+    uint64_t final_size;
 } quicly_sendstate_t;
 
 typedef struct st_quicly_sendstate_sent_t {
@@ -52,8 +54,9 @@ void quicly_sendstate_init(quicly_sendstate_t *state);
 void quicly_sendstate_init_closed(quicly_sendstate_t *state);
 void quicly_sendstate_dispose(quicly_sendstate_t *state);
 static int quicly_sendstate_transfer_complete(quicly_sendstate_t *state);
+static int quicly_sendstate_is_open(quicly_sendstate_t *state);
 int quicly_sendstate_activate(quicly_sendstate_t *state);
-int quicly_sendstate_shutdown(quicly_sendstate_t *state, uint64_t end_off);
+int quicly_sendstate_shutdown(quicly_sendstate_t *state, uint64_t final_size);
 int quicly_sendstate_acked(quicly_sendstate_t *state, quicly_sendstate_sent_t *args, int is_active, size_t *bytes_to_shift);
 int quicly_sendstate_lost(quicly_sendstate_t *state, quicly_sendstate_sent_t *args);
 
@@ -61,7 +64,12 @@ int quicly_sendstate_lost(quicly_sendstate_t *state, quicly_sendstate_sent_t *ar
 
 inline int quicly_sendstate_transfer_complete(quicly_sendstate_t *state)
 {
-    return !state->is_open && state->acked.ranges[0].end == state->size_committed;
+    return state->final_size != UINT64_MAX && state->acked.ranges[0].end == state->final_size + 1;
+}
+
+inline int quicly_sendstate_is_open(quicly_sendstate_t *state)
+{
+    return state->final_size == UINT64_MAX;
 }
 
 #endif

--- a/lib/streambuf.c
+++ b/lib/streambuf.c
@@ -89,7 +89,7 @@ int quicly_streambuf_egress_write(quicly_stream_t *stream, const void *src, size
     quicly_streambuf_t *sbuf = stream->data;
     int ret;
 
-    assert(stream->sendstate.is_open);
+    assert(quicly_sendstate_is_open(&stream->sendstate));
 
     ptls_buffer_pushv(&sbuf->egress.buf, src, len);
     sbuf->egress.max_stream_data += len;

--- a/src/cli.c
+++ b/src/cli.c
@@ -722,6 +722,8 @@ static void usage(const char *cmd)
            "  -e event-log-file    file to log events\n"
            "  -i interval          interval to reissue requests (in milliseconds)\n"
            "  -l log-file          file to log traffic secrets\n"
+           "  -M <bytes>           max stream data (in bytes; default: 1MB)\n"
+           "  -m <bytes>           max data (in bytes; default: 16MB)\n"
            "  -N                   enforce HelloRetryRequest (client-only)\n"
            "  -n                   enforce version negotiation (client-only)\n"
            "  -p path              path to request (can be set multiple times)\n"
@@ -752,7 +754,7 @@ int main(int argc, char **argv)
     setup_session_cache(ctx.tls);
     quicly_amend_ptls_context(ctx.tls);
 
-    while ((ch = getopt(argc, argv, "a:C:c:k:e:i:l:Nnp:Rr:s:Vvx:X:h")) != -1) {
+    while ((ch = getopt(argc, argv, "a:C:c:k:e:i:l:M:m:Nnp:Rr:s:Vvx:X:h")) != -1) {
         switch (ch) {
         case 'a':
             set_alpn(&hs_properties, optarg);
@@ -784,6 +786,22 @@ int main(int argc, char **argv)
             break;
         case 'l':
             setup_log_event(ctx.tls, optarg);
+            break;
+        case 'M': {
+            uint64_t v;
+            if (sscanf(optarg, "%" PRIu64, &v) != 1) {
+                fprintf(stderr, "failed to parse max stream data:%s\n", optarg);
+                exit(1);
+            }
+            ctx.transport_params.max_stream_data.bidi_local = v;
+            ctx.transport_params.max_stream_data.bidi_remote = v;
+            ctx.transport_params.max_stream_data.uni = v;
+        } break;
+        case 'm':
+            if (sscanf(optarg, "%" PRIu64, &ctx.transport_params.max_data) != 1) {
+                fprintf(stderr, "failed to parse max data:%s\n", optarg);
+                exit(1);
+            }
             break;
         case 'N':
             hs_properties.client.negotiate_before_key_exchange = 1;

--- a/src/cli.c
+++ b/src/cli.c
@@ -214,7 +214,7 @@ static int server_on_receive(quicly_stream_t *stream, size_t off, const void *sr
     if (send_sized_text(stream, path, is_http1))
         goto Sent;
 
-    if (!stream->sendstate.is_open)
+    if (!quicly_sendstate_is_open(&stream->sendstate))
         return 0;
 
     send_header(stream, is_http1, 404, "text/plain; charset=utf-8");


### PR DESCRIPTION
The strategy is to assign streams with pending payload to different slots, based on if it has data to be retransmitted or not. The side effect has been that we need to remember the cumulative number of bytes that have been sent in each stream. Hence split `size_committed` to two attributes.