### PR TITLE
use resumption token

### DIFF
--- a/examples/echo.c
+++ b/examples/echo.c
@@ -181,7 +181,7 @@ static void process_msg(int is_client, quicly_conn_t **conns, struct msghdr *msg
             quicly_receive(conns[i], &decoded);
         } else if (!is_client) {
             /* assume that the packet is a new connection */
-            quicly_accept(conns + i, &ctx, msg->msg_name, msg->msg_namelen, &decoded, &next_cid, NULL, NULL);
+            quicly_accept(conns + i, &ctx, msg->msg_name, msg->msg_namelen, &decoded, NULL, &next_cid, NULL);
         }
     }
 }

--- a/examples/echo.c
+++ b/examples/echo.c
@@ -391,7 +391,8 @@ int main(int argc, char **argv)
     if (!is_server()) {
         /* initiate a connection, and open a stream */
         int ret;
-        if ((ret = quicly_connect(&client, &ctx, host, (struct sockaddr *)&sa, salen, &next_cid, NULL, NULL)) != 0) {
+        if ((ret = quicly_connect(&client, &ctx, host, (struct sockaddr *)&sa, salen, &next_cid, NULL, NULL,
+                                  ptls_iovec_init(NULL, 0))) != 0) {
             fprintf(stderr, "quicly_connect failed:%d\n", ret);
             exit(1);
         }

--- a/examples/echo.c
+++ b/examples/echo.c
@@ -181,7 +181,7 @@ static void process_msg(int is_client, quicly_conn_t **conns, struct msghdr *msg
             quicly_receive(conns[i], &decoded);
         } else if (!is_client) {
             /* assume that the packet is a new connection */
-            quicly_accept(conns + i, &ctx, msg->msg_name, msg->msg_namelen, &decoded, NULL, &next_cid, NULL);
+            quicly_accept(conns + i, &ctx, msg->msg_name, msg->msg_namelen, &decoded, &next_cid, NULL, NULL);
         }
     }
 }

--- a/examples/echo.c
+++ b/examples/echo.c
@@ -391,8 +391,8 @@ int main(int argc, char **argv)
     if (!is_server()) {
         /* initiate a connection, and open a stream */
         int ret;
-        if ((ret = quicly_connect(&client, &ctx, host, (struct sockaddr *)&sa, salen, &next_cid, NULL, NULL,
-                                  ptls_iovec_init(NULL, 0))) != 0) {
+        if ((ret = quicly_connect(&client, &ctx, host, (struct sockaddr *)&sa, salen, &next_cid, ptls_iovec_init(NULL, 0), NULL,
+                                  NULL)) != 0) {
             fprintf(stderr, "quicly_connect failed:%d\n", ret);
             exit(1);
         }

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -768,7 +768,7 @@ int quicly_decode_transport_parameter_list(quicly_transport_parameters_t *params
  */
 int quicly_connect(quicly_conn_t **conn, quicly_context_t *ctx, const char *server_name, struct sockaddr *sa, socklen_t salen,
                    const quicly_cid_plaintext_t *new_cid, ptls_handshake_properties_t *handshake_properties,
-                   const quicly_transport_parameters_t *resumed_transport_params);
+                   const quicly_transport_parameters_t *resumed_transport_params, ptls_iovec_t address_token);
 /**
  * accepts a new connection
  * @param new_cid the CID to be used for the connection. When an error is being returned, the application can reuse the CID provided

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -775,8 +775,8 @@ int quicly_connect(quicly_conn_t **conn, quicly_context_t *ctx, const char *serv
  *                to the function.
  */
 int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *sa, socklen_t salen,
-                  quicly_decoded_packet_t *packet, quicly_address_token_plaintext_t *address_token,
-                  const quicly_cid_plaintext_t *new_cid, ptls_handshake_properties_t *handshake_properties);
+                  quicly_decoded_packet_t *packet, const quicly_cid_plaintext_t *new_cid,
+                  ptls_handshake_properties_t *handshake_properties, quicly_address_token_plaintext_t *address_token);
 /**
  *
  */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -67,6 +67,7 @@ typedef struct st_quicly_context_t quicly_context_t;
 typedef struct st_quicly_conn_t quicly_conn_t;
 typedef struct st_quicly_stream_t quicly_stream_t;
 typedef struct st_quicly_send_context_t quicly_send_context_t;
