### PR TITLE
Replaces uses of TLP and RTO with PTO

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -317,7 +317,7 @@ typedef struct st_quicly_transport_parameters_t {
     /**
      * in milliseconds; quicly ignores the value set for quicly_context_t::transport_parameters
      */
-    uint8_t max_ack_delay;
+    uint16_t max_ack_delay;
 } quicly_transport_parameters_t;
 
 struct st_quicly_cid_t {

--- a/include/quicly/constants.h
+++ b/include/quicly/constants.h
@@ -31,6 +31,12 @@ extern "C" {
 
 #define QUICLY_NUM_PACKETS_BEFORE_ACK 2
 #define QUICLY_DELAYED_ACK_TIMEOUT 25 /* milliseconds */
+#define QUICLY_DEFAULT_MAX_ACK_DELAY 25 /* milliseconds */
+#define QUICLY_LOCAL_MAX_ACK_DELAY 25 /* milliseconds */
+#define QUICLY_DEFAULT_MIN_PTO 1 /* milliseconds */
+#define QUICLY_DEFAULT_INITIAL_RTT 100
+#define QUICLY_MAX_PTO_COUNT 16 /* 65 seconds under 1ms granurality */
+
 #define QUICLY_MAX_PACKET_SIZE 1280   /* must be >= 1200 bytes */
 #define QUICLY_AEAD_TAG_SIZE 16
 

--- a/include/quicly/constants.h
+++ b/include/quicly/constants.h
@@ -30,14 +30,14 @@ extern "C" {
 #include <stdint.h>
 
 #define QUICLY_NUM_PACKETS_BEFORE_ACK 2
-#define QUICLY_DELAYED_ACK_TIMEOUT 25 /* milliseconds */
+#define QUICLY_DELAYED_ACK_TIMEOUT 25   /* milliseconds */
 #define QUICLY_DEFAULT_MAX_ACK_DELAY 25 /* milliseconds */
-#define QUICLY_LOCAL_MAX_ACK_DELAY 25 /* milliseconds */
-#define QUICLY_DEFAULT_MIN_PTO 1 /* milliseconds */
+#define QUICLY_LOCAL_MAX_ACK_DELAY 25   /* milliseconds */
+#define QUICLY_DEFAULT_MIN_PTO 1        /* milliseconds */
 #define QUICLY_DEFAULT_INITIAL_RTT 100
 #define QUICLY_MAX_PTO_COUNT 16 /* 65 seconds under 1ms granurality */
 
-#define QUICLY_MAX_PACKET_SIZE 1280   /* must be >= 1200 bytes */
+#define QUICLY_MAX_PACKET_SIZE 1280 /* must be >= 1200 bytes */
 #define QUICLY_AEAD_TAG_SIZE 16
 
 /* coexists with picotls error codes, assuming that int is at least 32-bits */

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -33,33 +33,20 @@ extern "C" {
 
 typedef struct quicly_loss_conf_t {
     /**
-     * Maximum number of tail loss probes before an RTO fires.
-     */
-    unsigned max_tlps;
-    /**
      * Maximum reordering in time space before time based loss detection considers a packet lost. In percentile (1/1024) of an RTT.
      */
     unsigned time_reordering_percentile;
     /**
-     * Minimum time in the future a tail loss probe alarm may be set for.
+     * Minimum time in the future a PTO alarm may be set for.
      */
-    uint32_t min_tlp_timeout;
-    /**
-     * Minimum time in the future an RTO alarm may be set for.
-     */
-    uint32_t min_rto_timeout;
+    uint32_t min_pto;
     /**
      * The default RTT used before an RTT sample is taken.
      */
     uint32_t default_initial_rtt;
 } quicly_loss_conf_t;
 
-#define QUICLY_LOSS_DEFAULT_MAX_TLPS 2
 #define QUICLY_LOSS_DEFAULT_TIME_REORDERING_PERCENTILE (1024 / 8)
-#define QUICLY_LOSS_DEFAULT_MIN_TLP_TIMEOUT 10
-#define QUICLY_LOSS_DEFAULT_MIN_RTO_TIMEOUT 200
-#define QUICLY_LOSS_DEFAULT_INITIAL_RTT 100
-#define QUICLY_LOSS_MAX_RTO_COUNT 16 /* 65 seconds under 1ms granurality */
 
 extern quicly_loss_conf_t quicly_loss_default_conf;
 
@@ -83,17 +70,9 @@ typedef struct quicly_loss_t {
      */
     uint8_t *max_ack_delay;
     /**
-     * The number of times a tail loss probe has been sent without receiving an ack.
+     * The number of consecutive PTOs (PTOs that have fired without receiving an ack).
      */
-    uint8_t tlp_count;
-    /**
-     * The number of times an rto has been sent without receiving an ack.
-     */
-    uint8_t rto_count;
-    /**
-     * The last packet number sent prior to the first retransmission timeout.
-     */
-    uint64_t largest_sent_before_rto;
+    uint8_t pto_count;
     /**
      * The time the most recent packet was sent.
      */
@@ -106,10 +85,6 @@ typedef struct quicly_loss_t {
      * The time at which the next packet will be considered lost based on exceeding the reordering window in time.
      */
     int64_t loss_time;
-    /**
-     *
-     */
-
     /**
      * The time at when lostdetect_on_alarm should be called.
      */
@@ -124,12 +99,6 @@ typedef int (*quicly_loss_do_detect_cb)(quicly_loss_t *r, uint64_t largest_acked
 
 static void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, uint8_t *max_ack_delay);
 static void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last_retransmittable_sent_at, int has_outstanding);
-
-/* called every time a is received for congestion control and loss recovery.
- * TODO (jri): Make this function be called on each packet newly acked, rather than every new ack received.
- */
-static int quicly_loss_on_packet_acked(quicly_loss_t *r, uint64_t acked);
-
 static void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_acked, uint32_t latest_rtt, uint32_t ack_delay,
                                         int is_ack_only);
 static int quicly_loss_on_alarm(quicly_loss_t *r, uint64_t largest_sent, uint64_t largest_acked, quicly_loss_do_detect_cb do_detect,
@@ -176,7 +145,7 @@ inline void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t _latest_rtt, uint32_t 
 
 inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, uint8_t *max_ack_delay)
 {
-    *r = (quicly_loss_t){conf, max_ack_delay, 0, 0, 0, 0, 0, INT64_MAX, INT64_MAX};
+    *r = (quicly_loss_t){conf, max_ack_delay, 0, 0, 0, INT64_MAX, INT64_MAX};
     quicly_rtt_init(&r->rtt, conf, initial_rtt);
 }
 
@@ -185,28 +154,16 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
     if (has_outstanding) {
         int64_t alarm_duration;
         if (r->loss_time != INT64_MAX) {
-            /* Time loss detection */
+            /* time-threshold loss detection */
             alarm_duration = r->loss_time - last_retransmittable_sent_at;
         } else if (r->rtt.smoothed == 0) {
-            /* handshake timer */
-            alarm_duration = 2 * r->rtt.latest /* should contain intial rtt */;
-            if (alarm_duration < r->conf->min_tlp_timeout)
-                alarm_duration = r->conf->min_tlp_timeout;
-            alarm_duration <<= r->tlp_count;
+            alarm_duration = 2 * r->rtt.latest /* should contain initial rtt */;
         } else {
-            /* RTO or TLP alarm (FIXME observe and use max_ack_delay) */
+            /* PTO alarm (FIXME observe and use max_ack_delay) */
             alarm_duration = r->rtt.smoothed + 4 * r->rtt.variance + *r->max_ack_delay;
-            if (alarm_duration < r->conf->min_rto_timeout)
-                alarm_duration = r->conf->min_rto_timeout;
-            alarm_duration <<= r->rto_count < QUICLY_LOSS_MAX_RTO_COUNT ? r->rto_count : QUICLY_LOSS_MAX_RTO_COUNT;
-            if (r->tlp_count < r->conf->max_tlps) {
-                /* Tail Loss Probe */
-                int64_t tlp_alarm_duration = r->rtt.smoothed * 3 / 2 + *r->max_ack_delay;
-                if (tlp_alarm_duration < r->conf->min_tlp_timeout)
-                    tlp_alarm_duration = r->conf->min_tlp_timeout;
-                if (tlp_alarm_duration < alarm_duration)
-                    alarm_duration = tlp_alarm_duration;
-            }
+            if (alarm_duration < r->conf->min_pto)
+                alarm_duration = r->conf->min_pto;
+            alarm_duration <<= r->pto_count < QUICLY_MAX_PTO_COUNT ? r->pto_count : QUICLY_MAX_PTO_COUNT;
         }
         r->alarm_at = last_retransmittable_sent_at + alarm_duration;
         if (r->alarm_at < now)
@@ -215,14 +172,6 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
         r->alarm_at = INT64_MAX;
         r->loss_time = INT64_MAX;
     }
-}
-
-inline int quicly_loss_on_packet_acked(quicly_loss_t *r, uint64_t acked)
-{
-    int rto_verified = r->rto_count > 0 && acked > r->largest_sent_before_rto;
-    r->tlp_count = 0;
-    r->rto_count = 0;
-    return rto_verified;
 }
 
 inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_acked, uint32_t latest_rtt, uint32_t ack_delay,
@@ -248,16 +197,9 @@ inline int quicly_loss_on_alarm(quicly_loss_t *r, uint64_t largest_sent, uint64_
         *num_packets_to_send = 0;
         return quicly_loss_detect_loss(r, largest_acked, do_detect);
     }
-    if (r->tlp_count < r->conf->max_tlps) {
-        /* Tail Loss Probe. */
-        r->tlp_count++;
-        *num_packets_to_send = 1;
-        return 0;
-    }
-    /* RTO */
-    if (r->rto_count == 0)
-        r->largest_sent_before_rto = largest_sent;
-    ++r->rto_count;
+    /* PTO */
+    if (r->pto_count == 0)
+    ++r->pto_count;
     *num_packets_to_send = 2;
     return 0;
 }

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -199,7 +199,7 @@ inline int quicly_loss_on_alarm(quicly_loss_t *r, uint64_t largest_sent, uint64_
     }
     /* PTO */
     if (r->pto_count == 0)
-    ++r->pto_count;
+        ++r->pto_count;
     *num_packets_to_send = 2;
     return 0;
 }

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -68,7 +68,7 @@ typedef struct quicly_loss_t {
     /**
      * pointer to transport parameter containing max_ack_delay
      */
-    uint8_t *max_ack_delay;
+    uint16_t *max_ack_delay;
     /**
      * The number of consecutive PTOs (PTOs that have fired without receiving an ack).
      */
@@ -97,7 +97,7 @@ typedef struct quicly_loss_t {
 
 typedef int (*quicly_loss_do_detect_cb)(quicly_loss_t *r, uint64_t largest_acked, uint32_t delay_until_lost, int64_t *loss_time);
 
-static void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, uint8_t *max_ack_delay);
+static void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, uint16_t *max_ack_delay);
 static void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last_retransmittable_sent_at, int has_outstanding);
 static void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_acked, uint32_t latest_rtt, uint32_t ack_delay,
                                         int is_ack_only);
