### PR TITLE
define noop stream callbacks for convenience

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -929,6 +929,32 @@ static void quicly_byte_to_hex(char *dst, uint8_t v);
  *
  */
 char *quicly_hexdump(const uint8_t *bytes, size_t len, size_t indent);
+/**
+ *
+ */
+void quicly_stream_noop_on_destroy(quicly_stream_t *stream, int err);
+/**
+ *
+ */
+void quicly_stream_noop_on_send_shift(quicly_stream_t *stream, size_t delta);
+/**
+ *
+ */
+int quicly_stream_noop_on_send_emit(quicly_stream_t *stream, size_t off, void *dst, size_t *len, int *wrote_all);
+/**
+ *
+ */
+int quicly_stream_noop_on_send_stop(quicly_stream_t *stream, int err);
+/**
+ *
+ */
+int quicly_stream_noop_on_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len);
+/**
+ *
+ */
+int quicly_stream_noop_on_receive_reset(quicly_stream_t *stream, int err);
+
+extern const quicly_stream_callbacks_t quicly_stream_noop_callbacks;
 
 /* inline definitions */
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4334,6 +4334,38 @@ void quicly_amend_ptls_context(ptls_context_t *ptls)
     ptls->update_traffic_key = &update_traffic_key;
 }
 
+void quicly_stream_noop_on_destroy(quicly_stream_t *stream, int err)
+{
+}
+
+void quicly_stream_noop_on_send_shift(quicly_stream_t *stream, size_t delta)
+{
+}
+
+int quicly_stream_noop_on_send_emit(quicly_stream_t *stream, size_t off, void *dst, size_t *len, int *wrote_all)
+{
+    return 0;
+}
+
+int quicly_stream_noop_on_send_stop(quicly_stream_t *stream, int err)
+{
+    return 0;
+}
+
+int quicly_stream_noop_on_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len)
+{
+    return 0;
+}
+
+int quicly_stream_noop_on_receive_reset(quicly_stream_t *stream, int err)
+{
+    return 0;
+}
+
+const quicly_stream_callbacks_t quicly_stream_noop_callbacks = {
+    quicly_stream_noop_on_destroy,   quicly_stream_noop_on_send_shift, quicly_stream_noop_on_send_emit,
+    quicly_stream_noop_on_send_stop, quicly_stream_noop_on_receive,    quicly_stream_noop_on_receive_reset};
+
 /**
  * an array of event names corresponding to quicly_event_type_t
  */


### PR DESCRIPTION
For the application, there is no point in waiting for delivery of stream-level signals, once both the send and receive side has been "closed."

At that moment, the noop callbacks can be set as the stream callbacks, and the application-level state (typically referred though `quicly_stream_t::data`) can be discarded immediately.