### PR TITLE
handle time skew for rtt update

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3558,6 +3558,10 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
 
     QUICLY_PROBE(QUICTRACE_RECV_ACK_DELAY, conn, probe_now(), frame.ack_delay);
 
+    /* Detect and fix time skew */
+    if (now < largest_newly_acked.sent_at)
+        now = largest_newly_acked.sent_at;
+
     /* Update loss detection engine on ack. The function uses ack_delay only when the largest_newly_acked is also the largest acked
      * so far. So, it does not matter if the ack_delay being passed in does not apply to the largest_newly_acked. */
     quicly_loss_on_ack_received(&conn->egress.loss, largest_newly_acked.packet_number, now, largest_newly_acked.sent_at,


### PR DESCRIPTION
While testing quicly integration on the FD.io/VPP project, I encountered a case where there was a time skew that caused the assert in quicly_rtt_update() to generate a SIGABRT.

This PR detects time skew and resolves it to avoid triggering the assert.