### PR TITLE
Ensure that the CID is lower than QUICLY_MAX_CID_LEN_V1

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -461,7 +461,7 @@ size_t quicly_decode_packet(quicly_context_t *ctx, quicly_decoded_packet_t *pack
         packet->cid.dest.encrypted.base = (uint8_t *)src;
         src += packet->cid.dest.encrypted.len;
         packet->cid.src.len = *src++;
-        if (src_end - src < packet->cid.src.len)
+        if (src_end - src < packet->cid.src.len || QUICLY_MAX_CID_LEN_V1 <= packet->cid.src.len)
             goto Error;
         packet->cid.src.base = (uint8_t *)src;
         src += packet->cid.src.len;


### PR DESCRIPTION
I believe that this is necessary so that the length used here: https://github.com/h2o/h2o/blob/master/lib/http3/common.c#L387 can't overflow the destination buffer