### PR TITLE
Acks for non-ack-eliciting packets do not generate RTT samples

### DIFF
--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -151,8 +151,8 @@ inline void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t latest_rtt, uint32_t a
         rtt->smoothed = rtt->latest;
     } else {
         uint32_t absdiff = rtt->smoothed >= rtt->latest ? rtt->smoothed - rtt->latest : rtt->latest - rtt->smoothed;
-        rtt->smoothed = (rtt->smoothed * 7 + rtt->latest) / 8;
         rtt->variance = (rtt->variance * 3 + absdiff) / 4;
+        rtt->smoothed = (rtt->smoothed * 7 + rtt->latest) / 8;
     }
     assert(rtt->smoothed != 0);
 }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3023,7 +3023,6 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
             LOG_CONNECTION_EVENT(conn, QUICLY_EVENT_TYPE_CC_RTO, INT_EVENT_ATTR(CC_TYPE, 0),
                                  INT_EVENT_ATTR(BYTES_IN_FLIGHT, conn->egress.sentmap.bytes_in_flight),
                                  INT_EVENT_ATTR(CWND, conn->egress.cc.cwnd));
-            /* TODO (jri): if r->pto_count > MAX_PTO, close connection */
             if (ptls_handshake_is_complete(conn->crypto.tls) &&
                 conn->super.ctx->stream_scheduler->can_send(conn->super.ctx->stream_scheduler, conn,
                                                             conn->egress.max_data.sent < conn->egress.max_data.permitted)) {


### PR DESCRIPTION
Implements [PR 2592](https://github.com/quicwg/base-drafts/pull/2592).  Also adds a few comments and a minor restructure.