### PR TITLE
refactor scheduler

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -765,7 +765,11 @@ static int quicly_is_client(quicly_conn_t *conn);
 /**
  *
  */
-static quicly_stream_id_t quicly_get_next_stream_id(quicly_conn_t *conn, int uni);
+static quicly_stream_id_t quicly_get_host_next_stream_id(quicly_conn_t *conn, int uni);
+/**
+ *
+ */
+static quicly_stream_id_t quicly_get_peer_next_stream_id(quicly_conn_t *conn, int uni);
 /**
  *
  */
@@ -981,10 +985,16 @@ inline int quicly_is_client(quicly_conn_t *conn)
     return (c->host.bidi.next_stream_id & 1) == 0;
 }
 
-inline quicly_stream_id_t quicly_get_next_stream_id(quicly_conn_t *conn, int uni)
+inline quicly_stream_id_t quicly_get_host_next_stream_id(quicly_conn_t *conn, int uni)
 {
     struct _st_quicly_conn_public_t *c = (struct _st_quicly_conn_public_t *)conn;
     return uni ? c->host.uni.next_stream_id : c->host.bidi.next_stream_id;
+}
+
+inline quicly_stream_id_t quicly_get_peer_next_stream_id(quicly_conn_t *conn, int uni)
+{
+    struct _st_quicly_conn_public_t *c = (struct _st_quicly_conn_public_t *)conn;
+    return uni ? c->peer.uni.next_stream_id : c->peer.bidi.next_stream_id;
 }
 
 inline void quicly_get_peername(quicly_conn_t *conn, struct sockaddr **sa, socklen_t *salen)

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -467,17 +467,14 @@ typedef struct st_quicly_stats_t {
 /**
  * The state of the default stream scheduler.
  * `active` is a linked-list of streams for which STREAM frames can be emitted.  `blocked` is a linked-list of streams that have
- * something to be sent but are currently blocked by the connection-level flow control.  `in_saturated_mode` is a boolean flag
- * that indicates if *all* the blocked connections have been moved to `blocked`.
+ * something to be sent but are currently blocked by the connection-level flow control.
  * When the `can_send` callback of the default stream scheduler is invoked with the `conn_is_saturated` flag set, connections that
- * are blocked are eventually moved to the `blocked` list.  The `in_saturated_mode` flag is set once the move completes.
- * When the callback is invoked without the flag being set, all the connections in the `blocked` list is moved to the `active` list
- * and the `in_saturated_mode` is cleared.
+ * are blocked are eventually moved to the `blocked` list. When the callback is invoked without the flag being set, all the
+ * connections in the `blocked` list is moved to the `active` list and the `in_saturated_mode` is cleared.
  */
 struct st_quicly_default_scheduler_state_t {
     quicly_linklist_t active;
     quicly_linklist_t blocked;
-    int in_saturated_mode;
 };
 
 struct _st_quicly_conn_public_t {

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -249,18 +249,9 @@ typedef struct st_quicly_stream_scheduler_t {
      */
     int (*do_send)(struct st_quicly_stream_scheduler_t *sched, quicly_conn_t *conn, quicly_send_context_t *s);
     /**
-     * Called by quicly to unregister a stream from the scheduler when there's nothing to be sent immediately on that stream.
+     *
      */
-    void (*clear)(struct st_quicly_stream_scheduler_t *sched, quicly_stream_t *stream);
-    /**
-     * Called by quicly to notify the scheduler that the stream has new data to be sent.
-     */
-    void (*set_new_data)(struct st_quicly_stream_scheduler_t *sched, quicly_stream_t *stream);
-    /**
-     * Called by quicly to notify the scheduler that the stream has something other than new data to be sent (i.e. retransmits or
-     * FIN-only).
-     */
-    void (*set_non_new_data)(struct st_quicly_stream_scheduler_t *sched, quicly_stream_t *stream);
+    int (*update_state)(struct st_quicly_stream_scheduler_t *sched, quicly_stream_t *stream);
 } quicly_stream_scheduler_t;
 
 /**
@@ -474,6 +465,22 @@ typedef struct st_quicly_stats_t {
     quicly_rtt_t rtt;
 } quicly_stats_t;
 
+struct st_quicly_default_scheduler_state_t {
+    /**
+     * Linked-list of streams for which STREAM frames can be emitted.  When `in_blocked_mode` is true, only contains streams can be
+     * sent when connection-level send window is zero.  Otherwise, contains all the streams that can make progress.
+     */
+    quicly_linklist_t active;
+    /**
+     * When `in_block_mode` is true, contains list of streams that are currently blocked by the connection-level flow control.
+     */
+    quicly_linklist_t blocked;
+    /**
+     * A boolean indicating the mode of the default scheduler.
+     */
+    int in_blocked_mode;
+};
+
 struct _st_quicly_conn_public_t {
     quicly_context_t *ctx;
     quicly_state_t state;
@@ -515,10 +522,7 @@ struct _st_quicly_conn_public_t {
             unsigned send_probe : 1;
         } address_validation;
     } peer;
-    struct {
-        quicly_linklist_t new_data;
-        quicly_linklist_t non_new_data;
-    } _default_scheduler;
+    struct st_quicly_default_scheduler_state_t _default_scheduler;
     struct {
         QUICLY_STATS_PREBUILT_FIELDS;
     } stats;
@@ -797,12 +801,17 @@ int quicly_close(quicly_conn_t *conn, int err, const char *reason_phrase);
  */
 int64_t quicly_get_first_timeout(quicly_conn_t *conn);
 /**
- * checks if quicly_send_stream can be invoked
+ * returns if the connection is currently capped by connection-level flow control.
  */
-int quicly_can_send_stream_data(quicly_conn_t *conn, quicly_send_context_t *s, int new_data);
+int quicly_is_flow_capped(quicly_conn_t *conn);
 /**
- * sends data of given stream. Called by stream scheduler.  Prior to calling the function each time, the scheduler should call
- * `quicly_can_send_stream_data` to see if stream-level data can be sent.
+ * checks if quicly_send_stream can be invoked
+ * @return a boolean indicating if quicly_send_stream can be called immediately
+ */
+int quicly_can_send_stream_data(quicly_conn_t *conn, quicly_send_context_t *s);
+/**
+ * Sends data of given stream.  Called by stream scheduler.  Only streams that can send some data or EOS should be specified.  It is
+ * the responsibilty of the stream scheduler to maintain a list of such streams.
  */
 int quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t *s);
 /**

--- a/include/quicly/sendstate.h
+++ b/include/quicly/sendstate.h
@@ -59,6 +59,12 @@ void quicly_sendstate_init_closed(quicly_sendstate_t *state);
 void quicly_sendstate_dispose(quicly_sendstate_t *state);
 static int quicly_sendstate_transfer_complete(quicly_sendstate_t *state);
 static int quicly_sendstate_is_open(quicly_sendstate_t *state);
+/**
+ * Returns if some data or EOS can be sent for the stream.  When `max_stream_data` is non-NULL, stream-level flow control is tested.
+ * When `max_stream_data` is NULL, retruns if something can be sent when the connection is capped by the connection-level flow
+ * control.
+ */
+int quicly_sendstate_can_send(quicly_sendstate_t *state, const uint64_t *max_stream_data);
 int quicly_sendstate_activate(quicly_sendstate_t *state);
 int quicly_sendstate_shutdown(quicly_sendstate_t *state, uint64_t final_size);
 void quicly_sendstate_reset(quicly_sendstate_t *state);

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -240,76 +240,88 @@ void quicly_free_default_cid_encryptor(quicly_cid_encryptor_t *_self)
     free(self);
 }
 
