### PR TITLE
report more stats (as well as providing further extensibility)

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -758,7 +758,7 @@ static void quicly_get_peername(quicly_conn_t *conn, struct sockaddr **sa, sockl
 /**
  *
  */
-static quicly_stats_t *quicly_get_stats(quicly_conn_t *conn);
+int quicly_get_stats(quicly_conn_t *conn, quicly_stats_t *stats);
 /**
  *
  */
@@ -1007,12 +1007,6 @@ inline int quicly_stream_has_receive_side(int is_client, quicly_stream_id_t stre
 inline int quicly_stream_is_self_initiated(quicly_stream_t *stream)
 {
     return quicly_stream_is_client_initiated(stream->stream_id) == quicly_is_client(stream->conn);
-}
-
-inline quicly_stats_t *quicly_get_stats(quicly_conn_t *conn)
-{
-    struct _st_quicly_conn_public_t *c = (struct _st_quicly_conn_public_t *)conn;
-    return &c->stats;
 }
 
 inline void quicly_byte_to_hex(char *dst, uint8_t v)

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -448,17 +448,31 @@ struct st_quicly_conn_streamgroup_state_t {
     quicly_stream_id_t next_stream_id;
 };
 
+/**
+ * Values that do not need to be gathered upon the invocation of `quicly_get_stats`. We use typedef to define the same fields in
+ * the same order for quicly_stats_t and `struct st_quicly_public_conn_t::stats`.
+ */
+#define QUICLY_STATS_PREBUILT_FIELDS                                                                                               \
+    struct {                                                                                                                       \
+        uint64_t received;                                                                                                         \
+        uint64_t sent;                                                                                                             \
+        uint64_t lost;                                                                                                             \
+        uint64_t ack_received;                                                                                                     \
+    } num_packets;                                                                                                                 \
+    struct {                                                                                                                       \
+        uint64_t received;                                                                                                         \
+        uint64_t sent;                                                                                                             \
+    } num_bytes
+
 typedef struct st_quicly_stats_t {
-    struct {
-        uint64_t received;
-        uint64_t sent;
-        uint64_t lost;
-        uint64_t ack_received;
-    } num_packets;
-    struct {
-        uint64_t received;
-        uint64_t sent;
-    } num_bytes;
+    /**
+     * The pre-built fields. This MUST be the first member of `quicly_stats_t` so that we can use `memcpy`.
+     */
+    QUICLY_STATS_PREBUILT_FIELDS;
+    /**
+     * RTT
+     */
+    quicly_rtt_t rtt;
 } quicly_stats_t;
 
 struct _st_quicly_conn_public_t {
@@ -506,7 +520,9 @@ struct _st_quicly_conn_public_t {
         quicly_linklist_t new_data;
         quicly_linklist_t non_new_data;
     } _default_scheduler;
-    quicly_stats_t stats;
+    struct {
+        QUICLY_STATS_PREBUILT_FIELDS;
+    } stats;
     uint32_t version;
     void *data;
 };

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -876,7 +876,12 @@ ptls_t *quicly_get_tls(quicly_conn_t *conn)
 
 int quicly_get_stats(quicly_conn_t *conn, quicly_stats_t *stats)
 {
-    *stats = conn->super.stats;
+    /* copy the pre-built stats fields */
+    memcpy(stats, &conn->super.stats, sizeof(conn->super.stats));
+
+    /* set or generate the non-pre-built stats fields here */
+    stats->rtt = conn->egress.loss.rtt;
+
     return 0;
 }
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -874,6 +874,12 @@ ptls_t *quicly_get_tls(quicly_conn_t *conn)
     return conn->crypto.tls;
 }
 
+int quicly_get_stats(quicly_conn_t *conn, quicly_stats_t *stats)
+{
+    *stats = conn->super.stats;
+    return 0;
+}
+
 void quicly_get_max_data(quicly_conn_t *conn, uint64_t *send_permitted, uint64_t *sent, uint64_t *consumed)
 {
     if (send_permitted != NULL)

--- a/src/cli.c
+++ b/src/cli.c
@@ -247,12 +247,13 @@ static int client_on_receive(quicly_stream_t *stream, size_t off, const void *sr
             if (request_interval != 0) {
                 enqueue_requests_at = ctx.now->cb(ctx.now) + request_interval;
             } else {
-                quicly_stats_t *stats = quicly_get_stats(stream->conn);
+                quicly_stats_t stats;
+                quicly_get_stats(stream->conn, &stats);
                 fprintf(stderr,
                         "packets: received: %" PRIu64 ", sent: %" PRIu64 ", lost: %" PRIu64 ", ack-received: %" PRIu64
                         ", bytes-received: %" PRIu64 ", bytes-sent: %" PRIu64 "\n",
-                        stats->num_packets.received, stats->num_packets.sent, stats->num_packets.lost,
-                        stats->num_packets.ack_received, stats->num_bytes.received, stats->num_bytes.sent);
+                        stats.num_packets.received, stats.num_packets.sent, stats.num_packets.lost, stats.num_packets.ack_received,
+                        stats.num_bytes.received, stats.num_bytes.sent);
                 quicly_close(stream->conn, 0, "");
             }
         }
@@ -475,12 +476,13 @@ static void on_signal(int signo)
     size_t i;
     for (i = 0; i != num_conns; ++i) {
         const quicly_cid_plaintext_t *master_id = quicly_get_master_id(conns[i]);
-        quicly_stats_t *stats = quicly_get_stats(conns[i]);
+        quicly_stats_t stats;
+        quicly_get_stats(conns[i], &stats);
         fprintf(stderr,
                 "conn:%08" PRIu32 ": received: %" PRIu64 ", sent: %" PRIu64 ", lost: %" PRIu64 ", ack-received: %" PRIu64
                 ", bytes-received: %" PRIu64 ", bytes-sent: %" PRIu64 "\n",
-                master_id->master_id, stats->num_packets.received, stats->num_packets.sent, stats->num_packets.lost,
-                stats->num_packets.ack_received, stats->num_bytes.received, stats->num_bytes.sent);
+                master_id->master_id, stats.num_packets.received, stats.num_packets.sent, stats.num_packets.lost,
+                stats.num_packets.ack_received, stats.num_bytes.received, stats.num_bytes.sent);
     }
     if (signo == SIGINT)
         _exit(0);


### PR DESCRIPTION
How you add more fields:
* If you want something like a simple counter, add it to `QUICLY_STATS_PREBUILT_FIELDS` and adjust the value in `quicly_connt::stats` (example to look at: `num_packets.received`).
* If you want something else, add a field directly to `quicly_stats_t`, and fill the value within `quicly_get_stats` (example to look at: `rtt`).
