### PR TITLE
Retain local address of a connection

### DIFF
--- a/examples/echo.c
+++ b/examples/echo.c
@@ -189,20 +189,10 @@ static void process_msg(int is_client, quicly_conn_t **conns, struct msghdr *msg
 static int send_one(int fd, quicly_datagram_t *p)
 {
     struct iovec vec = {.iov_base = p->data.base, .iov_len = p->data.len};
-    struct msghdr mess = {.msg_name = &p->dest.sa, .msg_iov = &vec, .msg_iovlen = 1};
+    struct msghdr mess = {
+        .msg_name = &p->dest.sa, .msg_namelen = quicly_get_socklen(&p->dest.sa), .msg_iov = &vec, .msg_iovlen = 1};
     int ret;
 
-    switch (p->dest.sa.sa_family) {
-    case AF_INET:
-        mess.msg_namelen = sizeof(struct sockaddr_in);
-        break;
-    case AF_INET6:
-        mess.msg_namelen = sizeof(struct sockaddr_in6);
-        break;
-    default:
-        assert(!"unexpected address family");
-        break;
-    }
     while ((ret = (int)sendmsg(fd, &mess, 0)) == -1 && errno == EINTR)
         ;
     return ret;

--- a/examples/echo.c
+++ b/examples/echo.c
@@ -402,7 +402,7 @@ int main(int argc, char **argv)
     if (!is_server()) {
         /* initiate a connection, and open a stream */
         int ret;
-        if ((ret = quicly_connect(&client, &ctx, host, (struct sockaddr *)&sa, salen, &next_cid, ptls_iovec_init(NULL, 0), NULL,
+        if ((ret = quicly_connect(&client, &ctx, host, NULL, (struct sockaddr *)&sa, &next_cid, ptls_iovec_init(NULL, 0), NULL,
                                   NULL)) != 0) {
             fprintf(stderr, "quicly_connect failed:%d\n", ret);
             exit(1);

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -194,6 +194,10 @@ typedef struct st_quicly_transport_parameters_t {
      * in milliseconds; quicly ignores the value set for quicly_context_t::transport_parameters
      */
     uint16_t max_ack_delay;
+    /**
+     *
+     */
+    uint8_t disable_migration : 1;
 } quicly_transport_parameters_t;
 
 struct st_quicly_cid_t {

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -758,7 +758,7 @@ int quicly_send_resumption_token(quicly_conn_t *conn);
 /**
  *
  */
-int quicly_receive(quicly_conn_t *conn, quicly_decoded_packet_t *packet);
+int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct sockaddr *src_addr, quicly_decoded_packet_t *packet);
 /**
  * consults if the incoming packet identified by (dest_addr, src_addr, decoded) belongs to the given connection
  */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -685,7 +685,7 @@ static quicly_stream_id_t quicly_get_peer_next_stream_id(quicly_conn_t *conn, in
 /**
  *
  */
-static void quicly_get_peername(quicly_conn_t *conn, struct sockaddr **sa, socklen_t *salen);
+static struct sockaddr *quicly_get_peername(quicly_conn_t *conn);
 /**
  *
  */
@@ -865,6 +865,10 @@ int quicly_decrypt_address_token(ptls_aead_context_t *aead, quicly_address_token
  */
 static void quicly_byte_to_hex(char *dst, uint8_t v);
 /**
+ *
+ */
+socklen_t quicly_get_socklen(struct sockaddr *sa);
+/**
  * Builds a safe string. Supplied buffer MUST be 4x + 1 bytes bigger than the input.
  */
 char *quicly_escape_unsafe_string(char *dst, const void *bytes, size_t len);
@@ -966,22 +970,10 @@ inline quicly_stream_id_t quicly_get_peer_next_stream_id(quicly_conn_t *conn, in
     return uni ? c->peer.uni.next_stream_id : c->peer.bidi.next_stream_id;
 }
 
-inline void quicly_get_peername(quicly_conn_t *conn, struct sockaddr **sa, socklen_t *salen)
+inline struct sockaddr *quicly_get_peername(quicly_conn_t *conn)
 {
     struct _st_quicly_conn_public_t *c = (struct _st_quicly_conn_public_t *)conn;
-    *sa = &c->peer.address.sa;
-    switch ((*sa)->sa_family) {
-    case AF_INET:
-        *salen = sizeof(struct sockaddr_in);
-        break;
-    case AF_INET6:
-        *salen = sizeof(struct sockaddr_in6);
-        break;
-    default:
-        *salen = 0;
-        assert(!"unexpected peer address type");
-        break;
-    }
+    return &c->peer.address.sa;
 }
 
 inline void **quicly_get_data(quicly_conn_t *conn)

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -66,14 +66,13 @@ const quicly_context_t quicly_performant_context = {
     &quicly_default_now
 };
 
-static quicly_datagram_t *default_alloc_packet(quicly_packet_allocator_t *self, socklen_t salen, size_t payloadsize)
+static quicly_datagram_t *default_alloc_packet(quicly_packet_allocator_t *self, size_t payloadsize)
 {
     quicly_datagram_t *packet;
 
-    if ((packet = malloc(offsetof(quicly_datagram_t, sa) + salen + payloadsize)) == NULL)
+    if ((packet = malloc(sizeof(*packet) + payloadsize)) == NULL)
         return NULL;
-    packet->salen = salen;
-    packet->data.base = (uint8_t *)packet + offsetof(quicly_datagram_t, sa) + salen;
+    packet->data.base = (uint8_t *)packet + sizeof(*packet);
 
     return packet;
 }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4307,6 +4307,11 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
                 conn->crypto.handshake_scheduled_for_discard = 1;
             }
         }
+        /* when running as a client, respect "disable_migration" TP sent by the peer at the end of the TLS handshake */
+        if (quicly_is_client(conn) && conn->super.host.address.sa.sa_family == AF_UNSPEC && dest_addr != NULL &&
+            dest_addr->sa_family != AF_UNSPEC && ptls_handshake_is_complete(conn->crypto.tls) &&
+            conn->super.peer.transport_params.disable_migration)
+            set_address(&conn->super.host.address, dest_addr);
         break;
     case QUICLY_EPOCH_1RTT:
         if (!is_ack_only && should_send_max_data(conn))

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4096,7 +4096,7 @@ Exit:
     return ret;
 }
 
-int quicly_receive(quicly_conn_t *conn, quicly_decoded_packet_t *packet)
+int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct sockaddr *src_addr, quicly_decoded_packet_t *packet)
 {
     ptls_cipher_context_t *header_protection;
     ptls_aead_context_t **aead;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4408,6 +4408,19 @@ void quicly_request_stop(quicly_stream_t *stream, int err)
     }
 }
 
+socklen_t quicly_get_socklen(struct sockaddr *sa)
+{
+    switch (sa->sa_family) {
+    case AF_INET:
+        return sizeof(struct sockaddr_in);
+    case AF_INET6:
+        return sizeof(struct sockaddr_in6);
+    default:
+        assert(!"unexpected socket type");
+        return 0;
+    }
+}
+
 char *quicly_escape_unsafe_string(char *buf, const void *bytes, size_t len)
 {
     char *dst = buf;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1341,6 +1341,8 @@ int quicly_encode_transport_parameter_list(ptls_buffer_t *buf, int is_client, co
                                      { pushv(buf, QUICLY_LOCAL_ACK_DELAY_EXPONENT); });
         if (QUICLY_LOCAL_MAX_ACK_DELAY != QUICLY_DEFAULT_MAX_ACK_DELAY)
             PUSH_TRANSPORT_PARAMETER(buf, QUICLY_TRANSPORT_PARAMETER_ID_MAX_ACK_DELAY, { pushv(buf, QUICLY_LOCAL_MAX_ACK_DELAY); });
+        if (params->disable_migration)
+            PUSH_TRANSPORT_PARAMETER(buf, QUICLY_TRANSPORT_PARAMETER_ID_DISABLE_MIGRATION, {});
     });
 #undef pushv
 
@@ -1443,6 +1445,9 @@ int quicly_decode_transport_parameter_list(quicly_transport_parameters_t *params
                         v = QUICLY_DEFAULT_MAX_ACK_DELAY;
                     params->max_ack_delay = (uint16_t)v;
                 } break;
+                case QUICLY_TRANSPORT_PARAMETER_ID_DISABLE_MIGRATION:
+                    params->disable_migration = 1;
+                    break;
                 default:
                     src = end;
                     break;
@@ -1580,34 +1585,35 @@ static int client_collected_extensions(ptls_t *tls, ptls_handshake_properties_t 
     assert(slots[1].type == UINT16_MAX);
 
     const uint8_t *src = slots[0].data.base, *end = src + slots[0].data.len;
+    quicly_transport_parameters_t params;
+    quicly_cid_t odcid;
 
-    {
-        quicly_transport_parameters_t params;
-        quicly_cid_t odcid;
-        if ((ret = quicly_decode_transport_parameter_list(&params, &odcid, conn->super.peer.stateless_reset._buf, 1, src, end)) !=
-            0)
-            goto Exit;
-        conn->super.peer.stateless_reset.token = conn->super.peer.stateless_reset._buf;
-        if (odcid.len != conn->retry_odcid.len || memcmp(odcid.cid, conn->retry_odcid.cid, odcid.len) != 0) {
-            ret = QUICLY_TRANSPORT_ERROR_TRANSPORT_PARAMETER;
-            goto Exit;
-        }
-        if (properties->client.early_data_acceptance == PTLS_EARLY_DATA_ACCEPTED) {
+    /* decode and validate */
+    if ((ret = quicly_decode_transport_parameter_list(&params, &odcid, conn->super.peer.stateless_reset._buf, 1, src, end)) !=
+        0)
+        goto Exit;
+    if (odcid.len != conn->retry_odcid.len || memcmp(odcid.cid, conn->retry_odcid.cid, odcid.len) != 0) {
+        ret = QUICLY_TRANSPORT_ERROR_TRANSPORT_PARAMETER;
+        goto Exit;
+    }
+    if (properties->client.early_data_acceptance == PTLS_EARLY_DATA_ACCEPTED) {
 #define ZERORTT_VALIDATE(x)                                                                                                        \
     if (params.x < conn->super.peer.transport_params.x) {                                                                          \
         ret = QUICLY_TRANSPORT_ERROR_TRANSPORT_PARAMETER;                                                                          \
         goto Exit;                                                                                                                 \
     }
-            ZERORTT_VALIDATE(max_data);
-            ZERORTT_VALIDATE(max_stream_data.bidi_local);
-            ZERORTT_VALIDATE(max_stream_data.bidi_remote);
-            ZERORTT_VALIDATE(max_stream_data.uni);
-            ZERORTT_VALIDATE(max_streams_bidi);
-            ZERORTT_VALIDATE(max_streams_uni);
+        ZERORTT_VALIDATE(max_data);
+        ZERORTT_VALIDATE(max_stream_data.bidi_local);
+        ZERORTT_VALIDATE(max_stream_data.bidi_remote);
+        ZERORTT_VALIDATE(max_stream_data.uni);
+        ZERORTT_VALIDATE(max_streams_bidi);
+        ZERORTT_VALIDATE(max_streams_uni);
 #undef ZERORTT_VALIDATE
-        }
-        conn->super.peer.transport_params = params;
     }
+
+    /* store the results */
+    conn->super.peer.stateless_reset.token = conn->super.peer.stateless_reset._buf;
+    conn->super.peer.transport_params = params;
 
 Exit:
     return ret; /* negative error codes used to transmit QUIC errors through picotls */

--- a/src/cli.c
+++ b/src/cli.c
@@ -371,17 +371,7 @@ static int send_one(int fd, quicly_datagram_t *p)
     struct iovec vec;
     memset(&mess, 0, sizeof(mess));
     mess.msg_name = &p->dest.sa;
-    switch (p->dest.sa.sa_family) {
-    case AF_INET:
-        mess.msg_namelen = sizeof(struct sockaddr_in);
-        break;
-    case AF_INET6:
-        mess.msg_namelen = sizeof(struct sockaddr_in6);
-        break;
-    default:
-        assert(!"unknown address type");
-        break;
-    }
+    mess.msg_namelen = quicly_get_socklen(&p->dest.sa);
     vec.iov_base = p->data.base;
     vec.iov_len = p->data.len;
     mess.msg_iov = &vec;

--- a/src/cli.c
+++ b/src/cli.c
@@ -530,7 +530,7 @@ static int run_client(struct sockaddr *sa, const char *host)
                 size_t plen = quicly_decode_packet(&ctx, &packet, buf + off, rret - off);
                 if (plen == SIZE_MAX)
                     break;
-                quicly_receive(conn, &packet);
+                quicly_receive(conn, NULL, &sa, &packet);
                 off += plen;
             }
         }
@@ -703,7 +703,7 @@ static int run_server(struct sockaddr *sa, socklen_t salen)
                 }
                 if (conn != NULL) {
                     /* existing connection */
-                    quicly_receive(conn, &packet);
+                    quicly_receive(conn, NULL, &sa, &packet);
                 } else if (QUICLY_PACKET_IS_LONG_HEADER(packet.octets.base[0])) {
                     /* long header packet; potentially a new connection */
                     quicly_address_token_plaintext_t *token = NULL, token_buf;

--- a/t/loss.c
+++ b/t/loss.c
@@ -125,7 +125,7 @@ static int transmit_cond(quicly_conn_t *src, quicly_conn_t *dst, size_t *num_sen
                 size_t num_decoded = decode_packets(decoded, packets + i, 1), j;
                 assert(num_decoded != 0);
                 for (j = 0; j != num_decoded; ++j) {
-                    ret = quicly_receive(dst, decoded + j);
+                    ret = quicly_receive(dst, NULL, &fake_address.sa, decoded + j);
                     if (!(ret == 0 || ret == QUICLY_ERROR_PACKET_IGNORED)) {
                         fprintf(stderr, "%s: quicly_receive: i=%zu, j=%zu, ret=%d\n", __FUNCTION__, i, j, ret);
                         return ret;

--- a/t/loss.c
+++ b/t/loss.c
@@ -159,8 +159,8 @@ static void test_even(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
-                             NULL);
+        ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, NULL, new_master_id(), ptls_iovec_init(NULL, 0),
+                             NULL, NULL);
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &raw, &num_packets);
@@ -168,7 +168,7 @@ static void test_even(void)
         ok(num_packets == 1);
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
         cond_up.cb(&cond_up);
@@ -263,8 +263,8 @@ static void loss_core(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
-                             NULL);
+        ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, NULL, new_master_id(), ptls_iovec_init(NULL, 0),
+                             NULL, NULL);
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &raw, &num_packets);
@@ -273,7 +273,7 @@ static void loss_core(void)
         quic_now += 10;
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
         quic_now += 10;

--- a/t/loss.c
+++ b/t/loss.c
@@ -159,7 +159,7 @@ static void test_even(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
+        ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
                              NULL);
         ok(ret == 0);
         num_packets = 1;
@@ -168,7 +168,7 @@ static void test_even(void)
         ok(num_packets == 1);
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
         cond_up.cb(&cond_up);
@@ -263,7 +263,7 @@ static void loss_core(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
+        ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
                              NULL);
         ok(ret == 0);
         num_packets = 1;
@@ -273,7 +273,7 @@ static void loss_core(void)
         quic_now += 10;
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
         quic_now += 10;

--- a/t/simple.c
+++ b/t/simple.c
@@ -33,8 +33,8 @@ static void test_handshake(void)
     int ret, i;
 
     /* send CH */
-    ret =
-        quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, new_master_id(), ptls_iovec_init(NULL, 0), NULL, NULL);
+    ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, NULL, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
+                         NULL);
     ok(ret == 0);
     num_packets = sizeof(packets) / sizeof(packets[0]);
     ret = quicly_send(client, packets, &num_packets);