@@ -143,7 +143,7 @@ inline void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t _latest_rtt, uint32_t 
     assert(rtt->smoothed != 0);
 }
 
-inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, uint8_t *max_ack_delay)
+inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, uint16_t *max_ack_delay)
 {
     *r = (quicly_loss_t){conf, max_ack_delay, 0, 0, 0, INT64_MAX, INT64_MAX};
     quicly_rtt_init(&r->rtt, conf, initial_rtt);

--- a/lib/loss.c
+++ b/lib/loss.c
@@ -22,9 +22,7 @@
 #include "quicly/loss.h"
 
 quicly_loss_conf_t quicly_loss_default_conf = {
-    QUICLY_LOSS_DEFAULT_MAX_TLPS,                   /* max_tlps */
     QUICLY_LOSS_DEFAULT_TIME_REORDERING_PERCENTILE, /* time_reordering_percentile */
-    QUICLY_LOSS_DEFAULT_MIN_TLP_TIMEOUT,            /* min_tlp_timeout */
-    QUICLY_LOSS_DEFAULT_MIN_RTO_TIMEOUT,            /* min_rto_timeout */
-    QUICLY_LOSS_DEFAULT_INITIAL_RTT                 /* initial_rtt */
+    QUICLY_DEFAULT_MIN_PTO,                         /* min_pto */
+    QUICLY_DEFAULT_INITIAL_RTT                      /* initial_rtt */
 };

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1374,7 +1374,6 @@ int quicly_decode_transport_parameter_list(quicly_transport_parameters_t *params
                     uint64_t v;
                     if ((ret = quicly_tls_decode_varint(&v, &src, end)) != 0)
                         goto Exit;
-                    /* FIXME do we have a maximum? */
                     if (v >= 16384)
                         v = QUICLY_DEFAULT_MAX_ACK_DELAY;
                     params->max_ack_delay = (uint16_t)v;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1375,10 +1375,9 @@ int quicly_decode_transport_parameter_list(quicly_transport_parameters_t *params
                     if ((ret = quicly_tls_decode_varint(&v, &src, end)) != 0)
                         goto Exit;
                     /* FIXME do we have a maximum? */
-                    if (v > 255)
-                        v = 255;
-                    // @@@@
-                    params->ack_delay_exponent = (uint8_t)v;
+                    if (v >= 16384)
+                        v = QUICLY_DEFAULT_MAX_ACK_DELAY;
+                    params->max_ack_delay = (uint16_t)v;
                 } break;
                 default:
                     src = end;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -307,7 +307,7 @@ static int update_traffic_key_cb(ptls_update_traffic_key_t *self, ptls_t *tls, i
 static int discard_sentmap_by_epoch(quicly_conn_t *conn, unsigned ack_epochs);
 
 static const quicly_transport_parameters_t transport_params_before_handshake = {
-    {0, 0, 0}, 0, 0, 0, 0, 3, QUICLY_DELAYED_ACK_TIMEOUT};
+    {0, 0, 0}, 0, 0, 0, 0, 3, QUICLY_DEFAULT_MAX_ACK_DELAY};
 
 static __thread int64_t now;
 
@@ -1274,6 +1274,7 @@ int quicly_encode_transport_parameter_list(ptls_buffer_t *buf, int is_client, co
                                      { pushv(buf, params->max_streams_uni); });
         }
         PUSH_TRANSPORT_PARAMETER(buf, QUICLY_TRANSPORT_PARAMETER_ID_ACK_DELAY_EXPONENT, { pushv(buf, QUICLY_ACK_DELAY_EXPONENT); });
+        PUSH_TRANSPORT_PARAMETER(buf, QUICLY_TRANSPORT_PARAMETER_ID_MAX_ACK_DELAY, { pushv(buf, QUICLY_LOCAL_MAX_ACK_DELAY); });
     });
 #undef pushv
 
