### PR TITLE
Simplify packet-threshold loss detection

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2601,9 +2601,6 @@ static int do_detect_loss(quicly_loss_t *ld, uint64_t largest_acked, uint32_t de
     quicly_conn_t *conn = (void *)((char *)ld - offsetof(quicly_conn_t, egress.loss));
     quicly_sentmap_iter_t iter;
     const quicly_sent_packet_t *sent;
-    int64_t time_threshold = now - delay_until_lost;
-    uint64_t packet_threshold =
-        largest_acked > QUICLY_LOSS_DEFAULT_PACKET_THRESHOLD ? largest_acked - QUICLY_LOSS_DEFAULT_PACKET_THRESHOLD : 0;
     uint64_t largest_newly_lost_pn = UINT64_MAX;
     int ret;
 
@@ -2611,19 +2608,12 @@ static int do_detect_loss(quicly_loss_t *ld, uint64_t largest_acked, uint32_t de
 
     init_acks_iter(conn, &iter);
 
-    /* Mark packets as lost if they are smaller than the largest_acked and
-     * outside either time-threshold or packet-threshold
-     * windows. Packet-threshold detection is only used for 0-RTT and 1-RTT
-     * packets, not for Initial or Handshake packets.
-     *
-     * (Note that this code can incorrectly mark packet number 0 as lost
-     * aggressively based on packet-threshold detection (that is, packet number
-     * 1 or 2 is acked). But since packet 0 will always be an Initial packet and
-     * we disable packet-threshold marking before the handshake is complete,
-     * this is ok.)
+    /* Mark packets as lost if they are smaller than the largest_acked and outside either time-threshold or packet-threshold windows
      */
     while ((sent = quicly_sentmap_get(&iter))->packet_number < largest_acked &&
-           (sent->sent_at <= time_threshold || (sent->ack_epoch == QUICLY_EPOCH_1RTT && sent->packet_number <= packet_threshold))) {
+           (sent->sent_at <= now - delay_until_lost || /* time threshold */
+            (largest_acked >= QUICLY_LOSS_DEFAULT_PACKET_THRESHOLD &&
+             sent->packet_number <= largest_acked - QUICLY_LOSS_DEFAULT_PACKET_THRESHOLD))) { /* packet threshold */
         if (sent->bytes_in_flight != 0 && conn->egress.max_lost_pn <= sent->packet_number) {
             if (sent->packet_number != largest_newly_lost_pn) {
                 ++conn->super.stats.num_packets.lost;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2608,7 +2608,7 @@ static int do_detect_loss(quicly_loss_t *ld, uint64_t largest_acked, uint32_t de
 
     init_acks_iter(conn, &iter);
 
-    /* Mark packets as lost if they are smaller than the largest_acked and outside either time-threshold or packet-threshold windows
+    /* Mark packets as lost if they are smaller than the largest_acked and outside either time-threshold or packet-threshold windows.
      */
     while ((sent = quicly_sentmap_get(&iter))->packet_number < largest_acked &&
            (sent->sent_at <= now - delay_until_lost || /* time threshold */


### PR DESCRIPTION
Removes condition on packet-threshold loss detection that disabled it for packets that were sent in Initial or Handshake packets. It is possible that there's slightly aggressive detection (reducing the threshold by 1) when packets are coalesced across the Handshake/1-RTT boundary, but that is limited enough. On the other hand, disabling packet-threshold might cause later detection of losses when there are > PACKET_THRESHOLD Handshake packets outstanding at the server, and that potential cost is unnecessary.