### PR TITLE
Changes to RTT estimator

### DIFF
--- a/include/quicly/constants.h
+++ b/include/quicly/constants.h
@@ -33,6 +33,8 @@ extern "C" {
 #define QUICLY_DELAYED_ACK_TIMEOUT 25   /* milliseconds */
 #define QUICLY_DEFAULT_MAX_ACK_DELAY 25 /* milliseconds */
 #define QUICLY_LOCAL_MAX_ACK_DELAY 25   /* milliseconds */
+#define QUICLY_DEFAULT_ACK_DELAY_EXPONENT 3
+#define QUICLY_LOCAL_ACK_DELAY_EXPONENT 10
 #define QUICLY_DEFAULT_MIN_PTO 1        /* milliseconds */
 #define QUICLY_DEFAULT_INITIAL_RTT 100
 #define QUICLY_MAX_PTO_COUNT 16 /* 65 seconds under 1ms granurality */

--- a/include/quicly/constants.h
+++ b/include/quicly/constants.h
@@ -35,7 +35,7 @@ extern "C" {
 #define QUICLY_LOCAL_MAX_ACK_DELAY 25   /* milliseconds */
 #define QUICLY_DEFAULT_ACK_DELAY_EXPONENT 3
 #define QUICLY_LOCAL_ACK_DELAY_EXPONENT 10
-#define QUICLY_DEFAULT_MIN_PTO 1        /* milliseconds */
+#define QUICLY_DEFAULT_MIN_PTO 1 /* milliseconds */
 #define QUICLY_DEFAULT_INITIAL_RTT 100
 #define QUICLY_MAX_PTO_COUNT 16 /* 65 seconds under 1ms granurality */
 

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -188,11 +188,11 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
     }
 }
 
-inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_acked, uint32_t latest_rtt, uint32_t ack_delay,
-                                        int is_ack_only)
+inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_acked, uint32_t latest_rtt, uint32_t ack_delay)
 {
-    if (r->largest_acked_packet < largest_acked)
-        r->largest_acked_packet = largest_acked;
+    if (r->largest_acked_packet > largest_acked)
+        return;
+    r->largest_acked_packet = largest_acked;
     if (latest_rtt != UINT32_MAX)
         quicly_rtt_update(&r->rtt, latest_rtt, ack_delay);
 }

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -195,7 +195,7 @@ inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly
         r->pto_count = 0;
 
     /* Only use RTT samples for new largest acked */
-    if (r->largest_acked_packet >= largest_newly_acked)
+    if (largest_newly_acked == UINT64_MAX || r->largest_acked_packet >= largest_newly_acked)
         return;
     r->largest_acked_packet = largest_newly_acked;
 

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -101,8 +101,7 @@ static void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, u
 
 static void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last_retransmittable_sent_at, int has_outstanding);
 
-static void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_acked, uint32_t latest_rtt, uint32_t ack_delay,
-                                        int is_ack_only);
+static void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_acked, uint32_t latest_rtt, uint32_t ack_delay);
 
 /* called every time an ACK is received that newly acks a packet
  */

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -101,13 +101,15 @@ typedef struct quicly_loss_t {
 
 typedef int (*quicly_loss_do_detect_cb)(quicly_loss_t *r, uint64_t largest_acked, uint32_t delay_until_lost, int64_t *loss_time);
 
-    static void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, uint16_t *max_ack_delay, uint8_t *ack_delay_exponent);
+static void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, uint16_t *max_ack_delay,
+                             uint8_t *ack_delay_exponent);
 
 static void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last_retransmittable_sent_at, int has_outstanding);
 
 /* called when an ACK is received
  */
