### PR TITLE
intelligent iovec for streambuf, use that in cli

### DIFF
--- a/include/quicly/streambuf.h
+++ b/include/quicly/streambuf.h
@@ -108,7 +108,7 @@ void quicly_recvbuf_shift(quicly_stream_t *stream, ptls_buffer_t *rb, size_t del
  */
 ptls_iovec_t quicly_recvbuf_get(quicly_stream_t *stream, ptls_buffer_t *rb);
 /**
- * The concrete function for `quily_stream_callbacks_t::on_receive`.
+ * The concrete function for `quicly_stream_callbacks_t::on_receive`.
  */
 int quicly_recvbuf_receive(quicly_stream_t *stream, ptls_buffer_t *rb, size_t off, const void *src, size_t len);
 

--- a/include/quicly/streambuf.h
+++ b/include/quicly/streambuf.h
@@ -75,6 +75,10 @@ int quicly_sendbuf_emit(quicly_stream_t *stream, quicly_sendbuf_t *sb, size_t of
 int quicly_sendbuf_write(quicly_stream_t *stream, quicly_sendbuf_t *sb, const void *src, size_t len);
 int quicly_sendbuf_write_vec(quicly_stream_t *stream, quicly_sendbuf_t *sb, quicly_sendbuf_vec_t *vec);
 
+void quicly_recvbuf_shift(quicly_stream_t *stream, ptls_buffer_t *rb, size_t delta);
+ptls_iovec_t quicly_recvbuf_get(quicly_stream_t *stream, ptls_buffer_t *rb);
+int quicly_recvbuf_receive(quicly_stream_t *stream, ptls_buffer_t *rb, size_t off, const void *src, size_t len);
+
 /**
  * The simple stream buffer.  The API assumes that stream->data points to quicly_streambuf_t.  Applications can extend the structure
  * by passing arbitrary size to `quicly_streambuf_create`.
@@ -91,8 +95,8 @@ int quicly_streambuf_egress_emit(quicly_stream_t *stream, size_t off, void *dst,
 static int quicly_streambuf_egress_write(quicly_stream_t *stream, const void *src, size_t len);
 static int quicly_streambuf_egress_write_vec(quicly_stream_t *stream, quicly_sendbuf_vec_t *vec);
 int quicly_streambuf_egress_shutdown(quicly_stream_t *stream);
-void quicly_streambuf_ingress_shift(quicly_stream_t *stream, size_t delta);
-ptls_iovec_t quicly_streambuf_ingress_get(quicly_stream_t *stream);
+static void quicly_streambuf_ingress_shift(quicly_stream_t *stream, size_t delta);
+static ptls_iovec_t quicly_streambuf_ingress_get(quicly_stream_t *stream);
 int quicly_streambuf_ingress_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len);
 
 /* inline definitions */
@@ -118,6 +122,18 @@ inline int quicly_streambuf_egress_write_vec(quicly_stream_t *stream, quicly_sen
 {
     quicly_streambuf_t *sbuf = stream->data;
     return quicly_sendbuf_write_vec(stream, &sbuf->egress, vec);
+}
+
+inline void quicly_streambuf_ingress_shift(quicly_stream_t *stream, size_t delta)
+{
+    quicly_streambuf_t *sbuf = stream->data;
+    quicly_recvbuf_shift(stream, &sbuf->ingress, delta);
+}
+
+inline ptls_iovec_t quicly_streambuf_ingress_get(quicly_stream_t *stream)
+{
+    quicly_streambuf_t *sbuf = (quicly_streambuf_t *)stream->data;
+    return quicly_recvbuf_get(stream, &sbuf->ingress);
 }
 
 #ifdef __cplusplus

--- a/include/quicly/streambuf.h
+++ b/include/quicly/streambuf.h
@@ -103,7 +103,7 @@ int quicly_sendbuf_write_vec(quicly_stream_t *stream, quicly_sendbuf_t *sb, quic
 void quicly_recvbuf_shift(quicly_stream_t *stream, ptls_buffer_t *rb, size_t delta);
 /**
  * Returns an iovec that refers to the data available in the receive buffer.  Applications are expected to call `quicly_recvbuf_get`
- * to at first peek the received data, process the bytes they can, then call `quicly_recvbuf_shift` to pop the data that have been
+ * to first peek at the received data, process the bytes they can, then call `quicly_recvbuf_shift` to pop the bytes that have been
  * processed.
  */
 ptls_iovec_t quicly_recvbuf_get(quicly_stream_t *stream, ptls_buffer_t *rb);

--- a/include/quicly/streambuf.h
+++ b/include/quicly/streambuf.h
@@ -34,12 +34,22 @@ extern "C" {
 
 typedef struct st_quicly_streambuf_sendvec_t quicly_streambuf_sendvec_t;
 
+/**
+ * Callback that flattens the contents of an iovec.
+ * @param dst the destination
+ * @param off offset within the iovec from where serialization should happen
+ * @param len number of bytes to serialize
+ * @return 0 if successful, otherwise an error code
+ */
 typedef int (*quicly_streambuf_sendvec_flatten_cb)(quicly_streambuf_sendvec_t *vec, void *dst, size_t off, size_t len);
-typedef void (*quicly_streambuf_sendvec_free_cb)(quicly_streambuf_sendvec_t *vec);
+/**
+ * An optional callback that is called when an iovec is discarded
+ */
+typedef void (*quicly_streambuf_sendvec_discard_cb)(quicly_streambuf_sendvec_t *vec);
 
 typedef struct st_quicly_streambuf_sendvec_callbacks_t {
     quicly_streambuf_sendvec_flatten_cb flatten;
-    quicly_streambuf_sendvec_free_cb free_;
+    quicly_streambuf_sendvec_discard_cb discard;
 } quicly_streambuf_sendvec_callbacks_t;
 
 struct st_quicly_streambuf_sendvec_t {

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4134,7 +4134,7 @@ int quicly_receive(quicly_conn_t *conn, quicly_decoded_packet_t *packet)
             quicly_stream_t *stream = quicly_get_stream(conn, -(quicly_stream_id_t)(1 + 2));
             assert(stream != NULL);
             quicly_streambuf_t *buf = stream->data;
-            if (buf->egress.buf.off == 0) {
+            if (buf->egress.vecs.size == 0) {
                 if ((ret = quicly_sentmap_prepare(&conn->egress.sentmap, conn->egress.packet_number, now,
                                                   QUICLY_EPOCH_HANDSHAKE)) != 0)
                     goto Exit;

--- a/src/cli.c
+++ b/src/cli.c
@@ -161,7 +161,7 @@ static int flatten_file_vec(quicly_streambuf_sendvec_t *vec, void *dst, size_t o
     return rret == len ? 0 : QUICLY_TRANSPORT_ERROR_INTERNAL; /* should return application-level error */
 }
 
-static void free_file_vec(quicly_streambuf_sendvec_t *vec)
+static void discard_file_vec(quicly_streambuf_sendvec_t *vec)
 {
     int fd = (int)vec->cbdata;
     close(fd);
@@ -169,7 +169,7 @@ static void free_file_vec(quicly_streambuf_sendvec_t *vec)
 
 static int send_file(quicly_stream_t *stream, int is_http1, const char *fn, const char *mime_type)
 {
-    static const quicly_streambuf_sendvec_callbacks_t send_file_callbacks = {flatten_file_vec, free_file_vec};
+    static const quicly_streambuf_sendvec_callbacks_t send_file_callbacks = {flatten_file_vec, discard_file_vec};
     int fd;
     struct stat st;
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -206,8 +206,9 @@ static int flatten_sized_text(quicly_sendbuf_vec_t *vec, void *dst, size_t off, 
         "world\nhello world\nhello world\nhello world\nhello world\nhello world\nhello world\nhello world\nhello world\nhello "
         "world\nhello world\nhello world\nhello world\nhello world\nhello world\n";
 
-    assert(len < sizeof(pattern) - 13); /* pattern is bigger than MTU size */
-    memcpy(dst, pattern + off % 12, len);
+    const char *src = pattern + off % 12;
+    assert(src + len - pattern <= sizeof(pattern) - 1); /* pattern is bigger than MTU size */
+    memcpy(dst, src, len);
     return 0;
 
 #undef PATTERN

--- a/src/cli.c
+++ b/src/cli.c
@@ -186,6 +186,10 @@ static int send_file(quicly_stream_t *stream, int is_http1, const char *fn, cons
     return 1;
 }
 
+/**
+ * This function is an implementation of the quicly_sendbuf_flatten_vec_cb callback.  Refer to the doc-comments of the callback type
+ * for the API.
+ */
 static int flatten_sized_text(quicly_sendbuf_vec_t *vec, void *dst, size_t off, size_t len)
 {
     static const char pattern[] =

--- a/t/simple.c
+++ b/t/simple.c
@@ -518,7 +518,7 @@ static void tiny_connection_window(void)
     quic_now += QUICLY_DELAYED_ACK_TIMEOUT;
     transmit(server, client);
 
-    ok(client_streambuf->super.egress.buf.off == 0);
+    ok(client_streambuf->super.egress.vecs.size == 0);
 
     quic_ctx.transport_params.max_data = max_data_orig;
 }


### PR DESCRIPTION
The PR ports "intelligent iovec" to quicly, a concept that we have in the H3 branch of H2O.

Intelligent iovec is an iovec-like structure that holds a fixed length of bytes, either being pre-flattened (just like an ordinary iovec) or flattened upon request.

The flatten-upon-request API helps reduce the memory footprint, because flattening can be delayed until the first moment the data is to be serialized as a packet payload, _or ultimately, flattened every time packets are being built_. In case of the latter, stream-level send buffer ceases to exist.

The PR changes the cli command to use the latter approach when responding with a file or a sized text (i.e. /NNN.txt).

We expect speed-up when serving sized text (see #88, #149).

We might see some slowdown when serving files (like ~20% depending on the architecture due to the command now calling pread(2) for every STREAM frame being sent). However I do not think that would be a blocker for this PR considering the fact that file serving is not a good metric for benchmarking a QUIC stack, and that we know we can optimize (e.g., by doing some read-ahead).

Closes #88, #149.