@@ -45,7 +45,7 @@ static void test_handshake(void)
     /* receive CH, send handshake upto ServerFinished */
     num_decoded = decode_packets(decoded, packets, num_packets);
     ok(num_decoded == 1);
-    ret = quicly_accept(&server, &quic_ctx, &fake_address.sa, decoded, NULL, new_master_id(), NULL);
+    ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, decoded, NULL, new_master_id(), NULL);
     ok(ret == 0);
     free_packets(packets, num_packets);
     ok(quicly_get_state(server) == QUICLY_STATE_CONNECTED);
@@ -477,8 +477,8 @@ static void tiny_connection_window(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
-                             NULL);
+        ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, NULL, new_master_id(), ptls_iovec_init(NULL, 0),
+                             NULL, NULL);
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &raw, &num_packets);
@@ -487,7 +487,7 @@ static void tiny_connection_window(void)
         ok(quicly_get_first_timeout(client) > quic_ctx.now->cb(quic_ctx.now));
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
     }

--- a/t/simple.c
+++ b/t/simple.c
@@ -58,7 +58,7 @@ static void test_handshake(void)
     /* receive ServerFinished */
     num_decoded = decode_packets(decoded, packets, num_packets);
     for (i = 0; i != num_decoded; ++i) {
-        ret = quicly_receive(client, decoded + i);
+        ret = quicly_receive(client, NULL, &fake_address.sa, decoded + i);
         ok(ret == 0);
     }
     free_packets(packets, num_packets);