@@ -1376,6 +1377,7 @@ int quicly_decode_transport_parameter_list(quicly_transport_parameters_t *params
                     /* FIXME do we have a maximum? */
                     if (v > 255)
                         v = 255;
+                    // @@@@
                     params->ack_delay_exponent = (uint8_t)v;
                 } break;
                 default:
@@ -2464,6 +2466,7 @@ UpdateState:
 static int64_t get_sentmap_expiration_time(quicly_conn_t *conn)
 {
     /* TODO reconsider this (maybe 3 PTO? also not sure why we need to add ack-delay twice) */
+    /* TODO (jri): The timeouts used here should be entirely the peer's */
     return (conn->egress.loss.rtt.smoothed + conn->egress.loss.rtt.variance) * 4 + conn->super.peer.transport_params.max_ack_delay +
            QUICLY_DELAYED_ACK_TIMEOUT;
 }
@@ -2501,7 +2504,7 @@ int discard_sentmap_by_epoch(quicly_conn_t *conn, unsigned ack_epochs)
 }
 
 /**
- * Determine frames to be retransmitted on TLP and RTO.
+ * Determine frames to be retransmitted on crypto timeout or PTO.
  */
 static int mark_packets_as_lost(quicly_conn_t *conn, size_t count)
 {
@@ -2950,38 +2953,27 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
         if ((ret = quicly_loss_on_alarm(&conn->egress.loss, conn->egress.packet_number - 1, conn->egress.loss.largest_acked_packet,
                                         do_detect_loss, &s.min_packets_to_send)) != 0)
             goto Exit;
-        switch (s.min_packets_to_send) {
-        case 1: /* TLP (try to send new data when handshake is done, otherwise retire oldest handshake packets and retransmit) */
-            LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_CC_TLP,
+        if (s.min_packets_to_send > 0) {
+            /* PTO  (try to send new data when handshake is done, otherwise retire oldest handshake packets and retransmit) */
+            LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_CC_RTO, INT_EVENT_ATTR(CC_TYPE, 0),
                                  INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight),
                                  INT_EVENT_ATTR(CWND, conn->egress.cc.cwnd));
+            /* TODO (jri): if r->pto_count > MAX_PTO, close connection */
             if (!ptls_handshake_is_complete(conn->crypto.tls)) {
                 if ((ret = mark_packets_as_lost(conn, s.min_packets_to_send)) != 0)
                     goto Exit;
             }
-            break;
-        case 2: /* RTO */ {
-            uint32_t cc_type = 0;
-            LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_CC_RTO, INT_EVENT_ATTR(CC_TYPE, cc_type),
-                                 INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight),
-                                 INT_EVENT_ATTR(CWND, conn->egress.cc.cwnd));
-            if ((ret = mark_packets_as_lost(conn, s.min_packets_to_send)) != 0)
-                goto Exit;
-        } break;
-        default:
-            break;
         }
     }
 
