### PR TITLE
Add update_now in quicly_close

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3240,6 +3240,7 @@ static int initiate_close(quicly_conn_t *conn, int err, uint64_t frame_type, con
 int quicly_close(quicly_conn_t *conn, int err, const char *reason_phrase)
 {
     assert(err == 0 || QUICLY_ERROR_IS_QUIC_APPLICATION(err));
+    update_now(conn->super.ctx);
 
     return initiate_close(conn, err, QUICLY_FRAME_TYPE_PADDING /* used when err == 0 */, reason_phrase);
 }


### PR DESCRIPTION
Hi,

I ran into an issue with the closing of quic connections (`quicly_close`) If I wait some time after the last packet send, the connection close frame will never be sent. Afaik, it's only the `now` not being updated on close.

Thanks a lot for your awesome library, it really made our life easy when adapting it for our use-case ! (We are using it to add QUIC support in [VPP](https://fdio-vpp.readthedocs.io/en/latest/index.html) ) 