@@ -367,7 +367,7 @@ static void test_rst_during_loss(void)
     {
         quicly_decoded_packet_t decoded;
         decode_packets(&decoded, &reordered_packet, 1);
-        ret = quicly_receive(server, &decoded);
+        ret = quicly_receive(server, NULL, &fake_address.sa, &decoded);
         ok(ret == 0);
     }
 
@@ -428,7 +428,7 @@ static void test_close(void)
     { /* server receives close */
         quicly_decoded_packet_t decoded;
         decode_packets(&decoded, &datagram, 1);
-        ret = quicly_receive(server, &decoded);
+        ret = quicly_receive(server, NULL, &fake_address.sa, &decoded);
         ok(ret == 0);
         ok(test_close_error_code == 12345);
         ok(quicly_get_state(server) == QUICLY_STATE_DRAINING);

--- a/t/simple.c
+++ b/t/simple.c
@@ -34,7 +34,7 @@ static void test_handshake(void)
 
     /* send CH */
     ret =
-        quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), ptls_iovec_init(NULL, 0), NULL, NULL);
+        quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, new_master_id(), ptls_iovec_init(NULL, 0), NULL, NULL);
     ok(ret == 0);
     num_packets = sizeof(packets) / sizeof(packets[0]);
     ret = quicly_send(client, packets, &num_packets);
