### PR TITLE
fix bug in PN rounding

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -654,7 +654,7 @@ size_t quicly_decode_packet(quicly_context_t *ctx, quicly_decoded_packet_t *pack
 /**
  *
  */
-uint64_t quicly_determine_packet_number(uint32_t bits, uint32_t mask, uint64_t next_expected);
+uint64_t quicly_determine_packet_number(uint32_t truncated, size_t num_bits, uint64_t expected);
 /**
  *
  */

--- a/t/test.c
+++ b/t/test.c
@@ -310,12 +310,15 @@ int max_data_is_equal(quicly_conn_t *client, quicly_conn_t *server)
 static void test_next_packet_number(void)
 {
     /* prefer lower in case the distance in both directions are equal; see https://github.com/quicwg/base-drafts/issues/674 */
-    uint64_t n = quicly_determine_packet_number(0xc0, 0xff, 0x140);
+    uint64_t n = quicly_determine_packet_number(0xc0, 8, 0x139);
     ok(n == 0xc0);
-    n = quicly_determine_packet_number(0xc0, 0xff, 0x141);
+    n = quicly_determine_packet_number(0xc0, 8, 0x140);
     ok(n == 0x1c0);
-    n = quicly_determine_packet_number(0x9b32, 0xffff, 0xa82f30eb);
+    n = quicly_determine_packet_number(0x9b32, 16, 0xa82f30eb);
     ok(n == 0xa82f9b32);
+
+    n = quicly_determine_packet_number(31, 16, 65259);
+    ok(n == 65567);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Without the fix, the connection breaks after exchanging 2^16 packets.