### PR TITLE
fix GCC 4.8.2 (Ubuntu 14.04) compatibility

### DIFF
--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -53,20 +53,20 @@ typedef struct quicly_loss_conf_t {
 #define QUICLY_LOSS_DEFAULT_TIME_REORDERING_PERCENTILE (1024 / 8)
 
 #define QUICLY_LOSS_SPEC_CONF                                                                                                      \
-    ((quicly_loss_conf_t){                                                                                                         \
+    {                                                                                                                              \
         QUICLY_LOSS_DEFAULT_TIME_REORDERING_PERCENTILE, /* time_reordering_percentile */                                           \
         QUICLY_DEFAULT_MIN_PTO,                         /* min_pto */                                                              \
         QUICLY_DEFAULT_INITIAL_RTT,                     /* initial_rtt */                                                          \
         0                                               /* number of speculative PTOs */                                           \
-    })
+    }
 
 #define QUICLY_LOSS_PERFORMANT_CONF                                                                                                \
-    ((quicly_loss_conf_t){                                                                                                         \
+    {                                                                                                                              \
         QUICLY_LOSS_DEFAULT_TIME_REORDERING_PERCENTILE, /* time_reordering_percentile */                                           \
         QUICLY_DEFAULT_MIN_PTO,                         /* min_pto */                                                              \
         QUICLY_DEFAULT_INITIAL_RTT,                     /* initial_rtt */                                                          \
         2                                               /* number of speculative PTOs */                                           \
-    })
+    }
 
 typedef struct quicly_rtt_t {
     uint32_t minimum;

--- a/t/loss.c
+++ b/t/loss.c
@@ -238,7 +238,7 @@ static void test_even(void)
     ok(quicly_get_state(client) == QUICLY_STATE_CONNECTED);
     ok(quicly_connection_is_ready(client));
 
-    quic_ctx.loss = QUICLY_LOSS_SPEC_CONF;
+    quic_ctx.loss = (quicly_loss_conf_t)QUICLY_LOSS_SPEC_CONF;
 }
 
 struct loss_cond_t loss_cond_down, loss_cond_up;


### PR DESCRIPTION
GCC 4.8.2 does not consider `(type){...}` a constant expression, and I assume that's per spec.