### PR TITLE
detect ack-eliciting packets properly when calculating RTT

### DIFF
--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -109,7 +109,7 @@ static void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
 /* called when an ACK is received
  */
 static void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, int64_t now, int64_t sent_at,
-                                        uint32_t ack_delay, size_t bytes_acked);
+                                        uint32_t ack_delay, int ack_eliciting);
 
 /* This function updates the early retransmit timer and indicates to the caller how many packets should be sent.
  * After calling this function, app should:
@@ -189,7 +189,7 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
 }
 
 inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, int64_t now, int64_t sent_at,
-                                        uint32_t ack_delay, size_t bytes_acked)
+                                        uint32_t ack_delay, int ack_eliciting)
 {
     if (largest_newly_acked != UINT64_MAX)
         r->pto_count = 0;
@@ -204,13 +204,8 @@ inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly
     /* Use min(ack_delay, max_ack_delay) for an ACK that acknowledges one or more ack-eliciting packets.
      * This makes it so that persistent late ACKs from the peer increase the SRTT.
      * OTOH, when the ACK does not acknowledge any ack-eliciting packets, the ack_delay can be large. In such cases,
-     * allow for the ack_delay to be arbitrarily large (effectively bounded by the lifetime of these packets in the sent_map).
-     *
-     * Note also that we assume that bytes_acked is greater than 0 when ack-eliciting packets are acked. This is not true if
-     * an ack-eliciting packet is acked but was previously marked as lost. We expect this to be a slight aberration, but rare enough
-     * to not matter.
-     */
-    if (ack_delay > *r->max_ack_delay && bytes_acked > 0)
+     * allow for the ack_delay to be arbitrarily large (effectively bounded by the lifetime of these packets in the sent_map). */
+    if (ack_delay > *r->max_ack_delay && ack_eliciting)
         ack_delay = *r->max_ack_delay;
     quicly_rtt_update(&r->rtt, (uint32_t)(now - sent_at), ack_delay);
 }

