### PR TITLE
Implements key update

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -299,6 +299,10 @@ struct st_quicly_context_t {
      *
      */
     quicly_generate_resumption_token_t *generate_resumption_token;
+    /**
+     * number of packets that can be sent without a key update
+     */
+    uint64_t max_packets_per_key;
 };
 
 /**

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -22,6 +22,8 @@
 #include <sys/time.h>
 #include "quicly/defaults.h"
 
+#define DEFAULT_MAX_PACKETS_PER_KEY 16777216
+
 /* profile that employs IETF specified values */
 const quicly_context_t quicly_spec_context = {
     NULL,                   /* tls */
@@ -42,7 +44,10 @@ const quicly_context_t quicly_spec_context = {
     NULL, /* on_stream_open */
     &quicly_default_stream_scheduler,
     NULL, /* on_conn_close */
-    &quicly_default_now
+    &quicly_default_now,
+    NULL,
+    NULL,
+    DEFAULT_MAX_PACKETS_PER_KEY
 };
 
 /* profile with a focus on reducing latency for the HTTP use case */
@@ -65,7 +70,10 @@ const quicly_context_t quicly_performant_context = {
     NULL, /* on_stream_open */
     &quicly_default_stream_scheduler,
     NULL, /* on_conn_close */
-    &quicly_default_now
+    &quicly_default_now,
+    NULL,
+    NULL,
+    DEFAULT_MAX_PACKETS_PER_KEY
 };
 
 static quicly_datagram_t *default_alloc_packet(quicly_packet_allocator_t *self, size_t payloadsize)

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1205,7 +1205,7 @@ static int apply_peer_transport_params(quicly_conn_t *conn)
     return 0;
 }
 