-static void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, int64_t now, int64_t sent_at, uint32_t ack_delay, size_t bytes_acked);
+static void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, int64_t now, int64_t sent_at,
+                                        uint32_t ack_delay, size_t bytes_acked);
 
 /* This function updates the early retransmit timer and indicates to the caller how many packets should be sent.
  * After calling this function, app should:
@@ -137,7 +139,7 @@ inline void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t latest_rtt, uint32_t a
     /* update minimum */
     if (rtt->latest < rtt->minimum)
         rtt->minimum = rtt->latest;
-    
+
     /* use ack_delay if it's a plausible value */
     if (rtt->latest > rtt->minimum + ack_delay)
         rtt->latest -= ack_delay;
@@ -153,7 +155,8 @@ inline void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t latest_rtt, uint32_t a
     assert(rtt->smoothed != 0);
 }
 
-inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, uint16_t *max_ack_delay, uint8_t *ack_delay_exponent)
+inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, uint16_t *max_ack_delay,
+                             uint8_t *ack_delay_exponent)
 {
     *r = (quicly_loss_t){conf, max_ack_delay, ack_delay_exponent, 0, 0, 0, INT64_MAX, INT64_MAX};
     quicly_rtt_init(&r->rtt, conf, initial_rtt);
@@ -185,7 +188,8 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
     }
 }
 
-inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, int64_t now, int64_t sent_at, uint32_t ack_delay, size_t bytes_acked)
+inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, int64_t now, int64_t sent_at,
+                                        uint32_t ack_delay, size_t bytes_acked)
 {
     if (largest_newly_acked != UINT64_MAX)
         r->pto_count = 0;

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -205,6 +205,10 @@ inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly
      * This makes it so that persistent late ACKs from the peer increase the SRTT.
      * OTOH, when the ACK does not acknowledge any ack-eliciting packets, the ack_delay can be large. In such cases,
      * allow for the ack_delay to be arbitrarily large (effectively bounded by the lifetime of these packets in the sent_map).
+     *
+     * Note also that we assume that bytes_acked is greater than 0 when ack-eliciting packets are acked. This is not true if
+     * an ack-eliciting packet is acked but was previously marked as lost. We expect this to be a slight aberration, but rare enough
+     * to not matter.
      */
     if (ack_delay > *r->max_ack_delay && bytes_acked > 0)
         ack_delay = *r->max_ack_delay;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -66,8 +66,6 @@
 #define QUICLY_TRANSPORT_PARAMETER_ID_DISABLE_MIGRATION 12
 #define QUICLY_TRANSPORT_PARAMETER_ID_PREFERRED_ADDRESS 13
 
-#define QUICLY_ACK_DELAY_EXPONENT 10
-
 #define QUICLY_EPOCH_INITIAL 0
 #define QUICLY_EPOCH_0RTT 1
 #define QUICLY_EPOCH_HANDSHAKE 2
@@ -307,7 +305,7 @@ static int update_traffic_key_cb(ptls_update_traffic_key_t *self, ptls_t *tls, i
 static int discard_sentmap_by_epoch(quicly_conn_t *conn, unsigned ack_epochs);
 
 static const quicly_transport_parameters_t transport_params_before_handshake = {
-    {0, 0, 0}, 0, 0, 0, 0, 3, QUICLY_DEFAULT_MAX_ACK_DELAY};
+    {0, 0, 0}, 0, 0, 0, 0, QUICLY_DEFAULT_ACK_DELAY_EXPONENT, QUICLY_DEFAULT_MAX_ACK_DELAY};
 
 static __thread int64_t now;
 
@@ -1272,7 +1270,7 @@ int quicly_encode_transport_parameter_list(ptls_buffer_t *buf, int is_client, co
             PUSH_TRANSPORT_PARAMETER(buf, QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAMS_UNI,
                                      { pushv(buf, params->max_streams_uni); });
         }
-        PUSH_TRANSPORT_PARAMETER(buf, QUICLY_TRANSPORT_PARAMETER_ID_ACK_DELAY_EXPONENT, { pushv(buf, QUICLY_ACK_DELAY_EXPONENT); });
+        PUSH_TRANSPORT_PARAMETER(buf, QUICLY_TRANSPORT_PARAMETER_ID_ACK_DELAY_EXPONENT, { pushv(buf, QUICLY_LOCAL_ACK_DELAY_EXPONENT); });
         PUSH_TRANSPORT_PARAMETER(buf, QUICLY_TRANSPORT_PARAMETER_ID_MAX_ACK_DELAY, { pushv(buf, QUICLY_LOCAL_MAX_ACK_DELAY); });
     });
 #undef pushv
