### PR TITLE
add argument to specify prefix for retry tokens

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -745,7 +745,7 @@ int quicly_retry_calc_cidpair_hash(ptls_hash_algorithm_t *sha256, ptls_iovec_t c
  */
 quicly_datagram_t *quicly_send_retry(quicly_context_t *ctx, ptls_aead_context_t *token_encrypt_ctx, struct sockaddr *dest_addr,
                                      ptls_iovec_t dest_cid, struct sockaddr *src_addr, ptls_iovec_t src_cid, ptls_iovec_t odcid,
-                                     ptls_iovec_t token);
+                                     ptls_iovec_t token_prefix, ptls_iovec_t appdata);
 /**
  *
  */

--- a/src/cli.c
+++ b/src/cli.c
@@ -701,7 +701,8 @@ static int run_server(struct sockaddr *sa, socklen_t salen)
                         new_server_cid[0] ^= 0xff;
                         quicly_datagram_t *rp = quicly_send_retry(&ctx, address_token_aead.enc, &sa, packet.cid.src, NULL,
                                                                   ptls_iovec_init(new_server_cid, sizeof(new_server_cid)),
-                                                                  packet.cid.dest.encrypted, ptls_iovec_init(NULL, 0));
+                                                                  packet.cid.dest.encrypted, ptls_iovec_init(NULL, 0),
+                                                                  ptls_iovec_init(NULL, 0));
                         assert(rp != NULL);
                         if (send_one(fd, rp) == -1)
                             perror("sendmsg failed");


### PR DESCRIPTION
The prefix of a token (which is covered by AEAD) is to be used for designating the encryption key. All other functions (i.e. quicly_encrypt_address_token, quicly_decrypt_address_token, generate_resumption_token) provide ways for specifying that, however `quicly_send_retry` function lacked the capability.