### PR TITLE
Ack ALPN on the server-side

### DIFF
--- a/t/e2e.t
+++ b/t/e2e.t
@@ -164,6 +164,16 @@ subtest "0-rtt-vs-hrr" => sub {
     like $resp, qr/^hello world\n/s;
 };
 
+subtest "alpn" => sub {
+    my $guard = spawn_server(qw(-a hq-23));
+    my $resp = `$cli -p /12 127.0.0.1 $port 2>&1`;
+    like $resp, qr/transport close:code=0x178;/, "no ALPN";
+    $resp = `$cli -a hq-23 -p /12 127.0.0.1 $port 2>&1`;
+    like $resp, qr/^hello world$/m, "ALPN match";
+    $resp = `$cli -a hX-23 -p /12 127.0.0.1 $port 2>&1`;
+    like $resp, qr/transport close:code=0x178;/, "ALPN mismatch";
+};
+
 done_testing;
 
 sub spawn_server {


### PR DESCRIPTION
Changes:
* `-a` option is now taken into account by the server too, in conformance with RFC 7301:
  * NO_APPLICATION_PROTOCOL alert is sent when the client does not send an ALPN extension
  * NO_APPLICATION_PROTOCOL alert is sent when no compatible ALPN identifiers are found
  * handshake will succeed when a compatible ALPN identifier is found (in that case, the server will inform the client the selected ALPN by using the extension), or when neither the client or server uses the `-a` option.
* users are requested to repeat the `-a` option when specifying multiple ALPN identifiers, instead of using comma (i.e., use `-a foo -a bar` instead of `-a foo,bar`)