--- a/include/quicly/sentmap.h
+++ b/include/quicly/sentmap.h
@@ -36,10 +36,26 @@ struct st_quicly_conn_t;
 typedef struct st_quicly_sent_t quicly_sent_t;
 
 typedef struct st_quicly_sent_packet_t {
+    /**
+     *
+     */
     uint64_t packet_number;
+    /**
+     *
+     */
     int64_t sent_at;
-    uint8_t ack_epoch;        /* epoch to be acked in */
-    uint16_t bytes_in_flight; /* number of bytes in-flight for the packet (0 if not ACK-eliciting or once deemed lost) */
+    /**
+     * epoch to be acked in
+     */
+    uint8_t ack_epoch;
+    /**
+     *
+     */
+    uint8_t ack_eliciting : 1;
+    /**
+     * number of bytes in-flight for the packet (becomes zero once deemed lost)
+     */
+    uint16_t bytes_in_flight;
 } quicly_sent_packet_t;
 
 typedef enum en_quicly_sentmap_event_t {
@@ -209,6 +225,7 @@ inline void quicly_sentmap_commit(quicly_sentmap_t *map, uint16_t bytes_in_fligh
     assert(map->_pending_packet != NULL);
 
     if (bytes_in_flight != 0) {
+        map->_pending_packet->data.packet.ack_eliciting = 1;
         map->_pending_packet->data.packet.bytes_in_flight = bytes_in_flight;
         map->bytes_in_flight += bytes_in_flight;
     }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3305,8 +3305,7 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
                     if (epoch == sent->ack_epoch) {
                         largest_newly_acked.packet_number = packet_number;
                         largest_newly_acked.sent_at = sent->sent_at;
-                        if (sent->ack_eliciting)
-                            includes_ack_eliciting = 1;
+                        includes_ack_eliciting |= sent->ack_eliciting;
                         LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_PACKET_ACKED, INT_EVENT_ATTR(PACKET_NUMBER, packet_number),
                                              INT_EVENT_ATTR(NEWLY_ACKED, 1));
                         if (sent->bytes_in_flight != 0) {

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3269,6 +3269,7 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
     struct {
         uint64_t packet_number;
         int64_t sent_at;
+        int ack_eliciting;
     } largest_newly_acked = {UINT64_MAX, INT64_MAX};
     size_t segs_acked = 0, bytes_acked = 0;
     int ret;
@@ -3300,6 +3301,7 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
                     if (epoch == sent->ack_epoch) {
                         largest_newly_acked.packet_number = packet_number;
                         largest_newly_acked.sent_at = sent->sent_at;
+                        largest_newly_acked.ack_eliciting = sent->ack_eliciting;
                         LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_PACKET_ACKED, INT_EVENT_ATTR(PACKET_NUMBER, packet_number),
                                              INT_EVENT_ATTR(NEWLY_ACKED, 1));
                         if (sent->bytes_in_flight != 0) {
@@ -3325,7 +3327,7 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
     /* Update loss detection engine on ack. The function uses ack_delay only when the largest_newly_acked is also the largest acked
      * so far. So, it does not matter if the ack_delay being passed in does not apply to the largest_newly_acked. */
     quicly_loss_on_ack_received(&conn->egress.loss, largest_newly_acked.packet_number, now, largest_newly_acked.sent_at,
-                                frame->ack_delay, bytes_acked);
+                                frame->ack_delay, largest_newly_acked.ack_eliciting);
 
     /* OnPacketAcked and OnPacketAckedCC */
     if (bytes_acked > 0) {

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3274,10 +3274,9 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
     struct {
         uint64_t packet_number;
         int64_t sent_at;
-        int ack_eliciting;
     } largest_newly_acked = {UINT64_MAX, INT64_MAX};
     size_t segs_acked = 0, bytes_acked = 0;
-    int ret;
+    int includes_ack_eliciting = 0, ret;
 
     switch (epoch) {
     case QUICLY_EPOCH_0RTT:
@@ -3306,7 +3305,8 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
                     if (epoch == sent->ack_epoch) {
                         largest_newly_acked.packet_number = packet_number;
                         largest_newly_acked.sent_at = sent->sent_at;
-                        largest_newly_acked.ack_eliciting = sent->ack_eliciting;
+                        if (sent->ack_eliciting)
+                            includes_ack_eliciting = 1;
                         LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_PACKET_ACKED, INT_EVENT_ATTR(PACKET_NUMBER, packet_number),
                                              INT_EVENT_ATTR(NEWLY_ACKED, 1));
                         if (sent->bytes_in_flight != 0) {
@@ -3332,7 +3332,7 @@ static int handle_ack_frame(quicly_conn_t *conn, size_t epoch, quicly_ack_frame_
     /* Update loss detection engine on ack. The function uses ack_delay only when the largest_newly_acked is also the largest acked
      * so far. So, it does not matter if the ack_delay being passed in does not apply to the largest_newly_acked. */
     quicly_loss_on_ack_received(&conn->egress.loss, largest_newly_acked.packet_number, now, largest_newly_acked.sent_at,
-                                frame->ack_delay, largest_newly_acked.ack_eliciting);
+                                frame->ack_delay, includes_ack_eliciting);
 
     /* OnPacketAcked and OnPacketAckedCC */
     if (bytes_acked > 0) {


### PR DESCRIPTION
I think this is what we need to do to calculate RTT using ACKs for non-ack-eliciting packets.

I am not sure if I like the current design of `quicly_sent_packet_t` - it has a state that gets modified (`bytes_in_flight`) and this PR introduces a flag called `ack_eliciting`. I think it might be better to have a flag named `is_lost` and `bytes_in_flight` being a constant for the lifetime of the object.

But meh this PR works (at least I think so), and it might be sufficient. @janaiyengar WDYT?