+typedef struct st_quicly_address_token_plaintext_t quicly_address_token_plaintext_t;
 
 #define QUICLY_CALLBACK_TYPE0(ret, name)                                                                                           \
     typedef struct st_quicly_##name##_t {                                                                                          \
@@ -146,6 +147,11 @@ QUICLY_CALLBACK_TYPE0(int64_t, now);
  * called when a NEW_TOKEN token is received on a connection
  */
 QUICLY_CALLBACK_TYPE(int, save_resumption_token, quicly_conn_t *conn, ptls_iovec_t token);
+/**
+ *
+ */
+QUICLY_CALLBACK_TYPE(int, generate_resumption_token, quicly_conn_t *conn, ptls_buffer_t *buf,
+                     quicly_address_token_plaintext_t *token);
 
 typedef struct st_quicly_max_stream_data_t {
     uint64_t bidi_local, bidi_remote, uni;
@@ -273,6 +279,10 @@ struct st_quicly_context_t {
      * called wen a NEW_TOKEN token is being received
      */
     quicly_save_resumption_token_t *save_resumption_token;
+    /**
+     *
+     */
+    quicly_generate_resumption_token_t *generate_resumption_token;
 };
 
 /**
@@ -582,7 +592,7 @@ typedef struct st_quicly_decoded_packet_t {
     } _is_stateless_reset_cached;
 } quicly_decoded_packet_t;
 
-typedef struct st_quicly_address_token_plaintext_t {
+struct st_quicly_address_token_plaintext_t {
     int is_retry;
     uint64_t issued_at;
     union {
@@ -604,7 +614,7 @@ typedef struct st_quicly_address_token_plaintext_t {
         uint8_t bytes[256];
         size_t len;
     } appdata;
-} quicly_address_token_plaintext_t;
+};
 
 /**
  *
@@ -730,6 +740,10 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
  *
  */
 quicly_datagram_t *quicly_send_stateless_reset(quicly_context_t *ctx, struct sockaddr *sa, socklen_t salen, const void *cid);
+/**
+ *
+ */
+int quicly_send_resumption_token(quicly_conn_t *conn);
 /**
  *
  */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -771,8 +771,11 @@ int quicly_connect(quicly_conn_t **conn, quicly_context_t *ctx, const char *serv
                    const quicly_transport_parameters_t *resumed_transport_params, ptls_iovec_t address_token);
 /**
  * accepts a new connection
- * @param new_cid the CID to be used for the connection. When an error is being returned, the application can reuse the CID provided
- *                to the function.
+ * @param new_cid        The CID to be used for the connection. When an error is being returned, the application can reuse the CID
+ *                       provided to the function.
+ * @param address_token  An validated address validation token, if any.  Applications MUST validate the address validation token
+ *                       before calling this function, dropping the ones that failed to validate.  When a token is supplied,
+ *                       `quicly_accept` will consult the values being supplied assuming that the peer's address has been validated.
  */
 int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *sa, socklen_t salen,
                   quicly_decoded_packet_t *packet, const quicly_cid_plaintext_t *new_cid,

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -142,6 +142,10 @@ QUICLY_CALLBACK_TYPE(void, closed_by_peer, quicly_conn_t *conn, int err, uint64_
  * returns current time in milliseconds
  */
 QUICLY_CALLBACK_TYPE0(int64_t, now);
+/**
+ * called when a NEW_TOKEN token is received on a connection
+ */
+QUICLY_CALLBACK_TYPE(int, save_resumption_token, quicly_conn_t *conn, ptls_iovec_t token);
 
 typedef struct st_quicly_max_stream_data_t {
     uint64_t bidi_local, bidi_remote, uni;
@@ -265,6 +269,10 @@ struct st_quicly_context_t {
      * returns current time in milliseconds
      */
     quicly_now_t *now;
+    /**
+     * called wen a NEW_TOKEN token is being received
+     */
+    quicly_save_resumption_token_t *save_resumption_token;
 };
 
 /**

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -767,8 +767,9 @@ int quicly_decode_transport_parameter_list(quicly_transport_parameters_t *params
  * @param new_cid the CID to be used for the connection. path_id is ignored.
  */
 int quicly_connect(quicly_conn_t **conn, quicly_context_t *ctx, const char *server_name, struct sockaddr *sa, socklen_t salen,
-                   const quicly_cid_plaintext_t *new_cid, ptls_handshake_properties_t *handshake_properties,
-                   const quicly_transport_parameters_t *resumed_transport_params, ptls_iovec_t address_token);
+                   const quicly_cid_plaintext_t *new_cid, ptls_iovec_t address_token,
+                   ptls_handshake_properties_t *handshake_properties,
+                   const quicly_transport_parameters_t *resumed_transport_params);
 /**
  * accepts a new connection
  * @param new_cid        The CID to be used for the connection. When an error is being returned, the application can reuse the CID

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -778,8 +778,8 @@ int quicly_connect(quicly_conn_t **conn, quicly_context_t *ctx, const char *serv
  *                       `quicly_accept` will consult the values being supplied assuming that the peer's address has been validated.
  */
 int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *sa, socklen_t salen,
-                  quicly_decoded_packet_t *packet, const quicly_cid_plaintext_t *new_cid,
-                  ptls_handshake_properties_t *handshake_properties, quicly_address_token_plaintext_t *address_token);
+                  quicly_decoded_packet_t *packet, quicly_address_token_plaintext_t *address_token,
+                  const quicly_cid_plaintext_t *new_cid, ptls_handshake_properties_t *handshake_properties);
 /**
  *
  */

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -215,7 +215,7 @@ typedef struct st_quicly_ack_frame_t {
 int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_frame_t *frame, int is_ack_ecn);
 
 static size_t quicly_new_token_frame_capacity(ptls_iovec_t token);
