### PR TITLE
cli: generate data on the fly when serving /SIZE.txt client requests.

### DIFF
--- a/include/quicly/streambuf.h
+++ b/include/quicly/streambuf.h
@@ -44,12 +44,14 @@ typedef struct st_quicly_streambuf_t {
     ptls_buffer_t ingress;
 } quicly_streambuf_t;
 
+quicly_streambuf_t *quicly_streambuf(quicly_stream_t *stream);
 int quicly_streambuf_create(quicly_stream_t *stream, size_t sz);
 void quicly_streambuf_destroy(quicly_stream_t *stream, int err);
 void quicly_streambuf_egress_shift(quicly_stream_t *stream, size_t delta);
 int quicly_streambuf_egress_emit(quicly_stream_t *stream, size_t off, void *dst, size_t *len, int *wrote_all);
 int quicly_streambuf_egress_write(quicly_stream_t *stream, const void *src, size_t len);
 int quicly_streambuf_egress_shutdown(quicly_stream_t *stream);
+size_t quicly_streambuf_egress_avail(quicly_stream_t *stream);
 void quicly_streambuf_ingress_shift(quicly_stream_t *stream, size_t delta);
 ptls_iovec_t quicly_streambuf_ingress_get(quicly_stream_t *stream);
 int quicly_streambuf_ingress_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len);

--- a/lib/streambuf.c
+++ b/lib/streambuf.c
@@ -31,6 +31,11 @@ static void shift_bytes(ptls_buffer_t *buf, size_t delta)
     memmove(buf->base, buf->base + delta, buf->off);
 }
 
+quicly_streambuf_t *quicly_streambuf(quicly_stream_t *stream)
+{
+    return stream->data;
+}
+
 int quicly_streambuf_create(quicly_stream_t *stream, size_t sz)
 {
     quicly_streambuf_t *sbuf;
@@ -106,6 +111,12 @@ int quicly_streambuf_egress_shutdown(quicly_stream_t *stream)
     quicly_streambuf_t *sbuf = stream->data;
     quicly_sendstate_shutdown(&stream->sendstate, sbuf->egress.max_stream_data);
     return quicly_stream_sync_sendbuf(stream, 1);
+}
+
+size_t quicly_streambuf_egress_avail(quicly_stream_t *stream)
+{
+    quicly_streambuf_t *sbuf = stream->data;
+    return sbuf->egress.buf.off;
 }
 
 void quicly_streambuf_ingress_shift(quicly_stream_t *stream, size_t delta)


### PR DESCRIPTION
There is no need for buffering data when serving /SIZE.txt requests. This saves both memory and CPU resources (memmove() in quicly_streambuf_egress_emit()). Below are the results for 10,20,30,100M local file transfers.

dimm@precision:~/dev/stablebits/quicly$ time ./cli localhost 4433 -p /10000000.txt > /dev/null
packets: received: 7974, sent: 3988, lost: 0, ack-received: 3772, bytes-received: 10200984, bytes-sent: 185175
real	0m0.130s
user	0m0.024s
sys	0m0.036s
dimm@precision:~/dev/stablebits/quicly$ time ./cli localhost 4433 -p /20000000.txt > /dev/null
packets: received: 15945, sent: 7976, lost: 0, ack-received: 7757, bytes-received: 20400456, bytes-sent: 363881
real	0m0.179s
user	0m0.028s
sys	0m0.072s
dimm@precision:~/dev/stablebits/quicly$ time ./cli localhost 4433 -p /30000000.txt > /dev/null
packets: received: 23911, sent: 11958, lost: 0, ack-received: 11710, bytes-received: 30599935, bytes-sent: 466148
real	0m0.195s
user	0m0.024s
sys	0m0.104s
dimm@precision:~/dev/stablebits/quicly$ time ./cli localhost 4433 -p /100000000.txt > /dev/null
packets: received: 79704, sent: 39874, lost: 0, ack-received: 39464, bytes-received: 101995883, bytes-sent: 1471478
real	0m0.417s
user	0m0.140s
sys	0m0.208s

Reference: Issue #88, "Performance: transfer rate decreased over time".