-static int default_stream_scheduler_can_send(quicly_stream_scheduler_t *self, quicly_conn_t *_conn, int new_data_allowed)
+static int default_stream_scheduler_can_send(quicly_stream_scheduler_t *self, quicly_conn_t *conn, int new_data_allowed)
 {
-    struct _st_quicly_conn_public_t *conn = (struct _st_quicly_conn_public_t *)_conn;
+    struct st_quicly_default_scheduler_state_t *sched = &((struct _st_quicly_conn_public_t *)conn)->_default_scheduler;
+
     if (new_data_allowed) {
-        if (quicly_linklist_is_linked(&conn->_default_scheduler.new_data))
-            return 1;
+        /* Connection NOT capped by connection-level flow control.  Merge the blocked list to the active list. */
+        quicly_linklist_insert_list(&sched->active, &sched->blocked);
+        sched->in_blocked_mode = 0;
+    } else if (!sched->in_blocked_mode) {
+        /* Connection capped by connection-level flow control and the "active" list might contain streams that cannot make progess
+         * under such condition.  Lazily move such streams to the "blocked" list, at the same time checking if anything can be sent.
+         */
+        quicly_linklist_t *l = sched->active.next;
+        while (l != &sched->active) {
+            quicly_stream_t *stream = (void *)((char *)(l - offsetof(quicly_stream_t, _send_aux.pending_link.default_scheduler)));
+            if (quicly_sendstate_can_send(&stream->sendstate, NULL))
+                return 1;
+            l = stream->_send_aux.pending_link.default_scheduler.next;
+            quicly_linklist_unlink(&stream->_send_aux.pending_link.default_scheduler);
+            quicly_linklist_insert(sched->blocked.prev, &stream->_send_aux.pending_link.default_scheduler);
+        }
+        sched->in_blocked_mode = 1;
     }
-    if (quicly_linklist_is_linked(&conn->_default_scheduler.non_new_data))
-        return 1;
+
+    return quicly_linklist_is_linked(&sched->active);
+}
+
+static int default_stream_scheduler_do_send(quicly_stream_scheduler_t *self, quicly_conn_t *conn, quicly_send_context_t *s)
+{
+    struct st_quicly_default_scheduler_state_t *sched = &((struct _st_quicly_conn_public_t *)conn)->_default_scheduler;
+    int conn_is_flow_capped = quicly_is_flow_capped(conn), ret = 0;
+
+    while (quicly_can_send_stream_data((quicly_conn_t *)conn, s) && quicly_linklist_is_linked(&sched->active)) {
+        /* detach the first active stream */
+        quicly_stream_t *stream =
+            (void *)((char *)sched->active.next - offsetof(quicly_stream_t, _send_aux.pending_link.default_scheduler));
+        quicly_linklist_unlink(&stream->_send_aux.pending_link.default_scheduler);
+        /* relink the stream to the blocked list if necessary */
+        if (conn_is_flow_capped && !quicly_sendstate_can_send(&stream->sendstate, NULL)) {
+            quicly_linklist_insert(sched->blocked.prev, &stream->_send_aux.pending_link.default_scheduler);
+            continue;
+        }
+        /* send! */
+        if ((ret = quicly_send_stream(stream, s)) != 0)
+            break;
+        /* reschedule */
+        conn_is_flow_capped = quicly_is_flow_capped(conn);
+        if (quicly_sendstate_can_send(&stream->sendstate, &stream->_send_aux.max_stream_data)) {
+            if (!conn_is_flow_capped || quicly_sendstate_can_send(&stream->sendstate, NULL)) {
+                quicly_linklist_insert(&sched->active, &stream->_send_aux.pending_link.default_scheduler);
+            } else {
+                quicly_linklist_insert(&sched->blocked, &stream->_send_aux.pending_link.default_scheduler);
+            }
+        }
+    }
+
+    return ret;
+}
+
+static int default_stream_scheduler_update_state(quicly_stream_scheduler_t *self, quicly_stream_t *stream)
+{
+    struct st_quicly_default_scheduler_state_t *sched = &((struct _st_quicly_conn_public_t *)stream->conn)->_default_scheduler;
+
+    if (quicly_sendstate_can_send(&stream->sendstate, &stream->_send_aux.max_stream_data)) {
+        /* activate if not */
+        if (!quicly_linklist_is_linked(&stream->_send_aux.pending_link.default_scheduler)) {
+            quicly_linklist_t *slot = &sched->active;
+            if (quicly_is_flow_capped(stream->conn) && !quicly_sendstate_can_send(&stream->sendstate, NULL))
+                slot = &sched->blocked;
+            quicly_linklist_insert(slot->prev, &stream->_send_aux.pending_link.default_scheduler);
+        }
+    } else {
+        /* disactivate if active */
+        if (quicly_linklist_is_linked(&stream->_send_aux.pending_link.default_scheduler))
+            quicly_linklist_unlink(&stream->_send_aux.pending_link.default_scheduler);
+    }
+
     return 0;
 }
 