-static uint8_t *quicly_encode_new_token_frame(uint8_t *dst, const uint8_t *dst_end, ptls_iovec_t token);
+static uint8_t *quicly_encode_new_token_frame(uint8_t *dst, ptls_iovec_t token);
 
 typedef struct st_quicly_new_token_frame_t {
     ptls_iovec_t token;
@@ -650,7 +650,7 @@ inline size_t quicly_new_token_frame_capacity(ptls_iovec_t token)
     return 1 + quicly_encodev_capacity(token.len) + token.len;
 }
 
-inline uint8_t *quicly_encode_new_token_frame(uint8_t *dst, const uint8_t *dst_end, ptls_iovec_t token)
+inline uint8_t *quicly_encode_new_token_frame(uint8_t *dst, ptls_iovec_t token)
 {
     *dst++ = QUICLY_FRAME_TYPE_NEW_TOKEN;
     dst = quicly_encodev(dst, token.len);

--- a/include/quicly/sentmap.h
+++ b/include/quicly/sentmap.h
@@ -105,6 +105,10 @@ struct st_quicly_sent_t {
         struct {
             quicly_stream_id_t stream_id;
         } stream_state_sender;
+        struct {
+            int is_inflight;
+            uint64_t generation;
+        } new_token;
     } data;
 };
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4024,8 +4024,8 @@ static int handle_stateless_reset(quicly_conn_t *conn)
 }
 
 int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *sa, socklen_t salen,
