### PR TITLE
improve build instructions and add cpanfile to install deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,8 @@ matrix:
       env:
         - label=osx/x86-64
       before_install: &bs_osx
-        - curl -L https://cpanmin.us | sudo perl - App::cpanminus
-        - sudo cpanm --notest JSON
-        - sudo cpanm --notest Scope::Guard
-        - sudo cpanm --notest Test::TCP
+        - curl -L https://cpanmin.us | perl - --self-upgrade --sudo
+        - cpanm --sudo --installdeps --notest .
       script:
         - cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl .
         - make && make check

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ How to build
 
 ```
 % git submodule update --init --recursive
-% curl -L https://cpanmin.us | perl - --installdeps --notest .
+% curl -sL https://cpanmin.us | perl - --self-upgrade # add --sudo if needed
+% cpanm --installdeps --notest . # --sudo if needed
 % cmake .
 % make
 % make check
@@ -22,8 +23,6 @@ If you have OpenSSL installed in a non-standard directory, you can pass the loca
 ```
 % PKG_CONFIG_PATH=/path/to/openssl/lib/pkgconfig cmake .
 ```
-
-You need to delete `CMakeCache.txt` when you get an error [Undefined symbols for architecture x86_64: "_SSL_is_server"](https://github.com/h2o/h2o/issues/2093).
 
 Running quicly
 ---

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ How to build
 
 ```
 % git submodule update --init --recursive
+% curl -L https://cpanmin.us | perl - --installdeps --notest .
 % cmake .
 % make
 % make check
@@ -21,6 +22,8 @@ If you have OpenSSL installed in a non-standard directory, you can pass the loca
 ```
 % PKG_CONFIG_PATH=/path/to/openssl/lib/pkgconfig cmake .
 ```
+
+You need to delete `CMakeCache.txt` when you get an error [Undefined symbols for architecture x86_64: "_SSL_is_server"](https://github.com/h2o/h2o/issues/2093).
 
 Running quicly
 ---

--- a/README.md
+++ b/README.md
@@ -8,10 +8,22 @@ The software is licensed under the MIT License.
 How to build
 ---
 
+Install dependencies first:
+
+```
+# If you use system perl, use --sudo
+% curl -sL https://cpanmin.us | perl - --sudo --self-upgrade
+% cpanm --installdeps --notest --sudo .
+
+# Otherwise, you'd better omit --sudo
+% curl -sL https://cpanmin.us | perl - --self-upgrade
+% cpanm --installdeps --notest .
+```
+
+Then, build this project.
+
 ```
 % git submodule update --init --recursive
-% curl -sL https://cpanmin.us | perl - --self-upgrade # add --sudo if needed
-% cpanm --installdeps --notest . # --sudo if needed
 % cmake .
 % make
 % make check

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,6 @@
+#!perl
+# cpanm --installdeps --notest .
+
+requires 'JSON';
+requires 'Test::TCP';
+requires 'Scope::Guard';


### PR DESCRIPTION
* Add `cpanfile` to install Perl modules that are used in tests
* Update build instructions in `README.md` to install Perl modules
* Mention to a typical build error (at least on macOS), reported in https://github.com/h2o/h2o/issues/2093 