@@ -45,7 +45,7 @@ static void test_handshake(void)
     /* receive CH, send handshake upto ServerFinished */
     num_decoded = decode_packets(decoded, packets, num_packets);
     ok(num_decoded == 1);
-    ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, decoded, NULL, new_master_id(), NULL);
+    ret = quicly_accept(&server, &quic_ctx, &fake_address.sa, decoded, NULL, new_master_id(), NULL);
     ok(ret == 0);
     free_packets(packets, num_packets);
     ok(quicly_get_state(server) == QUICLY_STATE_CONNECTED);
@@ -477,7 +477,7 @@ static void tiny_connection_window(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
+        ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
                              NULL);
         ok(ret == 0);
         num_packets = 1;
@@ -487,7 +487,7 @@ static void tiny_connection_window(void)
         ok(quicly_get_first_timeout(client) > quic_ctx.now->cb(quic_ctx.now));
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
     }

--- a/t/stream-concurrency.c
+++ b/t/stream-concurrency.c
@@ -37,8 +37,8 @@ void test_stream_concurrency(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
-                             NULL);
+        ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, NULL, new_master_id(), ptls_iovec_init(NULL, 0),
+                             NULL, NULL);
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &raw, &num_packets);
@@ -46,7 +46,7 @@ void test_stream_concurrency(void)
         ok(num_packets == 1);
         ok(decode_packets(&decoded, &raw, 1) == 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
         transmit(server, client);

--- a/t/stream-concurrency.c
+++ b/t/stream-concurrency.c
@@ -37,7 +37,7 @@ void test_stream_concurrency(void)
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
-        ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)"abc", 3, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
+        ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
                              NULL);
         ok(ret == 0);
         num_packets = 1;