-                  quicly_decoded_packet_t *packet, quicly_address_token_plaintext_t *address_token,
-                  const quicly_cid_plaintext_t *new_cid, ptls_handshake_properties_t *handshake_properties)
+                  quicly_decoded_packet_t *packet, const quicly_cid_plaintext_t *new_cid,
+                  ptls_handshake_properties_t *handshake_properties, quicly_address_token_plaintext_t *address_token)
 {
     struct st_quicly_cipher_context_t ingress_cipher = {NULL}, egress_cipher = {NULL};
     ptls_iovec_t payload;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1613,8 +1613,8 @@ Exit:
 }
 
 int quicly_connect(quicly_conn_t **_conn, quicly_context_t *ctx, const char *server_name, struct sockaddr *sa, socklen_t salen,
-                   const quicly_cid_plaintext_t *new_cid, ptls_handshake_properties_t *handshake_properties,
-                   const quicly_transport_parameters_t *resumed_transport_params, ptls_iovec_t address_token)
+                   const quicly_cid_plaintext_t *new_cid, ptls_iovec_t address_token,
+                   ptls_handshake_properties_t *handshake_properties, const quicly_transport_parameters_t *resumed_transport_params)
 {
     quicly_conn_t *conn = NULL;
     const quicly_cid_t *server_cid;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4081,7 +4081,8 @@ int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *
     egress_cipher = (struct st_quicly_cipher_context_t){NULL};
     (*conn)->crypto.handshake_properties.collected_extensions = server_collected_extensions;
 
-    QUICLY_PROBE(ACCEPT, *conn, probe_now(), QUICLY_PROBE_HEXDUMP(packet->cid.dest.encrypted.base, packet->cid.dest.encrypted.len));
+    QUICLY_PROBE(ACCEPT, *conn, probe_now(), QUICLY_PROBE_HEXDUMP(packet->cid.dest.encrypted.base, packet->cid.dest.encrypted.len),
+                 address_token);
     QUICLY_PROBE(CRYPTO_DECRYPT, *conn, pn, payload.base, payload.len);
     QUICLY_PROBE(QUICTRACE_RECV, *conn, probe_now(), pn);
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4067,8 +4067,11 @@ int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *
     (*conn)->super.state = QUICLY_STATE_CONNECTED;
     set_cid(&(*conn)->super.peer.cid, packet->cid.src);
     set_cid(&(*conn)->super.host.offered_cid, packet->cid.dest.encrypted);
-    if (address_token != NULL && address_token->is_retry)
-        set_cid(&(*conn)->retry_odcid, ptls_iovec_init(address_token->retry.odcid.cid, address_token->retry.odcid.len));
+    if (address_token != NULL) {
+        (*conn)->super.peer.address_validation.validated = 1;
+        if (address_token->is_retry)
+            set_cid(&(*conn)->retry_odcid, ptls_iovec_init(address_token->retry.odcid.cid, address_token->retry.odcid.len));
+    }
     if ((ret = setup_handshake_space_and_flow(*conn, QUICLY_EPOCH_INITIAL)) != 0)
         goto Exit;
     (*conn)->initial->super.next_expected_packet_number = next_expected_pn;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4024,8 +4024,8 @@ static int handle_stateless_reset(quicly_conn_t *conn)
 }
 
 int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *sa, socklen_t salen,