-static int update_1rtt_key(ptls_cipher_suite_t *cipher, ptls_aead_context_t **aead, int is_enc, uint8_t *secret)
+static int update_1rtt_key(ptls_cipher_suite_t *cipher, int is_enc, ptls_aead_context_t **aead, uint8_t *secret)
 {
     uint8_t new_secret[PTLS_MAX_DIGEST_SIZE];
     ptls_aead_context_t *new_aead = NULL;
@@ -1241,7 +1241,7 @@ static int update_1rtt_egress_key(quicly_conn_t *conn)
     int ret;
 
     /* generate next AEAD key, and increment key phase if it succeeds */
-    if ((ret = update_1rtt_key(cipher, &space->cipher.egress.key.aead, 1, space->cipher.egress.secret)) != 0)
+    if ((ret = update_1rtt_key(cipher, 1, &space->cipher.egress.key.aead, space->cipher.egress.secret)) != 0)
         return ret;
     ++space->cipher.egress.key_phase;
 
@@ -1866,7 +1866,7 @@ static int decrypt_packet(quicly_conn_t *conn, ptls_cipher_context_t *header_pro
             struct st_quicly_application_space_t *space = conn->application;
             ptls_cipher_suite_t *cipher = ptls_get_cipher(conn->crypto.tls);
             int ret;
-            if ((ret = update_1rtt_key(cipher, &space->cipher.ingress.aead[aead_index], 0, space->cipher.ingress.secret)) != 0)
+            if ((ret = update_1rtt_key(cipher, 0, &space->cipher.ingress.aead[aead_index], space->cipher.ingress.secret)) != 0)
                 return ret;
             ++space->cipher.ingress.key_phase.prepared;
             QUICLY_PROBE(CRYPTO_RECEIVE_KEY_UPDATE_PREPARE, conn, space->cipher.ingress.key_phase.prepared,

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -157,9 +157,28 @@ struct st_quicly_application_space_t {
             struct {
                 ptls_cipher_context_t *zero_rtt, *one_rtt;
             } header_protection;
-            ptls_aead_context_t *aead[2];
+            ptls_aead_context_t *aead[2]; /* 0-RTT uses aead[1], 1-RTT uses aead[key_phase] */
+            uint8_t secret[PTLS_MAX_DIGEST_SIZE];
+            struct {
+                uint64_t prepared;
+                uint64_t decrypted;
+            } key_phase;
         } ingress;
-        struct st_quicly_cipher_context_t egress;
+        struct {
+            struct st_quicly_cipher_context_t key;
+            uint8_t secret[PTLS_MAX_DIGEST_SIZE];
+            uint64_t key_phase;
+            struct {
+                /**
+                 * PN at which key update was initiated. Set to UINT64_MAX once key update is acked.
+                 */
+                uint64_t last;
+                /**
+                 * PN at which key update should be initiated. Set to UINT64_MAX when key update cannot be initiated.
+                 */
+                uint64_t next;
+            } key_update_pn;
+        } egress;
     } cipher;
     int one_rtt_writable;
 };
@@ -736,11 +755,12 @@ int crypto_stream_receive(quicly_stream_t *stream, size_t off, const void *src, 
             goto Exit;
         }
         /* drop 0-RTT write key if 0-RTT is rejected by peer */
-        if (conn->application != NULL && !conn->application->one_rtt_writable && conn->application->cipher.egress.aead != NULL) {
+        if (conn->application != NULL && !conn->application->one_rtt_writable &&
+            conn->application->cipher.egress.key.aead != NULL) {
             assert(quicly_is_client(conn));
             if (conn->crypto.handshake_properties.client.early_data_acceptance == PTLS_EARLY_DATA_REJECTED) {
-                dispose_cipher(&conn->application->cipher.egress);
-                conn->application->cipher.egress = (struct st_quicly_cipher_context_t){NULL};
+                dispose_cipher(&conn->application->cipher.egress.key);
+                conn->application->cipher.egress.key = (struct st_quicly_cipher_context_t){NULL};
                 discard_sentmap_by_epoch(
                     conn, 1u << QUICLY_EPOCH_1RTT); /* retire all packets with ack_epoch == 3; they are all 0-RTT packets */
             }
@@ -1055,15 +1075,18 @@ static int setup_cipher(ptls_cipher_context_t **hp_ctx, ptls_aead_context_t **ae
     uint8_t hpkey[PTLS_MAX_SECRET_SIZE];
     int ret;
 
-    *hp_ctx = NULL;
+    if (hp_ctx != NULL)
+        *hp_ctx = NULL;
     *aead_ctx = NULL;
 
-    if ((ret = ptls_hkdf_expand_label(hash, hpkey, aead->ctr_cipher->key_size, ptls_iovec_init(secret, hash->digest_size),
-                                      "quic hp", ptls_iovec_init(NULL, 0), NULL)) != 0)
-        goto Exit;
-    if ((*hp_ctx = ptls_cipher_new(aead->ctr_cipher, is_enc, hpkey)) == NULL) {
-        ret = PTLS_ERROR_NO_MEMORY;
-        goto Exit;
+    if (hp_ctx != NULL) {
+        if ((ret = ptls_hkdf_expand_label(hash, hpkey, aead->ctr_cipher->key_size, ptls_iovec_init(secret, hash->digest_size),
+                                          "quic hp", ptls_iovec_init(NULL, 0), NULL)) != 0)
+            goto Exit;
+        if ((*hp_ctx = ptls_cipher_new(aead->ctr_cipher, is_enc, hpkey)) == NULL) {
+            ret = PTLS_ERROR_NO_MEMORY;
+            goto Exit;
+        }
     }
     if ((*aead_ctx = ptls_aead_new(aead, hash, is_enc, secret, AEAD_BASE_LABEL)) == NULL) {
         ret = PTLS_ERROR_NO_MEMORY;
@@ -1112,8 +1135,9 @@ static void free_application_space(struct st_quicly_application_space_t **space)
         DISPOSE_INGRESS(aead[0], ptls_aead_free);
         DISPOSE_INGRESS(aead[1], ptls_aead_free);
 #undef DISPOSE_INGRESS
-        if ((*space)->cipher.egress.aead != NULL)
-            dispose_cipher(&(*space)->cipher.egress);
+        if ((*space)->cipher.egress.key.aead != NULL)
+            dispose_cipher(&(*space)->cipher.egress.key);
+        memset((*space)->cipher.egress.secret, 0, sizeof((*space)->cipher.egress.secret));
         do_free_pn_space(&(*space)->super);
         *space = NULL;
     }
@@ -1123,6 +1147,11 @@ static int setup_application_space(quicly_conn_t *conn)
 {
     if ((conn->application = (void *)alloc_pn_space(sizeof(struct st_quicly_application_space_t))) == NULL)
         return PTLS_ERROR_NO_MEMORY;
+
+    /* prohibit key-update until receiving an ACK for an 1-RTT packet */
+    conn->application->cipher.egress.key_update_pn.last = 0;
+    conn->application->cipher.egress.key_update_pn.next = UINT64_MAX;
+
     return create_handshake_flow(conn, QUICLY_EPOCH_1RTT);
 }
 
@@ -1172,6 +1201,56 @@ static int apply_peer_transport_params(quicly_conn_t *conn)
         return ret;
     if ((ret = update_max_streams(&conn->egress.max_streams.bidi, conn->super.peer.transport_params.max_streams_bidi)) != 0)
         return ret;
+
+    return 0;
+}
+
+static int update_1rtt_key(ptls_cipher_suite_t *cipher, ptls_aead_context_t **aead, int is_enc, uint8_t *secret)
+{
+    uint8_t new_secret[PTLS_MAX_DIGEST_SIZE];
+    ptls_aead_context_t *new_aead = NULL;
+    int ret;
+
+    /* generate next AEAD key */
+    if ((ret = ptls_hkdf_expand_label(cipher->hash, new_secret, cipher->hash->digest_size,
+                                      ptls_iovec_init(secret, cipher->hash->digest_size), "quic ku", ptls_iovec_init(NULL, 0),
+                                      NULL)) != 0)
+        goto Exit;
+    if ((ret = setup_cipher(NULL, &new_aead, cipher->aead, cipher->hash, is_enc, new_secret)) != 0)
+        goto Exit;
+
+    /* success! update AEAD and secret */
+    if (*aead != NULL)
+        ptls_aead_free(*aead);
+    *aead = new_aead;
+    new_aead = NULL;
+    memcpy(secret, new_secret, cipher->hash->digest_size);
+
+    ret = 0;
+Exit:
+    if (new_aead != NULL)
+        ptls_aead_free(new_aead);
+    ptls_clear_memory(new_secret, cipher->hash->digest_size);
+    return ret;
+}
+
+static int update_1rtt_egress_key(quicly_conn_t *conn)
+{
+    struct st_quicly_application_space_t *space = conn->application;
+    ptls_cipher_suite_t *cipher = ptls_get_cipher(conn->crypto.tls);
+    int ret;
+
+    /* generate next AEAD key, and increment key phase if it succeeds */
+    if ((ret = update_1rtt_key(cipher, &space->cipher.egress.key.aead, 1, space->cipher.egress.secret)) != 0)
+        return ret;
+    ++space->cipher.egress.key_phase;
+
+    /* signal that we are waiting for an ACK */
+    space->cipher.egress.key_update_pn.last = conn->egress.packet_number;
+    space->cipher.egress.key_update_pn.next = UINT64_MAX;
+
+    QUICLY_PROBE(CRYPTO_SEND_KEY_UPDATE, conn, space->cipher.egress.key_phase,
+                 QUICLY_PROBE_HEXDUMP(space->cipher.egress.secret, cipher->hash->digest_size));
 
     return 0;
 }
@@ -1607,8 +1686,7 @@ static int client_collected_extensions(ptls_t *tls, ptls_handshake_properties_t 
     quicly_cid_t odcid;
 
     /* decode and validate */
-    if ((ret = quicly_decode_transport_parameter_list(&params, &odcid, conn->super.peer.stateless_reset._buf, 1, src, end)) !=
-        0)
+    if ((ret = quicly_decode_transport_parameter_list(&params, &odcid, conn->super.peer.stateless_reset._buf, 1, src, end)) != 0)
         goto Exit;
     if (odcid.len != conn->retry_odcid.len || memcmp(odcid.cid, conn->retry_odcid.cid, odcid.len) != 0) {
         ret = QUICLY_TRANSPORT_ERROR_TRANSPORT_PARAMETER;
@@ -1754,8 +1832,11 @@ Exit:
     return ret;
 }
 
-static ptls_iovec_t decrypt_packet(ptls_cipher_context_t *header_protection, ptls_aead_context_t **aead, uint64_t *next_expected_pn,
-                                   quicly_decoded_packet_t *packet, uint64_t *pn)
+/**
+ * @param aead pointer to AEAD context, or a 2-element array of AEAD contexts in case of 1-RTT
+ */
+static int decrypt_packet(quicly_conn_t *conn, ptls_cipher_context_t *header_protection, ptls_aead_context_t **aead,
+                          uint64_t *next_expected_pn, quicly_decoded_packet_t *packet, uint64_t *pn, ptls_iovec_t *payload)
 {
     size_t encrypted_len = packet->octets.len - packet->encrypted_off;
     uint8_t hpmask[5] = {0};
@@ -1764,7 +1845,7 @@ static ptls_iovec_t decrypt_packet(ptls_cipher_context_t *header_protection, ptl
 
     /* decipher the header protection, as well as obtaining pnbits, pnlen */
     if (encrypted_len < header_protection->algo->iv_size + QUICLY_MAX_PN_SIZE)
-        goto Error;
+        return QUICLY_ERROR_PACKET_IGNORED;
     ptls_cipher_init(header_protection, packet->octets.base + packet->encrypted_off + QUICLY_MAX_PN_SIZE);
     ptls_cipher_encrypt(header_protection, hpmask, hpmask, sizeof(hpmask));
     packet->octets.base[0] ^= hpmask[0] & (QUICLY_PACKET_IS_LONG_HEADER(packet->octets.base[0]) ? 0xf : 0x1f);
@@ -1778,10 +1859,20 @@ static ptls_iovec_t decrypt_packet(ptls_cipher_context_t *header_protection, ptl
     if (QUICLY_PACKET_IS_LONG_HEADER(packet->octets.base[0])) {
         aead_index = 0;
     } else {
-        /* note: aead index 0 is used by 0-RTT */
-        aead_index = (packet->octets.base[0] & QUICLY_KEY_PHASE_BIT) == 0;
-        if (aead[aead_index] == NULL)
-            goto Error;
+        aead_index = (packet->octets.base[0] & QUICLY_KEY_PHASE_BIT) != 0;
+        if (aead[aead_index] == NULL) {
+            /* generate next key */
+        Retry_1RTT : {
+            struct st_quicly_application_space_t *space = conn->application;
+            ptls_cipher_suite_t *cipher = ptls_get_cipher(conn->crypto.tls);
+            int ret;
+            if ((ret = update_1rtt_key(cipher, &space->cipher.ingress.aead[aead_index], 0, space->cipher.ingress.secret)) != 0)
+                return ret;
+            ++space->cipher.ingress.key_phase.prepared;
+            QUICLY_PROBE(CRYPTO_RECEIVE_KEY_UPDATE_PREPARE, conn, space->cipher.ingress.key_phase.prepared,
+                         QUICLY_PROBE_HEXDUMP(space->cipher.ingress.secret, cipher->hash->digest_size));
+        }
+        }
     }
 
     /* AEAD */
@@ -1789,18 +1880,48 @@ static ptls_iovec_t decrypt_packet(ptls_cipher_context_t *header_protection, ptl
     size_t aead_off = packet->encrypted_off + pnlen, ptlen;
     if ((ptlen = ptls_aead_decrypt(aead[aead_index], packet->octets.base + aead_off, packet->octets.base + aead_off,
                                    packet->octets.len - aead_off, *pn, packet->octets.base, aead_off)) == SIZE_MAX) {
+        /* retry if necessary */
+        if (!QUICLY_PACKET_IS_LONG_HEADER(packet->octets.base[0])) {
+            struct st_quicly_application_space_t *space = conn->application;
+            if (space->cipher.ingress.key_phase.decrypted == space->cipher.ingress.key_phase.prepared &&
+                space->cipher.ingress.key_phase.decrypted % 2 != aead_index)
+                goto Retry_1RTT;
+        }
         if (QUICLY_DEBUG)
             fprintf(stderr, "%s: aead decryption failure (pn: %" PRIu64 ")\n", __FUNCTION__, *pn);
-        goto Error;
+        return QUICLY_ERROR_PACKET_IGNORED;
     }
 
-    /* check reserved bits after AEAD decryption */
+    /* update the confirmed key phase and also the egress key phase, if necessary */
+    if (!QUICLY_PACKET_IS_LONG_HEADER(packet->octets.base[0])) {
+        struct st_quicly_application_space_t *space = conn->application;
+        if (space->cipher.ingress.key_phase.prepared != space->cipher.ingress.key_phase.decrypted &&
+            space->cipher.ingress.key_phase.prepared % 2 == aead_index) {
+            ptls_cipher_suite_t *cipher = ptls_get_cipher(conn->crypto.tls);
+            assert(space->cipher.ingress.key_phase.prepared == space->cipher.ingress.key_phase.decrypted + 1);
+            space->cipher.ingress.key_phase.decrypted = space->cipher.ingress.key_phase.prepared;
+            QUICLY_PROBE(CRYPTO_RECEIVE_KEY_UPDATE, conn, space->cipher.ingress.key_phase.decrypted,
+                         QUICLY_PROBE_HEXDUMP(space->cipher.ingress.secret, cipher->hash->digest_size));
+            if (space->cipher.egress.key_phase < space->cipher.ingress.key_phase.decrypted) {
+                int ret;
+                if ((ret = update_1rtt_egress_key(conn)) != 0)
+                    return ret;
+            }
+        }
+    }
+
+    /* consistency checks after AEAD decryption */
     if ((packet->octets.base[0] & (QUICLY_PACKET_IS_LONG_HEADER(packet->octets.base[0]) ? QUICLY_LONG_HEADER_RESERVED_BITS
                                                                                         : QUICLY_SHORT_HEADER_RESERVED_BITS)) !=
         0) {
         if (QUICLY_DEBUG)
             fprintf(stderr, "%s: non-zero reserved bits (pn: %" PRIu64 ")\n", __FUNCTION__, *pn);
-        goto Error;
+        return QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION;
+    }
+    if (ptlen == 0) {
+        if (QUICLY_DEBUG)
+            fprintf(stderr, "%s: payload length is zero (pn: %" PRIu64 ")\n", __FUNCTION__, *pn);
+        return QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION;
     }
 
     if (QUICLY_DEBUG) {
@@ -1811,10 +1932,8 @@ static ptls_iovec_t decrypt_packet(ptls_cipher_context_t *header_protection, ptl
 
     if (*next_expected_pn <= *pn)
         *next_expected_pn = *pn + 1;
-    return ptls_iovec_init(packet->octets.base + aead_off, ptlen);
-
-Error:
-    return ptls_iovec_init(NULL, 0);
+    *payload = ptls_iovec_init(packet->octets.base + aead_off, ptlen);
+    return 0;
 }
 
 static int on_ack_ack(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent, quicly_sentmap_event_t event)
@@ -2147,14 +2266,24 @@ static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, int
         s->dst = s->target.packet->data.base + max_size;
     }
 
+    /* encode packet size, packet number, key-phase */
     if (QUICLY_PACKET_IS_LONG_HEADER(*s->target.first_byte_at)) {
         uint16_t length = s->dst - s->dst_payload_from + s->target.cipher->aead->algo->tag_size + QUICLY_SEND_PN_SIZE;
         /* length is always 2 bytes, see _do_prepare_packet */
         length |= 0x4000;
         quicly_encode16(s->dst_payload_from - QUICLY_SEND_PN_SIZE - 2, length);
+    } else {
+        if (conn->egress.packet_number >= conn->application->cipher.egress.key_update_pn.next) {
+            int ret;
+            if ((ret = update_1rtt_egress_key(conn)) != 0)
+                return ret;
+        }
+        if ((conn->application->cipher.egress.key_phase & 1) != 0)
+            *s->target.first_byte_at |= QUICLY_KEY_PHASE_BIT;
     }
     quicly_encode16(s->dst_payload_from - QUICLY_SEND_PN_SIZE, (uint16_t)conn->egress.packet_number);
 
+    /* AEAD protection */
     s->dst = s->dst_payload_from + ptls_aead_encrypt(s->target.cipher->aead, s->dst_payload_from, s->dst_payload_from,
                                                      s->dst - s->dst_payload_from, conn->egress.packet_number,
                                                      s->target.first_byte_at, s->dst_payload_from - s->target.first_byte_at);
@@ -3058,10 +3187,10 @@ static int update_traffic_key_cb(ptls_update_traffic_key_t *self, ptls_t *tls, i
         if (conn->application == NULL && (ret = setup_application_space(conn)) != 0)
             return ret;
         if (is_enc) {
-            SELECT_CIPHER_CONTEXT(&conn->application->cipher.egress);
+            SELECT_CIPHER_CONTEXT(&conn->application->cipher.egress.key);
         } else {
             hp_slot = &conn->application->cipher.ingress.header_protection.zero_rtt;
-            aead_slot = &conn->application->cipher.ingress.aead[0];
+            aead_slot = &conn->application->cipher.ingress.aead[1];
         }
         break;
     case QUICLY_EPOCH_HANDSHAKE:
@@ -3069,21 +3198,25 @@ static int update_traffic_key_cb(ptls_update_traffic_key_t *self, ptls_t *tls, i
             return ret;
         SELECT_CIPHER_CONTEXT(is_enc ? &conn->handshake->cipher.egress : &conn->handshake->cipher.ingress);
         break;
-    case QUICLY_EPOCH_1RTT:
+    case QUICLY_EPOCH_1RTT: {
         if (is_enc)
             if ((ret = apply_peer_transport_params(conn)) != 0)
                 return ret;
         if (conn->application == NULL && (ret = setup_application_space(conn)) != 0)
             return ret;
+        uint8_t *secret_store;
         if (is_enc) {
-            if (conn->application->cipher.egress.aead != NULL)
-                dispose_cipher(&conn->application->cipher.egress);
-            SELECT_CIPHER_CONTEXT(&conn->application->cipher.egress);
+            if (conn->application->cipher.egress.key.aead != NULL)
+                dispose_cipher(&conn->application->cipher.egress.key);
+            SELECT_CIPHER_CONTEXT(&conn->application->cipher.egress.key);
+            secret_store = conn->application->cipher.egress.secret;
         } else {
             hp_slot = &conn->application->cipher.ingress.header_protection.one_rtt;
-            aead_slot = &conn->application->cipher.ingress.aead[1];
+            aead_slot = &conn->application->cipher.ingress.aead[0];
+            secret_store = conn->application->cipher.ingress.secret;
         }
-        break;
+        memcpy(secret_store, secret, cipher->hash->digest_size);
+    } break;
     default:
         assert(!"logic flaw");
         break;
@@ -3157,7 +3290,7 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
         goto Exit;
 
     /* send encrypted frames */
-    if (conn->application != NULL && (s->current.cipher = &conn->application->cipher.egress)->header_protection != NULL) {
+    if (conn->application != NULL && (s->current.cipher = &conn->application->cipher.egress.key)->header_protection != NULL) {
         if (conn->application->one_rtt_writable) {
             s->current.first_byte = QUICLY_QUIC_BIT; /* short header */
             /* acks */
@@ -3266,7 +3399,7 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
             destroy_all_streams(conn, 0, 0); /* delayed until the emission of CONNECTION_CLOSE frame to allow quicly_close to be
                                               * called from a stream handler */
             if (conn->application != NULL && conn->application->one_rtt_writable) {
-                s.current.cipher = &conn->application->cipher.egress;
+                s.current.cipher = &conn->application->cipher.egress.key;
                 s.current.first_byte = QUICLY_QUIC_BIT;
             } else if (conn->handshake != NULL && (s.current.cipher = &conn->handshake->cipher.egress)->aead != NULL) {
                 s.current.first_byte = QUICLY_PACKET_TYPE_HANDSHAKE;
@@ -3559,6 +3692,14 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
                         }
                         if ((ret = quicly_sentmap_update(&conn->egress.sentmap, &iter, QUICLY_SENTMAP_EVENT_ACKED, conn)) != 0)
                             return ret;
+                        if (sent->ack_epoch == QUICLY_EPOCH_1RTT) {
+                            struct st_quicly_application_space_t *space = conn->application;
+                            if (space->cipher.egress.key_update_pn.last <= packet_number) {
+                                space->cipher.egress.key_update_pn.last = UINT64_MAX;
+                                space->cipher.egress.key_update_pn.next =
+                                    conn->egress.packet_number + conn->super.ctx->max_packets_per_key;
+                            }
+                        }
                     } else {
                         quicly_sentmap_skip(&iter);
                     }
@@ -4077,11 +4218,9 @@ int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *
                                         0)) != 0)
         goto Exit;
     next_expected_pn = 0; /* is this correct? do we need to take care of underflow? */
-    if ((payload = decrypt_packet(ingress_cipher.header_protection, &ingress_cipher.aead, &next_expected_pn, packet, &pn)).base ==
-        NULL) {
-        ret = QUICLY_ERROR_PACKET_IGNORED;
+    if ((ret = decrypt_packet(NULL, ingress_cipher.header_protection, &ingress_cipher.aead, &next_expected_pn, packet, &pn,
+                              &payload)) != 0)
         goto Exit;
-    }
 
     /* create connection */
     if ((*conn = create_connection(ctx, NULL, src_addr, dest_addr, new_cid, handshake_properties)) == NULL) {
@@ -4244,7 +4383,7 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
                 ret = QUICLY_ERROR_PACKET_IGNORED;
                 goto Exit;
             }
-            aead = &conn->application->cipher.ingress.aead[0];
+            aead = &conn->application->cipher.ingress.aead[1];
             space = (void *)&conn->application;
             epoch = QUICLY_EPOCH_0RTT;
             break;
@@ -4253,7 +4392,7 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
             goto Exit;
         }
     } else {
-        /* first 1-RTT keys is key_phase 1, see doc-comment of cipher.ingress */
+        /* short header packet */
         if (conn->application == NULL ||
             (header_protection = conn->application->cipher.ingress.header_protection.one_rtt) == NULL) {
             ret = QUICLY_ERROR_PACKET_IGNORED;
@@ -4265,14 +4404,8 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     }
 
     /* decrypt */
-    if ((payload = decrypt_packet(header_protection, aead, &(*space)->next_expected_packet_number, packet, &pn)).base == NULL) {
-        ret = QUICLY_ERROR_PACKET_IGNORED;
+    if ((ret = decrypt_packet(conn, header_protection, aead, &(*space)->next_expected_packet_number, packet, &pn, &payload)) != 0)
         goto Exit;
-    }
-    if (payload.len == 0) {
-        ret = QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION;
-        goto Exit;
-    }
 
     QUICLY_PROBE(CRYPTO_DECRYPT, conn, pn, payload.base, payload.len);
     QUICLY_PROBE(QUICTRACE_RECV, conn, probe_now(), pn);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3705,6 +3705,7 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
                                 space->cipher.egress.key_update_pn.last = UINT64_MAX;
                                 space->cipher.egress.key_update_pn.next =
                                     conn->egress.packet_number + conn->super.ctx->max_packets_per_key;
+                                QUICLY_PROBE(CRYPTO_SEND_KEY_UPDATE_CONFIRMED, conn, space->cipher.egress.key_update_pn.next);
                             }
                         }
                     } else {

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -38,6 +38,9 @@ provider quicly {
     probe crypto_decrypt(struct st_quicly_conn_t *conn, uint64_t pn, const void *decrypted, size_t decrypted_len);
     probe crypto_handshake(struct st_quicly_conn_t *conn, int ret);
     probe crypto_update_secret(struct st_quicly_conn_t *conn, int is_enc, uint8_t epoch, const char *label, const char *secret);
+    probe crypto_send_key_update(struct st_quicly_conn_t *conn, uint64_t phase, const char *secret);
+    probe crypto_receive_key_update(struct st_quicly_conn_t *conn, uint64_t phase, const char *secret);
+    probe crypto_receive_key_update_prepare(struct st_quicly_conn_t *conn, uint64_t phase, const char *secret);
 
     probe packet_prepare(struct st_quicly_conn_t *conn, int64_t at, uint8_t first_octet, const char *dcid);
     probe packet_commit(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, size_t len, int ack_only);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -39,6 +39,7 @@ provider quicly {
     probe crypto_handshake(struct st_quicly_conn_t *conn, int ret);
     probe crypto_update_secret(struct st_quicly_conn_t *conn, int is_enc, uint8_t epoch, const char *label, const char *secret);
     probe crypto_send_key_update(struct st_quicly_conn_t *conn, uint64_t phase, const char *secret);
+    probe crypto_send_key_update_confirmed(struct st_quicly_conn_t *conn, uint64_t next_pn);
     probe crypto_receive_key_update(struct st_quicly_conn_t *conn, uint64_t phase, const char *secret);
     probe crypto_receive_key_update_prepare(struct st_quicly_conn_t *conn, uint64_t phase, const char *secret);
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -904,6 +904,7 @@ static void usage(const char *cmd)
            "  -c certificate-file\n"
            "  -k key-file               specifies the credentials to be used for running the\n"
            "                            server. If omitted, the command runs as a client.\n"
+           "  -K num-packets            perform key update every num-packets packets\n"
            "  -e event-log-file         file to log events\n"
            "  -E                        expand Client Hello (sends multiple client Initials)\n"
            "  -i interval               interval to reissue requests (in milliseconds)\n"
@@ -953,7 +954,7 @@ int main(int argc, char **argv)
         address_token_aead.dec = ptls_aead_new(&ptls_openssl_aes128gcm, &ptls_openssl_sha256, 0, secret, "");
     }
 
-    while ((ch = getopt(argc, argv, "a:C:c:k:Ee:i:I:l:M:m:Nnp:P:Rr:S:s:Vvx:X:h")) != -1) {
+    while ((ch = getopt(argc, argv, "a:C:c:k:K:Ee:i:I:l:M:m:Nnp:P:Rr:S:s:Vvx:X:h")) != -1) {
         switch (ch) {
         case 'a':
             assert(negotiated_protocols.count < sizeof(negotiated_protocols.list) / sizeof(negotiated_protocols.list[0]));
@@ -967,6 +968,12 @@ int main(int argc, char **argv)
             break;
         case 'k':
             load_private_key(ctx.tls, optarg);
+            break;
+        case 'K':
+            if (sscanf(optarg, "%" PRIu64, &ctx.max_packets_per_key) != 1) {
+                fprintf(stderr, "failed to parse key update interval: %s\n", optarg);
+                exit(1);
+            }
             break;
         case 'E':
             ctx.expand_client_hello = 1;

--- a/t/test.c
+++ b/t/test.c
@@ -231,7 +231,8 @@ static void test_vector(void)
     ok(quicly_decode_packet(&quic_ctx, &packet, datagram, sizeof(datagram)) == sizeof(datagram));
     ret = setup_initial_encryption(&ptls_openssl_aes128gcmsha256, &ingress, &egress, packet.cid.dest.encrypted, 0);
     ok(ret == 0);
-    ok(decrypt_packet(NULL, ingress.header_protection, &ingress.aead, &next_expected_pn, &packet, &pn, &payload) == 0);
+    ok(decrypt_packet(ingress.header_protection, aead_decrypt_fixed_key, ingress.aead, &next_expected_pn, &packet, &pn, &payload) ==
+       0);
     ok(pn == 2);
     ok(sizeof(expected_payload) <= payload.len);
     ok(memcmp(expected_payload, payload.base, sizeof(expected_payload)) == 0);

--- a/t/test.c
+++ b/t/test.c
@@ -231,8 +231,7 @@ static void test_vector(void)
     ok(quicly_decode_packet(&quic_ctx, &packet, datagram, sizeof(datagram)) == sizeof(datagram));
     ret = setup_initial_encryption(&ptls_openssl_aes128gcmsha256, &ingress, &egress, packet.cid.dest.encrypted, 0);
     ok(ret == 0);
-    payload = decrypt_packet(ingress.header_protection, &ingress.aead, &next_expected_pn, &packet, &pn);
-    ok(payload.base != NULL);
+    ok(decrypt_packet(NULL, ingress.header_protection, &ingress.aead, &next_expected_pn, &packet, &pn, &payload) == 0);
     ok(pn == 2);
     ok(sizeof(expected_payload) <= payload.len);
     ok(memcmp(expected_payload, payload.base, sizeof(expected_payload)) == 0);


### PR DESCRIPTION
cli has `-K` option that can be used for setting the number of packets an endpoint might emit before attempting to switch to the next key.