### PR TITLE
Fix assertion in `default_decrypt_cid`->`ptls_cipher_encrypt`

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4305,13 +4305,14 @@ static size_t default_decrypt_cid(quicly_cid_encryptor_t *_self, quicly_cid_plai
 
     /* decrypt */
     if (len != 0 && len != cid_len) {
+        uint8_t ebuf[16];
         /* normalize the input, so that we would get consistent routing */
         if (len > cid_len)
             len = cid_len;
-        memcpy(buf, encrypted, cid_len);
+        memcpy(ebuf, encrypted, cid_len);
         if (len < cid_len)
-            memset(buf + len, 0, cid_len - len);
-        ptls_cipher_encrypt(self->cid_decrypt_ctx, buf, buf, cid_len);
+            memset(ebuf + len, 0, cid_len - len);
+        ptls_cipher_encrypt(self->cid_decrypt_ctx, buf, ebuf, cid_len);
     } else {
         ptls_cipher_encrypt(self->cid_decrypt_ctx, buf, encrypted, cid_len);
     }


### PR DESCRIPTION
`ptls_cipher_encrypt` ends up calling `EVP_DecryptUpdate`, in `picotls/lib/openssl.c`. In 1.1.1a, `EVP_DecryptUpdate` checks that the output and the input are not overlapping:

crypto/evp/evp_enc.c
```
326     if (is_partially_overlapping(out + ctx->buf_len, in, cmpl)) {
327         EVPerr(EVP_F_EVP_ENCRYPTUPDATE,
EVP_R_PARTIALLY_OVERLAPPING);
328         return 0;
329     }

```