### PR TITLE
get rid of `_send_aux.max_sent`

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -551,10 +551,6 @@ struct st_quicly_stream_t {
          */
         uint64_t max_stream_data;
         /**
-         * 1 + maximum offset of data that has been sent at least once (NOT counting eos)
-         */
-        uint64_t max_sent;
-        /**
          *
          */
         struct {

--- a/include/quicly/sendstate.h
+++ b/include/quicly/sendstate.h
@@ -57,6 +57,7 @@ static int quicly_sendstate_transfer_complete(quicly_sendstate_t *state);
 static int quicly_sendstate_is_open(quicly_sendstate_t *state);
 int quicly_sendstate_activate(quicly_sendstate_t *state);
 int quicly_sendstate_shutdown(quicly_sendstate_t *state, uint64_t final_size);
+void quicly_sendstate_reset(quicly_sendstate_t *state);
 int quicly_sendstate_acked(quicly_sendstate_t *state, quicly_sendstate_sent_t *args, int is_active, size_t *bytes_to_shift);
 int quicly_sendstate_lost(quicly_sendstate_t *state, quicly_sendstate_sent_t *args);
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -765,7 +765,6 @@ static void init_stream_properties(quicly_stream_t *stream, uint32_t initial_max
     stream->streams_blocked = 0;
 
     stream->_send_aux.max_stream_data = initial_max_stream_data_remote;
-    stream->_send_aux.max_sent = 0;
     stream->_send_aux.stop_sending.sender_state = QUICLY_SENDER_STATE_NONE;
     stream->_send_aux.stop_sending.error_code = 0;
     stream->_send_aux.rst.sender_state = QUICLY_SENDER_STATE_NONE;
@@ -2344,8 +2343,8 @@ static int send_stream_control_frames(quicly_stream_t *stream, struct st_quicly_
         if ((ret = prepare_stream_state_sender(stream, &stream->_send_aux.rst.sender_state, s, QUICLY_RST_FRAME_CAPACITY,
                                                on_ack_rst_stream)) != 0)
             return ret;
-        s->dst =
-            quicly_encode_rst_stream_frame(s->dst, stream->stream_id, stream->_send_aux.rst.error_code, stream->_send_aux.max_sent);
+        s->dst = quicly_encode_rst_stream_frame(s->dst, stream->stream_id, stream->_send_aux.rst.error_code,
+                                                stream->sendstate.size_inflight);
     }
 
     return 0;
@@ -2404,11 +2403,11 @@ static int send_stream_data(quicly_stream_t *stream, struct st_quicly_send_conte
         if (off + capacity > stream->_send_aux.max_stream_data)
             capacity = stream->_send_aux.max_stream_data - off;
         /* cap by max_data */
-        if (off + capacity > stream->_send_aux.max_sent) {
-            uint64_t new_bytes = off + capacity - stream->_send_aux.max_sent;
+        if (off + capacity > stream->sendstate.size_inflight) {
+            uint64_t new_bytes = off + capacity - stream->sendstate.size_inflight;
             if (new_bytes > stream->conn->egress.max_data.permitted - stream->conn->egress.max_data.sent) {
                 size_t max_stream_data =
-                    stream->_send_aux.max_sent + stream->conn->egress.max_data.permitted - stream->conn->egress.max_data.sent;
+                    stream->sendstate.size_inflight + stream->conn->egress.max_data.permitted - stream->conn->egress.max_data.sent;
                 capacity = max_stream_data - off;
             }
         }
@@ -2446,12 +2445,6 @@ static int send_stream_data(quicly_stream_t *stream, struct st_quicly_send_conte
     s->dst += len;
     end_off = off + len;
 
-    /* adjust max_stream_data, max_data */
-    if (stream->stream_id >= 0 && end_off > stream->_send_aux.max_sent) {
-        stream->conn->egress.max_data.sent += end_off - stream->_send_aux.max_sent;
-        stream->_send_aux.max_sent = end_off;
-    }
-
     /* determine if the frame incorporates FIN */
     if (!quicly_sendstate_is_open(&stream->sendstate) && end_off == stream->sendstate.final_size) {
         assert(end_off + 1 == stream->sendstate.pending.ranges[stream->sendstate.pending.num_ranges - 1].end);
@@ -2467,9 +2460,12 @@ UpdateState:
                      INT_EVENT_ATTR(LENGTH, end_off - off), INT_EVENT_ATTR(FIN, is_fin));
     LOG_STREAM_EVENT(stream->conn, stream->stream_id, QUICLY_EVENT_TYPE_QUICTRACE_SEND_STREAM, INT_EVENT_ATTR(OFFSET, off),
                      INT_EVENT_ATTR(LENGTH, end_off - off), INT_EVENT_ATTR(FIN, is_fin));
-    /* update sendstate */
-    if (stream->sendstate.size_inflight < end_off)
+    /* update sendstate (and also MAX_DATA counter) */
+    if (stream->sendstate.size_inflight < end_off) {
+        if (stream->stream_id >= 0)
+            stream->conn->egress.max_data.sent += end_off - stream->sendstate.size_inflight;
         stream->sendstate.size_inflight = end_off;
+    }
     if ((ret = quicly_ranges_subtract(&stream->sendstate.pending, off, end_off + is_fin)) != 0)
         return ret;
     if (wrote_all) {
@@ -4208,8 +4204,7 @@ void quicly_reset_stream(quicly_stream_t *stream, int err)
     assert(!quicly_sendstate_transfer_complete(&stream->sendstate));
 
     /* dispose sendbuf state */
-    quicly_sendstate_dispose(&stream->sendstate);
-    quicly_sendstate_init_closed(&stream->sendstate);
+    quicly_sendstate_reset(&stream->sendstate);
 
     /* setup RST_STREAM */
     stream->_send_aux.rst.sender_state = QUICLY_SENDER_STATE_SEND;

--- a/lib/sendstate.c
+++ b/lib/sendstate.c
@@ -82,6 +82,18 @@ int quicly_sendstate_shutdown(quicly_sendstate_t *state, uint64_t final_size)
     return 0;
 }
 
+void quicly_sendstate_reset(quicly_sendstate_t *state)
+{
+    int ret;
+
+    if (state->final_size == UINT64_MAX)
+        state->final_size = state->size_inflight;
+
+    ret = quicly_ranges_add(&state->acked, 0, state->final_size + 1);
+    assert(ret == 0 && "guaranteed to succeed, because the numebr of ranges never increases");
+    quicly_ranges_clear(&state->pending);
+}
+
 int quicly_sendstate_acked(quicly_sendstate_t *state, quicly_sendstate_sent_t *args, int is_active, size_t *bytes_to_shift)
 {
     uint64_t prev_sent_upto = state->acked.ranges[0].end;


### PR DESCRIPTION
We can track the value using `quicly_sendstate_t::size_inflight` added in #113.