@@ -46,7 +46,7 @@ void test_stream_concurrency(void)
         ok(num_packets == 1);
         ok(decode_packets(&decoded, &raw, 1) == 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, (void *)"abc", 3, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
         free_packets(&raw, 1);
         transmit(server, client);

--- a/t/test.c
+++ b/t/test.c
@@ -87,6 +87,7 @@ static void on_destroy(quicly_stream_t *stream, int err);
 static int on_egress_stop(quicly_stream_t *stream, int err);
 static int on_ingress_reset(quicly_stream_t *stream, int err);
 
+quicly_address_t fake_address;
 int64_t quic_now;
 quicly_context_t quic_ctx;
 quicly_stream_callbacks_t stream_callbacks = {on_destroy,     quicly_streambuf_egress_shift,    quicly_streambuf_egress_emit,
@@ -383,6 +384,8 @@ int main(int argc, char **argv)
     quic_ctx.transport_params.max_streams_bidi = 10;
     quic_ctx.stream_open = &stream_open;
     quic_ctx.now = &get_now;
+
+    fake_address.sa.sa_family = AF_INET;
 
     ERR_load_crypto_strings();
     OpenSSL_add_all_algorithms();

--- a/t/test.c
+++ b/t/test.c
@@ -284,7 +284,7 @@ size_t transmit(quicly_conn_t *src, quicly_conn_t *dst)
     if (num_datagrams != 0) {
         size_t num_packets = decode_packets(decoded, datagrams, num_datagrams);
         for (i = 0; i != num_packets; ++i) {
-            ret = quicly_receive(dst, decoded + i);
+            ret = quicly_receive(dst, NULL, &fake_address.sa, decoded + i);
             ok(ret == 0 || ret == QUICLY_ERROR_PACKET_IGNORED);
         }
         free_packets(datagrams, num_datagrams);

--- a/t/test.h
+++ b/t/test.h
@@ -35,6 +35,7 @@ typedef struct st_test_streambuf_t {
     int is_detached;
 } test_streambuf_t;
 
+extern quicly_address_t fake_address;
 extern int64_t quic_now;
 extern quicly_context_t quic_ctx;
 extern quicly_stream_callbacks_t stream_callbacks;


### PR DESCRIPTION
So that the server will respond from the address specified by the client, even when the server has multiple addresses assigned to it's interface.

For convenience, this has been designed as an optional feature - an endpoint MAY specify NULL as the source address to let the kernel select the most appropriate address. In case of clients, that might cause address migration for example when an network interface disappears.