-                  quicly_decoded_packet_t *packet, const quicly_cid_plaintext_t *new_cid,
-                  ptls_handshake_properties_t *handshake_properties, quicly_address_token_plaintext_t *address_token)
+                  quicly_decoded_packet_t *packet, quicly_address_token_plaintext_t *address_token,
+                  const quicly_cid_plaintext_t *new_cid, ptls_handshake_properties_t *handshake_properties)
 {
     struct st_quicly_cipher_context_t ingress_cipher = {NULL}, egress_cipher = {NULL};
     ptls_iovec_t payload;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3598,9 +3598,13 @@ static int handle_path_response_frame(quicly_conn_t *conn, struct st_quicly_hand
 static int handle_new_token_frame(quicly_conn_t *conn, struct st_quicly_handle_payload_state_t *state)
 {
     quicly_new_token_frame_t frame;
+    int ret;
 
-    /* TODO save the token along with the session ticket */
-    return quicly_decode_new_token_frame(&state->src, state->end, &frame);
+    if ((ret = quicly_decode_new_token_frame(&state->src, state->end, &frame)) != 0)
+        return ret;
+    if (conn->super.ctx->save_resumption_token == NULL)
+        return 0;
+    return conn->super.ctx->save_resumption_token->cb(conn->super.ctx->save_resumption_token, conn, frame.token);
 }
 
 static int handle_stop_sending_frame(quicly_conn_t *conn, struct st_quicly_handle_payload_state_t *state)

--- a/misc/probe2trace.pl
+++ b/misc/probe2trace.pl
@@ -142,8 +142,10 @@ for my $probe (@probes) {
                 } else {
                     push @ap, "arg$i";
                 }
-            } elsif ($type =~ /^const\s+void\s+\*$/) {
-                # skip const void *
+            } elsif ($type =~ /\s+\*$/) {
+                # emit the address for other pointers
+                push @fmt, qq!"name":"0x%llx"!;
+                push @ap, "(unsigned long long)arg$i";
             } else {
                 die "can't handle type: $type";
             }

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -70,6 +70,10 @@ provider quicly {
     probe max_stream_data_send(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t limit);
     probe max_stream_data_receive(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t limit);
 
+    probe new_token_send(struct st_quicly_conn_t *conn, int64_t at, uint8_t *token, size_t len, uint64_t generation);
+    probe new_token_acked(struct st_quicly_conn_t *conn, int64_t at, uint64_t generation);
+    probe new_token_receive(struct st_quicly_conn_t *conn, int64_t at, uint8_t *token, size_t len);
+
     probe streams_blocked_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t limit, int is_unidirectional);
     probe streams_blocked_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t limit, int is_unidirectional);
 

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -26,7 +26,8 @@
  */
 provider quicly {
     probe connect(struct st_quicly_conn_t *conn, int64_t at, uint32_t version);
-    probe accept(struct st_quicly_conn_t *conn, int64_t at, const char *dcid);
+    probe accept(struct st_quicly_conn_t *conn, int64_t at, const char *dcid,
+                 struct st_quicly_address_token_plaintext_t *address_token);
     probe free(struct st_quicly_conn_t *conn, int64_t at);
     probe send(struct st_quicly_conn_t *conn, int64_t at, int state, const char *dcid);
     probe receive(struct st_quicly_conn_t *conn, int64_t at, const char *dcid, const void *bytes, size_t num_bytes);

--- a/src/cli.c
+++ b/src/cli.c
@@ -465,7 +465,7 @@ static int run_client(struct sockaddr *sa, socklen_t salen, const char *host)
         perror("bind(2) failed");
         return 1;
     }
-    ret = quicly_connect(&conn, &ctx, host, sa, salen, &next_cid, &hs_properties, &resumed_transport_params, resumption_token);
+    ret = quicly_connect(&conn, &ctx, host, sa, salen, &next_cid, resumption_token, &hs_properties, &resumed_transport_params);
     assert(ret == 0);
     ++next_cid.master_id;
     enqueue_requests(conn);

--- a/src/cli.c
+++ b/src/cli.c
@@ -465,7 +465,7 @@ static int run_client(struct sockaddr *sa, socklen_t salen, const char *host)
         perror("bind(2) failed");
         return 1;
     }
-    ret = quicly_connect(&conn, &ctx, host, sa, salen, &next_cid, &hs_properties, &resumed_transport_params);
+    ret = quicly_connect(&conn, &ctx, host, sa, salen, &next_cid, &hs_properties, &resumed_transport_params, resumption_token);
     assert(ret == 0);
     ++next_cid.master_id;
     enqueue_requests(conn);