@@ -1467,7 +1465,8 @@ static quicly_conn_t *create_connection(quicly_context_t *ctx, const char *serve
     quicly_sentmap_init(&conn->_.egress.sentmap);
     quicly_loss_init(&conn->_.egress.loss, conn->_.super.ctx->loss,
                      conn->_.super.ctx->loss->default_initial_rtt /* FIXME remember initial_rtt in session ticket */,
-                     &conn->_.super.peer.transport_params.max_ack_delay);
+                     &conn->_.super.peer.transport_params.max_ack_delay,
+                     &conn->_.super.peer.transport_params.ack_delay_exponent);
     init_max_streams(&conn->_.egress.max_streams.uni);
     init_max_streams(&conn->_.egress.max_streams.bidi);
     conn->_.egress.path_challenge.tail_ref = &conn->_.egress.path_challenge.head;
@@ -2237,9 +2236,9 @@ static int send_ack(quicly_conn_t *conn, struct st_quicly_pn_space_t *space, qui
 
     /* calc ack_delay */
     if (space->largest_pn_received_at < now) {
-        /* We underreport ack_delay up to 1 milliseconds assuming that QUICLY_ACK_DELAY_EXPONENT is 10. It's considered a non-issue
+        /* We underreport ack_delay up to 1 milliseconds assuming that QUICLY_LOCAL_ACK_DELAY_EXPONENT is 10. It's considered a non-issue
          * because our time measurement is at millisecond granurality anyways. */
-        ack_delay = ((now - space->largest_pn_received_at) * 1000) >> QUICLY_ACK_DELAY_EXPONENT;
+        ack_delay = ((now - space->largest_pn_received_at) * 1000) >> QUICLY_LOCAL_ACK_DELAY_EXPONENT;
     } else {
         ack_delay = 0;
     }
@@ -3318,23 +3317,8 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
 
     LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_RECV_ACK, INT_EVENT_ATTR(ACK_DELAY, frame->ack_delay));
 
-    /* OnPacketAcked */
-    uint32_t latest_rtt = UINT32_MAX, ack_delay = 0;
-    if (largest_newly_acked.packet_number == frame->largest_acknowledged) {
-        uint64_t ack_delay_microsecs = frame->ack_delay << conn->super.peer.transport_params.ack_delay_exponent;
-        ack_delay = (uint32_t)((ack_delay_microsecs * 2 + 1000) / 2000);
-        /* Ignore samples where ack_delay is larger than max_ack_delay.  Note: This is a departure from the recovery
-         * draft which uses this RTT sample, but limiting the ack_delay to min(ack_delay, max_ack_delay). This departure
-         * allows us to not ignore RTT samples where the largest acked is in fact not ack-eliciting, since we simply ignore
-         * the sample where ack_delay is too large for such a packet. */
-        if (ack_delay > conn->super.peer.transport_params.max_ack_delay)
-                latest_rtt = (uint32_t)(now - largest_newly_acked.sent_at);
-    }
-
-    quicly_loss_on_ack_received(&conn->egress.loss, frame->largest_acknowledged, latest_rtt, ack_delay);
-
-    if (largest_newly_acked.packet_number != UINT64_MAX)
-        quicly_loss_on_newly_acked(&conn->egress.loss);
+    /* update loss detection engine on ack */
+    quicly_loss_on_ack_received(&conn->egress.loss, largest_newly_acked.packet_number, now, largest_newly_acked.sent_at, frame->ack_delay, bytes_acked);
 
     /* OnPacketAcked and OnPacketAckedCC */
     if (bytes_acked > 0) {

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3317,8 +3317,8 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
 
     LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_RECV_ACK, INT_EVENT_ATTR(ACK_DELAY, frame->ack_delay));
 