-static int default_stream_scheduler_do_send(quicly_stream_scheduler_t *self, quicly_conn_t *_conn, quicly_send_context_t *s)
-{
-#define SEND_ONE(anchor)                                                                                                           \
-    do {                                                                                                                           \
-        quicly_stream_t *stream =                                                                                                  \
-            (void *)((char *)(anchor)->next - offsetof(quicly_stream_t, _send_aux.pending_link.default_scheduler));                \
-        if ((ret = quicly_send_stream(stream, s)) != 0)                                                                            \
-            goto Exit;                                                                                                             \
-    } while (0)
-
-    struct _st_quicly_conn_public_t *conn = (struct _st_quicly_conn_public_t *)_conn;
-    int ret = 0;
-
-    /* retransmits and fin-only STREAM frames */
-    while (quicly_can_send_stream_data((quicly_conn_t *)conn, s, 0) &&
-           quicly_linklist_is_linked(&conn->_default_scheduler.non_new_data))
-        SEND_ONE(&conn->_default_scheduler.non_new_data);
-    /* STREAMS with data */
-    while (quicly_can_send_stream_data((quicly_conn_t *)conn, s, 1) &&
-           quicly_linklist_is_linked(&conn->_default_scheduler.new_data)) {
-        SEND_ONE(&conn->_default_scheduler.new_data);
-    }
-
-Exit:
-    return ret;
-
-#undef SEND_ONE
-}
-
-static void default_stream_scheduler_clear(quicly_stream_scheduler_t *self, quicly_stream_t *stream)
-{
-    quicly_linklist_unlink(&stream->_send_aux.pending_link.default_scheduler);
-}
-
-static void schedule_to_slot(quicly_linklist_t *slot, quicly_stream_t *stream)
-{
-    /* TODO Add logic that refrains from re-registering the object to the same slot. Otherwise, arrival of additional data moves a
-     * stream that is already in the send list to the end of the list */
-    if (quicly_linklist_is_linked(&stream->_send_aux.pending_link.default_scheduler))
-        quicly_linklist_unlink(&stream->_send_aux.pending_link.default_scheduler);
-    quicly_linklist_insert(slot->prev, &stream->_send_aux.pending_link.default_scheduler);
-}
-
-static void default_stream_scheduler_set_new_data(quicly_stream_scheduler_t *self, quicly_stream_t *stream)
-{
-    struct _st_quicly_conn_public_t *conn = (struct _st_quicly_conn_public_t *)stream->conn;
-    schedule_to_slot(&conn->_default_scheduler.new_data, stream);
-}
-
-static void default_stream_scheduler_set_non_new_data(quicly_stream_scheduler_t *self, quicly_stream_t *stream)
-{
-    struct _st_quicly_conn_public_t *conn = (struct _st_quicly_conn_public_t *)stream->conn;
-    schedule_to_slot(&conn->_default_scheduler.non_new_data, stream);
-}
-
 quicly_stream_scheduler_t quicly_default_stream_scheduler = {default_stream_scheduler_can_send, default_stream_scheduler_do_send,
-                                                             default_stream_scheduler_clear, default_stream_scheduler_set_new_data,
-                                                             default_stream_scheduler_set_non_new_data};
+                                                             default_stream_scheduler_update_state};
 
 quicly_stream_t *quicly_default_alloc_stream(quicly_context_t *ctx)
 {


### PR DESCRIPTION
* Let the scheduler "pull" the states to determine how a stream should be scheduled.
  * instead of pushing the states from quicly
* Use one linked-list (`st_quicly_default_stream_scheduler_state_t::active`) for scheduling along with a backup linked-list for holding `blocked` streams.
  * The design is a simplification - for H2O implementing a custom scheduler, it's expensive and meaningless to retain two different priority trees, one for blocked streams and one for the other. The downside is that scheduling would become incorrect during transition to / from "connection saturated" state (meaning when STREAM frames carrying additional data cannot be sent to connection-level flow control), but that should be fine, assuming that we would not see the case under normal circumstances.

To be accompanied by a PR to H2O that actually uses the API refactored by this PR.