### PR TITLE
Discard ACK ranges that we can't consume in one go

### DIFF
--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -62,7 +62,7 @@ extern "C" {
 #define QUICLY_FRAME_TYPE_STREAM_BIT_LEN 0x2
 #define QUICLY_FRAME_TYPE_STREAM_BIT_FIN 0x1
 
-#define QUICLY_MAX_ACK_FRAME_RANGE 256
+#define QUICLY_MAX_ACK_RANGE_COUNT 256
 #define QUICLY_MAX_DATA_FRAME_CAPACITY (1 + 8)
 #define QUICLY_MAX_STREAM_DATA_FRAME_CAPACITY (1 + 8 + 8)
 #define QUICLY_MAX_STREAMS_FRAME_CAPACITY (1 + 8)
@@ -207,8 +207,8 @@ typedef struct st_quicly_ack_frame_t {
     uint64_t smallest_acknowledged;
     uint64_t ack_delay;
     uint64_t num_gaps;
-    uint64_t ack_block_lengths[257];
-    uint64_t gaps[QUICLY_MAX_ACK_FRAME_RANGE];
+    uint64_t ack_block_lengths[QUICLY_MAX_ACK_RANGE_COUNT + 1];
+    uint64_t gaps[QUICLY_MAX_ACK_RANGE_COUNT];
 } quicly_ack_frame_t;
 
 int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_frame_t *frame, int is_ack_ecn);

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -62,7 +62,6 @@ extern "C" {
 #define QUICLY_FRAME_TYPE_STREAM_BIT_LEN 0x2
 #define QUICLY_FRAME_TYPE_STREAM_BIT_FIN 0x1
 
-#define QUICLY_MAX_ACK_RANGE_COUNT 256
 #define QUICLY_MAX_DATA_FRAME_CAPACITY (1 + 8)
 #define QUICLY_MAX_STREAM_DATA_FRAME_CAPACITY (1 + 8 + 8)
 #define QUICLY_MAX_STREAMS_FRAME_CAPACITY (1 + 8)
@@ -70,6 +69,7 @@ extern "C" {
 #define QUICLY_RST_FRAME_CAPACITY (1 + 8 + 2 + 8)
 #define QUICLY_STREAMS_BLOCKED_FRAME_CAPACITY (1 + 8)
 #define QUICLY_STOP_SENDING_FRAME_CAPACITY (1 + 8 + 2)
+#define QUICLY_ACK_MAX_GAPS 256
 #define QUICLY_ACK_FRAME_CAPACITY (1 + 8 + 8 + 1 + 8)
 #define QUICLY_PATH_CHALLENGE_FRAME_CAPACITY (1 + 8)
 #define QUICLY_STREAM_FRAME_CAPACITY (1 + 8 + 8 + 1)
@@ -207,8 +207,8 @@ typedef struct st_quicly_ack_frame_t {
     uint64_t smallest_acknowledged;
     uint64_t ack_delay;
     uint64_t num_gaps;
-    uint64_t ack_block_lengths[QUICLY_MAX_ACK_RANGE_COUNT + 1];
-    uint64_t gaps[QUICLY_MAX_ACK_RANGE_COUNT];
+    uint64_t ack_block_lengths[QUICLY_ACK_MAX_GAPS + 1];
+    uint64_t gaps[QUICLY_ACK_MAX_GAPS];
 } quicly_ack_frame_t;
 
 int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_frame_t *frame, int is_ack_ecn);

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -62,6 +62,7 @@ extern "C" {
 #define QUICLY_FRAME_TYPE_STREAM_BIT_LEN 0x2
 #define QUICLY_FRAME_TYPE_STREAM_BIT_FIN 0x1
 
+#define QUICLY_MAX_ACK_FRAME_RANGE 256
 #define QUICLY_MAX_DATA_FRAME_CAPACITY (1 + 8)
 #define QUICLY_MAX_STREAM_DATA_FRAME_CAPACITY (1 + 8 + 8)
 #define QUICLY_MAX_STREAMS_FRAME_CAPACITY (1 + 8)
@@ -207,7 +208,7 @@ typedef struct st_quicly_ack_frame_t {
     uint64_t ack_delay;
     uint64_t num_gaps;
     uint64_t ack_block_lengths[257];
-    uint64_t gaps[256];
+    uint64_t gaps[QUICLY_MAX_ACK_FRAME_RANGE];
 } quicly_ack_frame_t;
 
 int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_frame_t *frame, int is_ack_ecn);

--- a/lib/frame.c
+++ b/lib/frame.c
@@ -81,8 +81,8 @@ int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_
     frame->smallest_acknowledged = frame->largest_acknowledged - tmp;
     frame->ack_block_lengths[0] = tmp + 1;
 
-    if (frame->num_gaps > QUICLY_MAX_ACK_FRAME_RANGE)
-        frame->num_gaps = QUICLY_MAX_ACK_FRAME_RANGE;
+    if (frame->num_gaps > QUICLY_MAX_ACK_RANGE_COUNT)
+        frame->num_gaps = QUICLY_MAX_ACK_RANGE_COUNT;
 
     for (i = 0; i != frame->num_gaps; ++i) {
         if ((tmp = quicly_decodev(src, end)) == UINT64_MAX)

--- a/lib/frame.c
+++ b/lib/frame.c
@@ -93,10 +93,11 @@ int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_
         tmp += 1;
         if (frame->smallest_acknowledged < tmp)
             goto Error;
-        frame->ack_block_lengths[i + 1] = tmp;
-        frame->smallest_acknowledged -= tmp;
-        if (i < QUICLY_MAX_ACK_RANGE_COUNT)
+        if (i < QUICLY_MAX_ACK_RANGE_COUNT) {
+            frame->ack_block_lengths[i + 1] = tmp;
+            frame->smallest_acknowledged -= tmp;
             frame->gaps[i] = curr_gap;
+        }
     }
 
     if (is_ack_ecn) {

--- a/lib/frame.c
+++ b/lib/frame.c
@@ -71,7 +71,8 @@ int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_
         goto Error;
     if ((frame->ack_delay = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
-    if ((frame->num_gaps = quicly_decodev(src, end)) == UINT64_MAX)
+    if ((frame->num_gaps = quicly_decodev(src, end)) == UINT64_MAX ||
+        frame->num_gaps > sizeof(frame->gaps) / sizeof(frame->gaps[0]))
         goto Error;
 
     if ((tmp = quicly_decodev(src, end)) == UINT64_MAX)

--- a/lib/frame.c
+++ b/lib/frame.c
@@ -73,8 +73,8 @@ int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_
         goto Error;
     if ((frame->num_gaps = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
-    if (frame->num_gaps > QUICLY_MAX_ACK_RANGE_COUNT)
-        frame->num_gaps = QUICLY_MAX_ACK_RANGE_COUNT;
+    if (frame->num_gaps > QUICLY_ACK_MAX_GAPS)
+        frame->num_gaps = QUICLY_ACK_MAX_GAPS;
 
     if ((tmp = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
@@ -95,7 +95,7 @@ int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_
         tmp += 1;
         if (frame->smallest_acknowledged < tmp)
             goto Error;
-        if (i < QUICLY_MAX_ACK_RANGE_COUNT) {
+        if (i < QUICLY_ACK_MAX_GAPS) {
             frame->ack_block_lengths[i + 1] = tmp;
             frame->smallest_acknowledged -= tmp;
             frame->gaps[i] = curr_gap;

--- a/lib/frame.c
+++ b/lib/frame.c
@@ -73,6 +73,8 @@ int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_
         goto Error;
     if ((frame->num_gaps = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
+    if (frame->num_gaps > QUICLY_MAX_ACK_RANGE_COUNT)
+        frame->num_gaps = QUICLY_MAX_ACK_RANGE_COUNT;
 
     if ((tmp = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;

--- a/lib/frame.c
+++ b/lib/frame.c
@@ -65,45 +65,37 @@ uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t
 
 int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_frame_t *frame, int is_ack_ecn)
 {
-    uint64_t i, tmp, curr_gap;
+    uint64_t i, num_gaps, gap, ack_range;
 
     if ((frame->largest_acknowledged = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
     if ((frame->ack_delay = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
-    if ((frame->num_gaps = quicly_decodev(src, end)) == UINT64_MAX)
+    if ((num_gaps = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
 
-    if ((tmp = quicly_decodev(src, end)) == UINT64_MAX)
+    if ((ack_range = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
-    if (frame->largest_acknowledged < tmp)
+    if (frame->largest_acknowledged < ack_range)
         goto Error;
-    frame->smallest_acknowledged = frame->largest_acknowledged - tmp;
-    frame->ack_block_lengths[0] = tmp + 1;
+    frame->smallest_acknowledged = frame->largest_acknowledged - ack_range;
+    frame->ack_block_lengths[0] = ack_range + 1;
+    frame->num_gaps = 0;
 
-    for (i = 0; i != frame->num_gaps; ++i) {
-        if ((tmp = quicly_decodev(src, end)) == UINT64_MAX)
+    for (i = 0; i != num_gaps; ++i) {
+        if ((gap = quicly_decodev(src, end)) == UINT64_MAX)
             goto Error;
-        curr_gap = tmp + 1;
-        if (frame->smallest_acknowledged < curr_gap)
+        if ((ack_range = quicly_decodev(src, end)) == UINT64_MAX)
             goto Error;
-        if ((tmp = quicly_decodev(src, end)) == UINT64_MAX)
-            goto Error;
-        tmp += 1;
         if (i < QUICLY_ACK_MAX_GAPS) {
-            frame->smallest_acknowledged -= curr_gap;
-            if (frame->smallest_acknowledged < tmp)
+            if (frame->smallest_acknowledged < gap + ack_range + 2)
                 goto Error;
-            frame->ack_block_lengths[i + 1] = tmp;
-            frame->smallest_acknowledged -= tmp;
-            frame->gaps[i] = curr_gap;
+            frame->gaps[i] = gap + 1;
+            frame->ack_block_lengths[i + 1] = ack_range + 1;
+            frame->smallest_acknowledged -= gap + ack_range + 2;
+            ++frame->num_gaps;
         }
     }
-
-    /* the entire ACK-Ranges section was decoded, but ranges beyond
-       QUICLY_ACK_MAX_GAPS are skipped. therefore calibrate the value. */
-    if (frame->num_gaps > QUICLY_ACK_MAX_GAPS)
-        frame->num_gaps = QUICLY_ACK_MAX_GAPS;
 
     if (is_ack_ecn) {
         /* just skip ECT(0), ECT(1), ECT-CE counters for the time being */

--- a/lib/frame.c
+++ b/lib/frame.c
@@ -71,8 +71,7 @@ int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_
         goto Error;
     if ((frame->ack_delay = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
-    if ((frame->num_gaps = quicly_decodev(src, end)) == UINT64_MAX ||
-        frame->num_gaps > sizeof(frame->gaps) / sizeof(frame->gaps[0]))
+    if ((frame->num_gaps = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
 
     if ((tmp = quicly_decodev(src, end)) == UINT64_MAX)
@@ -81,6 +80,9 @@ int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_
         goto Error;
     frame->smallest_acknowledged = frame->largest_acknowledged - tmp;
     frame->ack_block_lengths[0] = tmp + 1;
+
+    if (frame->num_gaps > QUICLY_MAX_ACK_FRAME_RANGE)
+        frame->num_gaps = QUICLY_MAX_ACK_FRAME_RANGE;
 
     for (i = 0; i != frame->num_gaps; ++i) {
         if ((tmp = quicly_decodev(src, end)) == UINT64_MAX)

--- a/t/frame.c
+++ b/t/frame.c
@@ -94,26 +94,27 @@ static void test_ack_decode(void)
         const uint8_t *src = pat;
         int i, range_sum;
         quicly_ack_frame_t decoded;
-        pos = quicly_encodev(pos, 0x84D0);
+        pos = quicly_encodev(pos, 0xFA00);
         pos = quicly_encodev(pos, 0);
         pos = quicly_encodev(pos, QUICLY_ACK_MAX_GAPS + 1);
         pos = quicly_encodev(pos, 8);
         for (i = 0; i <= QUICLY_ACK_MAX_GAPS ; ++i) {
             pos = quicly_encodev(pos, i); // gap
-            pos = quicly_encodev(pos, 1); // ack-range
+            pos = quicly_encodev(pos, i % 10); // ack-range
         }
+
         ok(quicly_decode_ack_frame(&src, pos, &decoded, 0) == 0);
-        ok(decoded.largest_acknowledged == 0x84D0);
+        ok(decoded.largest_acknowledged == 0xFA00);
         ok(decoded.ack_delay == 0);
         ok(decoded.num_gaps == QUICLY_ACK_MAX_GAPS);
         ok(decoded.ack_block_lengths[0] == 8 + 1); // first ack-range
         range_sum = decoded.ack_block_lengths[0];
         for (i = 0; i < QUICLY_ACK_MAX_GAPS; ++i) {
             ok(decoded.gaps[i] == i + 1);
-            ok(decoded.ack_block_lengths[i + 1] == 1 + 1);
+            ok(decoded.ack_block_lengths[i + 1] == (i % 10) + 1);
             range_sum += decoded.gaps[i] + decoded.ack_block_lengths[i + 1];
         }
-        ok(decoded.smallest_acknowledged == 0x84D0 - range_sum + 1);
+        ok(decoded.smallest_acknowledged == 0xFA00 - range_sum + 1);
     }
 
     subtest("underflow", test_ack_decode_underflow);

--- a/t/frame.c
+++ b/t/frame.c
@@ -90,20 +90,20 @@ static void test_ack_decode(void)
     }
 
     { /* Bogus ACK Frame larger than the internal buffer */
-        uint8_t pat[1024], *pos = pat;
+        uint8_t pat[1024], *end = pat;
         const uint8_t *src = pat;
         int i, range_sum;
         quicly_ack_frame_t decoded;
-        pos = quicly_encodev(pos, 0xFA00);
-        pos = quicly_encodev(pos, 0);
-        pos = quicly_encodev(pos, QUICLY_ACK_MAX_GAPS + 1);
-        pos = quicly_encodev(pos, 8);
+        end = quicly_encodev(end, 0xFA00);
+        end = quicly_encodev(end, 0);
+        end = quicly_encodev(end, QUICLY_ACK_MAX_GAPS + 1);
+        end = quicly_encodev(end, 8);
         for (i = 0; i < QUICLY_ACK_MAX_GAPS + 30; ++i) {
-            pos = quicly_encodev(pos, i); // gap
-            pos = quicly_encodev(pos, i % 10); // ack-range
+            end = quicly_encodev(end, i); // gap
+            end = quicly_encodev(end, i % 10); // ack-range
         }
 
-        ok(quicly_decode_ack_frame(&src, pos, &decoded, 0) == 0);
+        ok(quicly_decode_ack_frame(&src, end, &decoded, 0) == 0);
         ok(decoded.largest_acknowledged == 0xFA00);
         ok(decoded.ack_delay == 0);
         ok(decoded.num_gaps == QUICLY_ACK_MAX_GAPS);
@@ -114,7 +114,7 @@ static void test_ack_decode(void)
             ok(decoded.ack_block_lengths[i + 1] == (i % 10) + 1);
             range_sum += decoded.gaps[i] + decoded.ack_block_lengths[i + 1];
         }
-        ok(src == pos); // decoded the entire frame
+        ok(src == end); // decoded the entire frame
         ok(decoded.smallest_acknowledged == 0xFA00 - range_sum + 1);
     }
 

--- a/t/frame.c
+++ b/t/frame.c
@@ -96,7 +96,7 @@ static void test_ack_decode(void)
         quicly_ack_frame_t decoded;
         end = quicly_encodev(end, 0xFA00);
         end = quicly_encodev(end, 0);
-        end = quicly_encodev(end, QUICLY_ACK_MAX_GAPS + 1);
+        end = quicly_encodev(end, QUICLY_ACK_MAX_GAPS + 30); // with excess ranges
         end = quicly_encodev(end, 8);
         for (i = 0; i < QUICLY_ACK_MAX_GAPS + 30; ++i) {
             end = quicly_encodev(end, i); // gap

--- a/t/frame.c
+++ b/t/frame.c
@@ -90,7 +90,7 @@ static void test_ack_decode(void)
     }
 
     { /* Bogus ACK Frame larger than the internal buffer */
-        uint8_t pat[528], *pos = pat;
+        uint8_t pat[1024], *pos = pat;
         const uint8_t *src = pat;
         int i;
         quicly_ack_frame_t decoded;

--- a/t/frame.c
+++ b/t/frame.c
@@ -96,19 +96,19 @@ static void test_ack_decode(void)
         quicly_ack_frame_t decoded;
         pos = quicly_encodev(pos, 0x84D0);
         pos = quicly_encodev(pos, 0);
-        pos = quicly_encodev(pos, QUICLY_MAX_ACK_RANGE_COUNT + 1);
+        pos = quicly_encodev(pos, QUICLY_ACK_MAX_GAPS + 1);
         pos = quicly_encodev(pos, 8);
-        for (i = 0; i <= QUICLY_MAX_ACK_RANGE_COUNT; ++i) {
+        for (i = 0; i <= QUICLY_ACK_MAX_GAPS ; ++i) {
             pos = quicly_encodev(pos, i); // gap
             pos = quicly_encodev(pos, 1); // ack-range
         }
         ok(quicly_decode_ack_frame(&src, pos, &decoded, 0) == 0);
         ok(decoded.largest_acknowledged == 0x84D0);
         ok(decoded.ack_delay == 0);
-        ok(decoded.num_gaps == QUICLY_MAX_ACK_RANGE_COUNT);
+        ok(decoded.num_gaps == QUICLY_ACK_MAX_GAPS);
         ok(decoded.ack_block_lengths[0] == 8 + 1); // first ack-range
         range_sum = decoded.ack_block_lengths[0];
-        for (i = 0; i < QUICLY_MAX_ACK_RANGE_COUNT; ++i) {
+        for (i = 0; i < QUICLY_ACK_MAX_GAPS; ++i) {
             ok(decoded.gaps[i] == i + 1);
             ok(decoded.ack_block_lengths[i + 1] == 1 + 1);
             range_sum += decoded.gaps[i] + decoded.ack_block_lengths[i + 1];

--- a/t/frame.c
+++ b/t/frame.c
@@ -98,7 +98,7 @@ static void test_ack_decode(void)
         pos = quicly_encodev(pos, 0);
         pos = quicly_encodev(pos, QUICLY_ACK_MAX_GAPS + 1);
         pos = quicly_encodev(pos, 8);
-        for (i = 0; i <= QUICLY_ACK_MAX_GAPS ; ++i) {
+        for (i = 0; i < QUICLY_ACK_MAX_GAPS + 30; ++i) {
             pos = quicly_encodev(pos, i); // gap
             pos = quicly_encodev(pos, i % 10); // ack-range
         }
@@ -109,11 +109,12 @@ static void test_ack_decode(void)
         ok(decoded.num_gaps == QUICLY_ACK_MAX_GAPS);
         ok(decoded.ack_block_lengths[0] == 8 + 1); // first ack-range
         range_sum = decoded.ack_block_lengths[0];
-        for (i = 0; i < QUICLY_ACK_MAX_GAPS; ++i) {
+        for (i = 0; i < decoded.num_gaps; ++i) {
             ok(decoded.gaps[i] == i + 1);
             ok(decoded.ack_block_lengths[i + 1] == (i % 10) + 1);
             range_sum += decoded.gaps[i] + decoded.ack_block_lengths[i + 1];
         }
+        ok(src == pos); // decoded the entire frame
         ok(decoded.smallest_acknowledged == 0xFA00 - range_sum + 1);
     }
 


### PR DESCRIPTION
We should decode the entire [ACK Frame](https://quicwg.org/base-drafts/draft-ietf-quic-transport.html#rfc.section.19.3), but only store the [ACK Ranges](https://quicwg.org/base-drafts/draft-ietf-quic-transport.html#rfc.section.19.3.1) that we can slurp in one go. Thanks to NCC group for the feedback.