### PR TITLE
client Initial may not fit into single datagram

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -264,6 +264,10 @@ struct st_quicly_context_t {
      */
     unsigned is_clustered : 1;
     /**
+     * expand client hello so that it does not fit into one datagram
+     */
+    unsigned expand_client_hello : 1;
+    /**
      * callback for allocating memory for raw packet
      */
     quicly_packet_allocator_t *packet_allocator;
@@ -779,7 +783,7 @@ int quicly_is_destination(quicly_conn_t *conn, struct sockaddr *dest_addr, struc
  *
  */
 int quicly_encode_transport_parameter_list(ptls_buffer_t *buf, int is_client, const quicly_transport_parameters_t *params,
-                                           const quicly_cid_t *odcid, const void *stateless_reset_token);
+                                           const quicly_cid_t *odcid, const void *stateless_reset_token, int expand);
 /**
  *
  */

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -36,6 +36,7 @@ const quicly_context_t quicly_spec_context = {
     },
     0, /* enforce_version_negotiation */
     0, /* is_clustered */
+    0, /* enlarge_client_hello */
     &quicly_default_packet_allocator,
     NULL,
     NULL, /* on_stream_open */
@@ -58,6 +59,7 @@ const quicly_context_t quicly_performant_context = {
     },
     0, /* enforce_version_negotiation */
     0, /* is_clustered */
+    0, /* enlarge_client_hello */
     &quicly_default_packet_allocator,
     NULL,
     NULL, /* on_stream_open */

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -69,6 +69,17 @@ subtest "retry" => sub {
     }, "CH deemed lost in response to retry";
 };
 
+subtest "large-client-hello" => sub {
+    my $guard = spawn_server();
+    my $resp = `$cli -E -e $tempdir/events -p /12 127.0.0.1 $port 2> /dev/null`;
+    is $resp, "hello world\n";
+    my $events = slurp_file("$tempdir/events");
+    complex $events, sub {
+        my $before_receive = (split /"receive"/, $_)[0];
+        $before_receive =~ /"stream-send".*?\n.*?"stream-send"/s;
+    };
+};
+
 unlink "$tempdir/session";
 
 subtest "0-rtt" => sub {


### PR DESCRIPTION
Changes:
* add a flag that instructs quicly to expand CH to more than 1 MTU
* in cli command, expose the flag as `-E` option
* add unit test

Unexpectedly, no change was required on the server-side, as `quicly_accept` was building the connection state after the transport layer extracts the CRYPTO stream data, but never checked if picotls was returning some data in response (the return code from picotls is 514 (in-progress) either when complete or partial Client Hello is provided).

Closes #220.