-    /* Update loss detection engine on ack. The function uses ack_delay only when the largest_newly_acked is also the largest acked so far.
-     * So, it does not matter if the ack_delay being passed in does not apply to the largest_newly_acked. */
+    /* Update loss detection engine on ack. The function uses ack_delay only when the largest_newly_acked is also the largest acked
+     * so far. So, it does not matter if the ack_delay being passed in does not apply to the largest_newly_acked. */
     quicly_loss_on_ack_received(&conn->egress.loss, largest_newly_acked.packet_number, now, largest_newly_acked.sent_at,
                                 frame->ack_delay, bytes_acked);
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3325,7 +3325,7 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
         ack_delay = (uint32_t)((ack_delay_microsecs * 2 + 1000) / 2000);
         /* Ignore samples where ack_delay is larger than max_ack_delay.  Note: This is a departure from the recovery
          * draft which uses this RTT sample, but limiting the ack_delay to min(ack_delay, max_ack_delay). This departure
-         * allows us to not ignore RTT samples where the largest acked is in fact not ack-eliciting, since we simply ignore 
+         * allows us to not ignore RTT samples where the largest acked is in fact not ack-eliciting, since we simply ignore
          * the sample where ack_delay is too large for such a packet. */
         if (ack_delay > conn->super.peer.transport_params.max_ack_delay)
             return;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3317,7 +3317,8 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
 
     LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_RECV_ACK, INT_EVENT_ATTR(ACK_DELAY, frame->ack_delay));
 
-    /* update loss detection engine on ack */
+    /* Update loss detection engine on ack. The function uses ack_delay only when the largest_newly_acked is also the largest acked so far.
+     * So, it does not matter if the ack_delay being passed in does not apply to the largest_newly_acked. */
     quicly_loss_on_ack_received(&conn->egress.loss, largest_newly_acked.packet_number, now, largest_newly_acked.sent_at,
                                 frame->ack_delay, bytes_acked);
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3328,9 +3328,7 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
          * allows us to not ignore RTT samples where the largest acked is in fact not ack-eliciting, since we simply ignore
          * the sample where ack_delay is too large for such a packet. */
         if (ack_delay > conn->super.peer.transport_params.max_ack_delay)
-            return;
-        int64_t t = now - largest_newly_acked.sent_at;
-        latest_rtt = (uint32_t)t;
+                latest_rtt = (uint32_t)(now - largest_newly_acked.sent_at);
     }
 
     quicly_loss_on_ack_received(&conn->egress.loss, frame->largest_acknowledged, latest_rtt, ack_delay);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3333,9 +3333,11 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
 
     quicly_loss_on_ack_received(&conn->egress.loss, frame->largest_acknowledged, latest_rtt, ack_delay);
 
+    if (largest_newly_acked.packet_number != UINT64_MAX)
+        quicly_loss_on_newly_acked(&conn->egress.loss);
+
     /* OnPacketAcked and OnPacketAckedCC */
     if (bytes_acked > 0) {
-        quicly_loss_on_newly_acked(&conn->egress.loss);
         quicly_cc_on_acked(&conn->egress.cc, (uint32_t)bytes_acked, frame->largest_acknowledged,
                            conn->egress.sentmap.bytes_in_flight + bytes_acked);
         LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_QUICTRACE_CC_ACK, INT_EVENT_ATTR(MIN_RTT, conn->egress.loss.rtt.minimum),


### PR DESCRIPTION
Makes RTT estimator use ack_delay correctly, and also fixes use of RTT for non-ack-eliciting packets.