### PR TITLE
Encryption offloading API : make structs and macro public, add getters functions

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -56,6 +56,10 @@ extern "C" {
 #define QUICLY_STATELESS_RESET_TOKEN_LEN 16
 #define QUICLY_STATELESS_RESET_PACKET_MIN_LEN 39
 
+#define QUICLY_MAX_PN_SIZE 4  /* maximum defined by the RFC used for calculating header protection sampling offset */
+#define QUICLY_KEY_PHASE_BIT 0x4
+#define QUICLY_SEND_PN_SIZE 2 /* size of PN used for sending */
+
 typedef union st_quicly_address_t {
     struct sockaddr sa;
     struct sockaddr_in sin;
@@ -74,6 +78,7 @@ typedef struct st_quicly_conn_t quicly_conn_t;
 typedef struct st_quicly_stream_t quicly_stream_t;
 typedef struct st_quicly_send_context_t quicly_send_context_t;
 typedef struct st_quicly_address_token_plaintext_t quicly_address_token_plaintext_t;
+typedef struct st_quicly_pn_space_t quicly_pn_space_t;
 
 #define QUICLY_CALLBACK_TYPE0(ret, name)                                                                                           \
     typedef struct st_quicly_##name##_t {                                                                                          \
@@ -330,6 +335,26 @@ typedef enum {
 struct st_quicly_conn_streamgroup_state_t {
     uint32_t num_streams;
     quicly_stream_id_t next_stream_id;
+};
+
+
+struct st_quicly_pn_space_t {
+    /**
+     * acks to be sent to peer
+     */
+    quicly_ranges_t ack_queue;
+    /**
+     * time at when the largest pn in the ack_queue has been received (or INT64_MAX if none)
+     */
+    int64_t largest_pn_received_at;
+    /**
+     *
+     */
+    uint64_t next_expected_packet_number;
+    /**
+     * packet count before ack is sent
+     */
+    uint32_t unacked_count;
 };
 
 /**

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -713,6 +713,18 @@ static quicly_state_t quicly_get_state(quicly_conn_t *conn);
 /**
  *
  */
+ptls_cipher_context_t *quicly_get_conn_cipher_context(quicly_conn_t *conn, int packet_type);
+/**
+ *
+ */
+ptls_aead_context_t **quicly_get_conn_aead_context(quicly_conn_t *conn, int packet_type);
+/**
+ *
+ */
+struct st_quicly_pn_space_t **quicly_get_conn_pn_space(quicly_conn_t *conn, int packet_type);
+/**
+ *
+ */
 int quicly_connection_is_ready(quicly_conn_t *conn);
 /**
  *

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -878,6 +878,81 @@ int quicly_get_stats(quicly_conn_t *conn, quicly_stats_t *stats)
     return 0;
 }
 
+ptls_cipher_context_t *quicly_get_conn_cipher_context(quicly_conn_t *conn, int packet_type)
+{
+    if (!conn)
+      return NULL;
+    switch(packet_type)
+    {
+      case QUICLY_PACKET_TYPE_INITIAL:
+        if (conn->initial)
+          return conn->initial->cipher.ingress.header_protection;
+        return NULL;
+      case QUICLY_PACKET_TYPE_HANDSHAKE:
+        if (conn->handshake)
+          return conn->handshake->cipher.ingress.header_protection;
+        return NULL;
+      case QUICLY_PACKET_TYPE_0RTT:
+        if (conn->application)
+          return conn->application->cipher.ingress.header_protection.zero_rtt;
+        return NULL;
+      case -1:
+        if (conn->application)
+          return conn->application->cipher.ingress.header_protection.one_rtt;
+        return NULL;
+      default:
+        return NULL;
+    }
+}
+
+ptls_aead_context_t **quicly_get_conn_aead_context(quicly_conn_t *conn, int packet_type)
+{
+    if (!conn)
+      return NULL;
+    switch(packet_type)
+    {
+      case QUICLY_PACKET_TYPE_INITIAL:
+        if (conn->initial)
+          return &conn->initial->cipher.ingress.aead;
+       return NULL;
+      case QUICLY_PACKET_TYPE_HANDSHAKE:
+        if (conn->handshake)
+          return &conn->handshake->cipher.ingress.aead;
+       return NULL;
+      case QUICLY_PACKET_TYPE_0RTT:
+      case -1:
+        if (conn->application)
+         return conn->application->cipher.ingress.aead;
+       return NULL;
+      default:
+        return NULL;
+    }
+}
+
+struct st_quicly_pn_space_t **quicly_get_conn_pn_space(quicly_conn_t *conn, int packet_type)
+{
+    if (!conn)
+      return NULL;
+    switch(packet_type)
+    {
+      case QUICLY_PACKET_TYPE_INITIAL:
+        if (conn->initial)
+          return (void*)&conn->initial;
+       return NULL;
+      case QUICLY_PACKET_TYPE_HANDSHAKE:
+        if (conn->handshake)
+          return (void*)&conn->handshake;
+       return NULL;
+      case QUICLY_PACKET_TYPE_0RTT:
+      case -1:
+        if (conn->application)
+         return (void*)&conn->application;
+       return NULL;
+      default:
+        return NULL;
+    }
+}
+
 quicly_stream_id_t quicly_get_ingress_max_streams(quicly_conn_t *conn, int uni)
 {
     quicly_maxsender_t *maxsender = uni ? conn->ingress.max_streams.uni : conn->ingress.max_streams.bidi;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -44,7 +44,6 @@
 #define QUICLY_QUIC_BIT 0x40
 #define QUICLY_LONG_HEADER_RESERVED_BITS 0xc
 #define QUICLY_SHORT_HEADER_RESERVED_BITS 0x18
-#define QUICLY_KEY_PHASE_BIT 0x4
 
 #define QUICLY_PACKET_TYPE_INITIAL (QUICLY_LONG_HEADER_BIT | QUICLY_QUIC_BIT | 0)
 #define QUICLY_PACKET_TYPE_0RTT (QUICLY_LONG_HEADER_BIT | QUICLY_QUIC_BIT | 0x10)
@@ -53,9 +52,6 @@
 #define QUICLY_PACKET_TYPE_BITMASK 0xf0
 
 #define QUICLY_MIN_INITIAL_DCID_LEN 8
-
-#define QUICLY_MAX_PN_SIZE 4  /* maximum defined by the RFC used for calculating header protection sampling offset */
-#define QUICLY_SEND_PN_SIZE 2 /* size of PN used for sending */
 
 #define QUICLY_TLS_EXTENSION_TYPE_TRANSPORT_PARAMETERS 0xffa5
 #define QUICLY_TRANSPORT_PARAMETER_ID_ORIGINAL_CONNECTION_ID 0
@@ -121,25 +117,6 @@ struct st_quicly_pending_path_challenge_t {
     struct st_quicly_pending_path_challenge_t *next;
     uint8_t is_response;
     uint8_t data[QUICLY_PATH_CHALLENGE_DATA_LEN];
-};
-
-struct st_quicly_pn_space_t {
-    /**
-     * acks to be sent to peer
-     */
-    quicly_ranges_t ack_queue;
-    /**
-     * time at when the largest pn in the ack_queue has been received (or INT64_MAX if none)
-     */
-    int64_t largest_pn_received_at;
-    /**
-     *
-     */
-    uint64_t next_expected_packet_number;
-    /**
-     * packet count before ack is sent
-     */
-    uint32_t unacked_count;
 };
 
 struct st_quicly_handshake_space_t {


### PR DESCRIPTION
To be able to use the offloading API #214 we need to move some structs and macros to quicly.h.
We also need getters to retrieve pointers to ciphers structs related to a connection.