### PR TITLE
omit `.txt` for sized objects

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -221,7 +221,7 @@ static int send_sized_text(quicly_stream_t *stream, const char *path, int is_htt
     size_t size;
     int lastpos;
 
-    if (sscanf(path, "/%zu.txt%n", &size, &lastpos) != 1)
+    if (sscanf(path, "/%zu%n", &size, &lastpos) != 1)
         return 0;
     if (lastpos != strlen(path))
         return 0;

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -34,7 +34,7 @@ my $tempdir = tempdir(CLEANUP => 1);
 
 subtest "hello" => sub {
     my $guard = spawn_server();
-    my $resp = `$cli -e $tempdir/events -p /12.txt 127.0.0.1 $port 2> /dev/null`;
+    my $resp = `$cli -e $tempdir/events -p /12 127.0.0.1 $port 2> /dev/null`;
     is $resp, "hello world\n";
     subtest "events" => sub {
         my $events = slurp_file("$tempdir/events");
@@ -47,7 +47,7 @@ subtest "hello" => sub {
 
 subtest "version-negotiation" => sub {
     my $guard = spawn_server();
-    my $resp = `$cli -n -e $tempdir/events -p /12.txt 127.0.0.1 $port 2> /dev/null`;
+    my $resp = `$cli -n -e $tempdir/events -p /12 127.0.0.1 $port 2> /dev/null`;
     is $resp, "hello world\n";
     my $events = slurp_file("$tempdir/events");
     if ($events =~ /"type":"connect",.*"version":(\d+)(?:.|\n)*"type":"version-switch",.*"new-version":(\d+)/m) {
@@ -61,7 +61,7 @@ subtest "version-negotiation" => sub {
 
 subtest "retry" => sub {
     my $guard = spawn_server("-R");
-    my $resp = `$cli -e $tempdir/events -p /12.txt 127.0.0.1 $port 2> /dev/null`;
+    my $resp = `$cli -e $tempdir/events -p /12 127.0.0.1 $port 2> /dev/null`;
     is $resp, "hello world\n";
     my $events = slurp_file("$tempdir/events");
     complex $events, sub {
@@ -73,7 +73,7 @@ unlink "$tempdir/session";
 
 subtest "0-rtt" => sub {
     my $guard = spawn_server();
-    my $resp = `$cli -s $tempdir/session -p /12.txt 127.0.0.1 $port 2> /dev/null`;
+    my $resp = `$cli -s $tempdir/session -p /12 127.0.0.1 $port 2> /dev/null`;
     is $resp, "hello world\n";
     ok -e "$tempdir/session", "session saved";
     system "$cli -s $tempdir/session -e $tempdir/events 127.0.0.1 $port > /dev/null 2>&1";
@@ -108,7 +108,7 @@ subtest "stateless-reset" => sub {
 
 subtest "idle-timeout" => sub {
     my $guard = spawn_server(qw(-I 1000 -e), "$tempdir/server-events");
-    my $resp = `$cli -e $tempdir/client-events -p /12.txt -i 2000 127.0.0.1 $port 2> /dev/null`;
+    my $resp = `$cli -e $tempdir/client-events -p /12 -i 2000 127.0.0.1 $port 2> /dev/null`;
     # Because we start using idle timeout at the moment we dispose handshake key (currently 3PTO after handshake), there is an
     # uncertainty in if the first request-response is covered by the idle timeout.  Therefore, we check if we have either one or
     # to responses, add a sleep in case server timeouts after client does, pass the case where the server sends stateless-reset...
@@ -121,17 +121,17 @@ subtest "idle-timeout" => sub {
 
 subtest "blocked-streams" => sub {
     my $guard = spawn_server(qw(-X 2));
-    my $resp = `$cli -p /12.txt -p /12.txt 127.0.0.1 $port 2> /dev/null`;
+    my $resp = `$cli -p /12 -p /12 127.0.0.1 $port 2> /dev/null`;
     is $resp, "hello world\nhello world\n";
-    $resp = `$cli -p /12.txt -p /12.txt -p /12.txt 127.0.0.1 $port 2> /dev/null`;
+    $resp = `$cli -p /12 -p /12 -p /12 127.0.0.1 $port 2> /dev/null`;
     is $resp, "hello world\nhello world\nhello world\n";
-    $resp = `$cli -p /12.txt -p /12.txt -p /12.txt -p /12.txt 127.0.0.1 $port 2> /dev/null`;
+    $resp = `$cli -p /12 -p /12 -p /12 -p /12 127.0.0.1 $port 2> /dev/null`;
     is $resp, "hello world\nhello world\nhello world\nhello world\n";
 };
 
 subtest "max-data-crapped" => sub {
     my $guard = spawn_server('-e', "$tempdir/events");
-    my $resp = `$cli -m 10 -p /12.txt 127.0.0.1 $port 2> /dev/null`;
+    my $resp = `$cli -m 10 -p /12 127.0.0.1 $port 2> /dev/null`;
     is $resp, "hello world\n";
     undef $guard;
     # build list of filtered events
@@ -156,11 +156,11 @@ subtest "0-rtt-vs-hrr" => sub {
     plan skip_all => "no support for x25519, we need multiple key exchanges to run this test"
         if `$cli -x x25519 2>&1` =~ /unknown key exchange/;
     my $guard = spawn_server(qw(-x x25519));
-    my $resp = `$cli -x x25519 -x secp256r1 -s $tempdir/session -p /12.txt 127.0.0.1 $port 2> $tempdir/stderr.log; cat $tempdir/stderr.log`;
+    my $resp = `$cli -x x25519 -x secp256r1 -s $tempdir/session -p /12 127.0.0.1 $port 2> $tempdir/stderr.log; cat $tempdir/stderr.log`;
     like $resp, qr/^hello world\n/s;
     undef $guard;
     $guard = spawn_server(qw(-x secp256r1));
-    $resp = `$cli -x x25519 -x secp256r1 -s $tempdir/session -p /12.txt 127.0.0.1 $port 2> $tempdir/stderr.log; cat $tempdir/stderr.log`;
+    $resp = `$cli -x x25519 -x secp256r1 -s $tempdir/session -p /12 127.0.0.1 $port 2> $tempdir/stderr.log; cat $tempdir/stderr.log`;
     like $resp, qr/^hello world\n/s;
 };
 


### PR DESCRIPTION
The cli command has long supported URI path `/NNN.txt` where NNN is a number indicating the size of the response to be served.

However, it seems that the interop assumes that `.txt` to not exist. Hence the PR.