--- a/src/cli.c
+++ b/src/cli.c
@@ -716,7 +716,7 @@ static int run_server(struct sockaddr *sa, socklen_t salen)
                         break;
                     } else {
                         /* new connection */
-                        int ret = quicly_accept(&conn, &ctx, &sa, mess.msg_namelen, &packet, &next_cid, NULL, token);
+                        int ret = quicly_accept(&conn, &ctx, &sa, mess.msg_namelen, &packet, token, &next_cid, NULL);
                         if (ret == 0) {
                             assert(conn != NULL);
                             ++next_cid.master_id;

--- a/src/cli.c
+++ b/src/cli.c
@@ -355,6 +355,14 @@ static void on_closed_by_peer(quicly_closed_by_peer_t *self, quicly_conn_t *conn
 
 static quicly_closed_by_peer_t closed_by_peer = {&on_closed_by_peer};
 
+static int on_generate_resumption_token(quicly_generate_resumption_token_t *self, quicly_conn_t *conn, ptls_buffer_t *buf,
+                                       quicly_address_token_plaintext_t *token)
+{
+    return quicly_encrypt_address_token(tlsctx.random_bytes, address_token_aead.enc, buf, buf->off, token);
+}
+
+static quicly_generate_resumption_token_t generate_resumption_token = {&on_generate_resumption_token};
+
 static int send_one(int fd, quicly_datagram_t *p)
 {
     int ret;
@@ -862,6 +870,7 @@ int main(int argc, char **argv)
     ctx.tls = &tlsctx;
     ctx.stream_open = &stream_open;
     ctx.closed_by_peer = &closed_by_peer;
+    ctx.generate_resumption_token = &generate_resumption_token;
 
     setup_session_cache(ctx.tls);
     quicly_amend_ptls_context(ctx.tls);

--- a/src/cli.c
+++ b/src/cli.c
@@ -716,7 +716,7 @@ static int run_server(struct sockaddr *sa, socklen_t salen)
                         break;
                     } else {
                         /* new connection */
-                        int ret = quicly_accept(&conn, &ctx, &sa, mess.msg_namelen, &packet, token, &next_cid, NULL);
+                        int ret = quicly_accept(&conn, &ctx, &sa, mess.msg_namelen, &packet, &next_cid, NULL, token);
                         if (ret == 0) {
                             assert(conn != NULL);
                             ++next_cid.master_id;

--- a/t/loss.c
+++ b/t/loss.c
@@ -159,8 +159,8 @@ static void test_even(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL,
-                             ptls_iovec_init(NULL, 0));
+        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
+                             NULL);
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &raw, &num_packets);
@@ -263,8 +263,8 @@ static void loss_core(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL,
-                             ptls_iovec_init(NULL, 0));
+        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
+                             NULL);
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &raw, &num_packets);

--- a/t/loss.c
+++ b/t/loss.c
@@ -168,7 +168,7 @@ static void test_even(void)
         ok(num_packets == 1);
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, new_master_id(), NULL, NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
         cond_up.cb(&cond_up);
@@ -273,7 +273,7 @@ static void loss_core(void)
         quic_now += 10;
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, new_master_id(), NULL, NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
         quic_now += 10;

--- a/t/loss.c
+++ b/t/loss.c
@@ -168,7 +168,7 @@ static void test_even(void)
         ok(num_packets == 1);
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, new_master_id(), NULL, NULL);
+        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
         cond_up.cb(&cond_up);
@@ -273,7 +273,7 @@ static void loss_core(void)
         quic_now += 10;
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, new_master_id(), NULL, NULL);
+        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
         quic_now += 10;

--- a/t/loss.c
+++ b/t/loss.c
@@ -159,7 +159,8 @@ static void test_even(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL);
+        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL,
+                             ptls_iovec_init(NULL, 0));
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &raw, &num_packets);
@@ -262,7 +263,8 @@ static void loss_core(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL);
+        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL,
+                             ptls_iovec_init(NULL, 0));
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &raw, &num_packets);

--- a/t/simple.c
+++ b/t/simple.c
@@ -45,7 +45,7 @@ static void test_handshake(void)
     /* receive CH, send handshake upto ServerFinished */
     num_decoded = decode_packets(decoded, packets, num_packets);
     ok(num_decoded == 1);
-    ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, decoded, NULL, new_master_id(), NULL);
+    ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, decoded, new_master_id(), NULL, NULL);
     ok(ret == 0);
     free_packets(packets, num_packets);
     ok(quicly_get_state(server) == QUICLY_STATE_CONNECTED);
