### PR TITLE
draft-24

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -50,7 +50,7 @@ extern "C" {
 #define QUICLY_LONG_HEADER_BIT 0x80
 #define QUICLY_PACKET_IS_LONG_HEADER(first_byte) (((first_byte)&QUICLY_LONG_HEADER_BIT) != 0)
 
-#define QUICLY_PROTOCOL_VERSION 0xff000017
+#define QUICLY_PROTOCOL_VERSION 0xff000018
 
 #define QUICLY_PACKET_IS_INITIAL(first_byte) (((first_byte)&0xf0) == 0xc0)
 

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -541,6 +541,8 @@ inline int quicly_decode_max_streams_frame(const uint8_t **src, const uint8_t *e
 {
     if ((frame->count = quicly_decodev(src, end)) == UINT64_MAX)
         return QUICLY_TRANSPORT_ERROR_FRAME_ENCODING;
+    if (frame->count > (uint64_t)1 << 60)
+        return QUICLY_TRANSPORT_ERROR_FRAME_ENCODING;
     return 0;
 }
 
@@ -586,6 +588,8 @@ inline uint8_t *quicly_encode_streams_blocked_frame(uint8_t *dst, int uni, uint6
 inline int quicly_decode_streams_blocked_frame(const uint8_t **src, const uint8_t *end, quicly_streams_blocked_frame_t *frame)
 {
     if ((frame->count = quicly_decodev(src, end)) == UINT64_MAX)
+        return QUICLY_TRANSPORT_ERROR_FRAME_ENCODING;
+    if (frame->count > (uint64_t)1 << 60)
         return QUICLY_TRANSPORT_ERROR_FRAME_ENCODING;
     return 0;
 }

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -664,6 +664,8 @@ inline int quicly_decode_new_token_frame(const uint8_t **src, const uint8_t *end
     uint64_t token_len;
     if ((token_len = quicly_decodev(src, end)) == UINT64_MAX)
         goto Error;
+    if (token_len == 0)
+        goto Error;
     if ((uint64_t)(end - *src) < token_len)
         goto Error;
     frame->token = ptls_iovec_init(*src, (size_t)token_len);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3993,8 +3993,8 @@ static int handle_payload(quicly_conn_t *conn, size_t epoch, const uint8_t *_src
         FRAME( retire_connection_id ,  0 ,  0 ,  0 ,  1 ,             1 ),
         FRAME( path_challenge       ,  0 ,  1 ,  0 ,  1 ,             1 ),
         FRAME( path_response        ,  0 ,  0 ,  0 ,  1 ,             1 ),
-        FRAME( transport_close      ,  1 ,  1 ,  1 ,  1 ,             1 ),
-        FRAME( application_close    ,  0 ,  1 ,  0 ,  1 ,             1 )
+        FRAME( transport_close      ,  1 ,  1 ,  1 ,  1 ,             0 ),
+        FRAME( application_close    ,  0 ,  1 ,  0 ,  1 ,             0 )
         /*   +----------------------+----+----+----+----+---------------+ */
 #undef FRAME
     };

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3966,7 +3966,7 @@ static int handle_payload(quicly_conn_t *conn, size_t epoch, const uint8_t *_src
          *   |                      | IN | 0R | HS | 1R |               |
          *   +----------------------+----+----+----+----+---------------+ */
         FRAME( padding              ,  1 ,  1 ,  1 ,  1 ,             0 ), /* 0 */
-        FRAME( ping                 ,  0 ,  1 ,  0 ,  1 ,             1 ),
+        FRAME( ping                 ,  1 ,  1 ,  1 ,  1 ,             1 ),
         FRAME( ack                  ,  1 ,  0 ,  1 ,  1 ,             0 ),
         FRAME( ack                  ,  1 ,  0 ,  1 ,  1 ,             0 ),
         FRAME( reset_stream         ,  0 ,  1 ,  0 ,  1 ,             1 ),

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -51,8 +51,8 @@ subtest "version-negotiation" => sub {
     is $resp, "hello world\n";
     my $events = slurp_file("$tempdir/events");
     if ($events =~ /"type":"connect",.*"version":(\d+)(?:.|\n)*"type":"version-switch",.*"new-version":(\d+)/m) {
-        is $2, 0xff000017;
-        isnt $1, 0xff000017;
+        is $2, 0xff000018;
+        isnt $1, 0xff000018;
     } else {
         fail "no quic-version-switch event";
         diag $events;


### PR DESCRIPTION
The leftovers are:
* support ClientHello spanning across multiple packets
* stateless reset is detected per-datagram, not per-packet (which we do not care to fix)