### PR TITLE
Fix Reno beta value to be same as in Cubic RFC (8312)

### DIFF
--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -24,7 +24,7 @@
 
 #define QUICLY_INITIAL_WINDOW 10
 #define QUICLY_MIN_CWND 2
-#define QUICLY_RENO_BETA 0.8
+#define QUICLY_RENO_BETA 0.7
 
 void quicly_cc_init(quicly_cc_t *cc)
 {


### PR DESCRIPTION
The Cubic paper says 0.8, but the RFC says 0.7. Praveen said that MS uses 0.7 and I believe the Linux kernel uses 0.7 as well. So, rectifying.