@@ -487,7 +487,7 @@ static void tiny_connection_window(void)
         ok(quicly_get_first_timeout(client) > quic_ctx.now->cb(quic_ctx.now));
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, new_master_id(), NULL, NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
     }

--- a/t/simple.c
+++ b/t/simple.c
@@ -34,7 +34,7 @@ static void test_handshake(void)
 
     /* send CH */
     ret =
-        quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL, ptls_iovec_init(NULL, 0));
+        quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), ptls_iovec_init(NULL, 0), NULL, NULL);
     ok(ret == 0);
     num_packets = sizeof(packets) / sizeof(packets[0]);
     ret = quicly_send(client, packets, &num_packets);
@@ -477,8 +477,8 @@ static void tiny_connection_window(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL,
-                             ptls_iovec_init(NULL, 0));
+        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
+                             NULL);
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &raw, &num_packets);

--- a/t/simple.c
+++ b/t/simple.c
@@ -33,7 +33,8 @@ static void test_handshake(void)
     int ret, i;
 
     /* send CH */
-    ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL);
+    ret =
+        quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL, ptls_iovec_init(NULL, 0));
     ok(ret == 0);
     num_packets = sizeof(packets) / sizeof(packets[0]);
     ret = quicly_send(client, packets, &num_packets);
@@ -476,7 +477,8 @@ static void tiny_connection_window(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL);
+        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL,
+                             ptls_iovec_init(NULL, 0));
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &raw, &num_packets);

--- a/t/simple.c
+++ b/t/simple.c
@@ -45,7 +45,7 @@ static void test_handshake(void)
     /* receive CH, send handshake upto ServerFinished */
     num_decoded = decode_packets(decoded, packets, num_packets);
     ok(num_decoded == 1);
-    ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, decoded, new_master_id(), NULL, NULL);
+    ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, decoded, NULL, new_master_id(), NULL);
     ok(ret == 0);
     free_packets(packets, num_packets);
     ok(quicly_get_state(server) == QUICLY_STATE_CONNECTED);
@@ -487,7 +487,7 @@ static void tiny_connection_window(void)
         ok(quicly_get_first_timeout(client) > quic_ctx.now->cb(quic_ctx.now));
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, new_master_id(), NULL, NULL);
+        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
     }

--- a/t/stream-concurrency.c
+++ b/t/stream-concurrency.c
@@ -46,7 +46,7 @@ void test_stream_concurrency(void)
         ok(num_packets == 1);
         ok(decode_packets(&decoded, &raw, 1) == 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, new_master_id(), NULL, NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
         transmit(server, client);

--- a/t/stream-concurrency.c
+++ b/t/stream-concurrency.c
@@ -46,7 +46,7 @@ void test_stream_concurrency(void)
         ok(num_packets == 1);
         ok(decode_packets(&decoded, &raw, 1) == 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, new_master_id(), NULL, NULL);
+        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
         transmit(server, client);

--- a/t/stream-concurrency.c
+++ b/t/stream-concurrency.c
@@ -37,7 +37,8 @@ void test_stream_concurrency(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL);
+        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL,
+                             ptls_iovec_init(NULL, 0));
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &raw, &num_packets);

--- a/t/stream-concurrency.c
+++ b/t/stream-concurrency.c
@@ -37,8 +37,8 @@ void test_stream_concurrency(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), NULL, NULL,
-                             ptls_iovec_init(NULL, 0));
+        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
+                             NULL);
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &raw, &num_packets);


### PR DESCRIPTION
* send NEW_TOKEN tokens
  * the first token is sent in 0.5 RTT
  * by calling `quicly_send_resumption_token`, apps can instruct quicly to send additional tokens
  * `generate_resumption_token` is the callback that applications would define. The callback is responsible for encrypting the token in an application-defined manner as well as associating arbitrary data.
* receiving NEW_TOKEN tokens
  * `save_resumption_token` is the new callback for the purpose.