-    // TODO (jri): The following two blocks not need to be done. Extend the CC API to allow additional packets when TLP or RTO
-    // fires.
+    // TODO (jri): The following two blocks not need to be done. Extend the CC API to allow additional packets when PTO fires.
     { /* calculate send window */
         uint32_t cwnd = conn->egress.cc.cwnd;
         if (conn->egress.sentmap.bytes_in_flight < cwnd)
             s.send_window = cwnd - conn->egress.sentmap.bytes_in_flight;
     }
 
-    /* If TLP or RTO, ensure there's enough send_window to send */
+    /* If PTO, ensure there's enough send_window to send */
     if (s.min_packets_to_send != 0) {
         assert(s.min_packets_to_send <= s.max_packets);
         if (s.send_window < s.min_packets_to_send * conn->super.ctx->max_packet_size)
@@ -3054,7 +3046,7 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
     if (s.target.packet != NULL)
         commit_send_packet(conn, &s, 0);
 
-    /* TLP (TODO use these packets to retransmit data) */
+    /* PTO (TODO use these packets to retransmit data) */
     if (s.min_packets_to_send != 0) {
         if (QUICLY_PACKET_IS_LONG_HEADER(s.current.first_byte)) {
             if (conn->handshake != NULL && (s.current.cipher = &conn->handshake->cipher.egress)->aead != NULL) {
@@ -3327,10 +3319,8 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
     /* OnPacketAckedCC */
     /* TODO (jri): this function should be called for every packet newly acked. (kazuho) I do not think so;
      * quicly_loss_on_packet_acked is NOT OnPacketAcked */
-    if (smallest_newly_acked != UINT64_MAX)
-        quicly_loss_on_packet_acked(&conn->egress.loss, smallest_newly_acked);
-
     if (bytes_acked > 0) {
+        conn->egress.loss.pto_count = 0;
         quicly_cc_on_acked(&conn->egress.cc, (uint32_t)bytes_acked, frame->largest_acknowledged,
                            conn->egress.sentmap.bytes_in_flight + bytes_acked);
         LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_CC_ACK, INT_EVENT_ATTR(MIN_RTT, conn->egress.loss.rtt.minimum),

--- a/src/cli.c
+++ b/src/cli.c
@@ -880,7 +880,7 @@ int main(int argc, char **argv)
     if (ctx.tls->certificates.count != 0 || ctx.tls->sign_certificate != NULL) {
         /* server */
         if (ctx.tls->certificates.count == 0 || ctx.tls->sign_certificate == NULL) {
-            fprintf(stderr, "-ck and -k options must be used together\n");
+            fprintf(stderr, "-c and -k options must be used together\n");
             exit(1);
         }
         if (cid_key == NULL) {

--- a/t/loss.c
+++ b/t/loss.c
@@ -87,7 +87,6 @@ static void test_even(void)
     size_t num_sent, num_received;
     int ret;
 
-    lossconf.max_tlps = 0;
     quic_ctx.loss = &lossconf;
 
     quic_now = 0;


### PR DESCRIPTION
This PR does the first pass of replacing TLP and RTO with PTO. Persistent congestion is not yet detected, and I've filed #132 for doing this.

With TLP and RTO, the sender would prioritize sending new data on TLP and old data on RTO. This change prioritizes new data over old on a PTO. We may want to revisit this in the scheduler, filed #133 for this.

This PR also fixes a bug with max_ack_delay in transport params.

Fixes #108.
