### PR TITLE
Cap amount of connection state

### DIFF
--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -200,7 +200,7 @@ typedef struct st_quicly_stop_sending_frame_t {
 
 static int quicly_decode_stop_sending_frame(const uint8_t **src, const uint8_t *end, quicly_stop_sending_frame_t *frame);
 
-#define QUICLY_ENCODE_ACK_MAX_BLOCKS 63 /* exclusive, see encode_ack_frame */
+#define QUICLY_ENCODE_ACK_MAX_BLOCKS 63
 uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t *ranges, uint64_t ack_delay);
 
 typedef struct st_quicly_ack_frame_t {

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -200,7 +200,6 @@ typedef struct st_quicly_stop_sending_frame_t {
 
 static int quicly_decode_stop_sending_frame(const uint8_t **src, const uint8_t *end, quicly_stop_sending_frame_t *frame);
 
-#define QUICLY_ENCODE_ACK_MAX_BLOCKS 63
 uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t *ranges, uint64_t ack_delay);
 
 typedef struct st_quicly_ack_frame_t {

--- a/include/quicly/ranges.h
+++ b/include/quicly/ranges.h
@@ -68,7 +68,7 @@ int quicly_ranges_add(quicly_ranges_t *ranges, uint64_t start, uint64_t end);
  */
 int quicly_ranges_subtract(quicly_ranges_t *ranges, uint64_t start, uint64_t end);
 /**
- * removes ranges specified by the range indexes
+ * removes the smallest range (e.g., the old ACK range)
  */
 void quicly_ranges_drop_smallest_range(quicly_ranges_t *ranges);
 

--- a/include/quicly/ranges.h
+++ b/include/quicly/ranges.h
@@ -30,6 +30,8 @@ extern "C" {
 #include <stdint.h>
 #include <stdlib.h>
 
+#define QUICLY_MAX_RANGES 64
+
 typedef struct st_quicly_range_t {
     uint64_t start;
     uint64_t end; /* non-inclusive */

--- a/include/quicly/ranges.h
+++ b/include/quicly/ranges.h
@@ -70,7 +70,7 @@ int quicly_ranges_subtract(quicly_ranges_t *ranges, uint64_t start, uint64_t end
 /**
  * removes ranges specified by the range indexes
  */
-void quicly_ranges_shrink(quicly_ranges_t *ranges, size_t begin_range_index, size_t end_range_index);
+void quicly_ranges_drop_smallest_range(quicly_ranges_t *ranges);
 
 /* inline functions */
 

--- a/include/quicly/ranges.h
+++ b/include/quicly/ranges.h
@@ -30,7 +30,11 @@ extern "C" {
 #include <stdint.h>
 #include <stdlib.h>
 
-#define QUICLY_MAX_RANGES 64
+/**
+ * maximum number of ranges (inclusive) that can be contained by quicly_ranges_t.  Functions would report error if the requested
+ * operation causes the structure to exceed that limit.
+ */
+#define QUICLY_MAX_RANGES 63
 
 typedef struct st_quicly_range_t {
     uint64_t start;
@@ -43,11 +47,29 @@ typedef struct st_quicly_ranges_t {
     quicly_range_t _initial;
 } quicly_ranges_t;
 
+/**
+ * initializes the structure
+ */
 static void quicly_ranges_init(quicly_ranges_t *ranges);
+/**
+ * initializes the structure, registering given range
+ */
 int quicly_ranges_init_with_range(quicly_ranges_t *ranges, uint64_t start, uint64_t end);
+/**
+ * clears the structure
+ */
 static void quicly_ranges_clear(quicly_ranges_t *ranges);
+/**
+ * adds given range, returns 0 if successful
+ */
 int quicly_ranges_add(quicly_ranges_t *ranges, uint64_t start, uint64_t end);
+/**
+ * subtracts given range, returns 0 if sucessful
+ */
 int quicly_ranges_subtract(quicly_ranges_t *ranges, uint64_t start, uint64_t end);
+/**
+ * removes ranges specified by the range indexes
+ */
 void quicly_ranges_shrink(quicly_ranges_t *ranges, size_t start, size_t end);
 
 /* inline functions */

--- a/include/quicly/ranges.h
+++ b/include/quicly/ranges.h
@@ -70,7 +70,7 @@ int quicly_ranges_subtract(quicly_ranges_t *ranges, uint64_t start, uint64_t end
 /**
  * removes ranges specified by the range indexes
  */
-void quicly_ranges_shrink(quicly_ranges_t *ranges, size_t start, size_t end);
+void quicly_ranges_shrink(quicly_ranges_t *ranges, size_t begin_range_index, size_t end_range_index);
 
 /* inline functions */
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1091,7 +1091,6 @@ static int record_receipt(quicly_conn_t *conn, struct st_quicly_pn_space_t *spac
     if (ack_now) {
         conn->egress.send_ack_at = now;
     } else if (conn->egress.send_ack_at == INT64_MAX) {
-        /* FIXME use 1/4 minRTT */
         conn->egress.send_ack_at = now + QUICLY_DELAYED_ACK_TIMEOUT;
     }
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -74,9 +74,9 @@
  */
 #define MIN_SEND_WINDOW 64
 /**
- * maximum number of ACK blocks that quicly retains
+ * maximum number of ACK blocks that quicly retains (should be smaller than QUICLY_MAX_RANGES)
  */
-#define QUICLY_MAX_ACK_BLOCKS 63
+#define QUICLY_MAX_ACK_BLOCKS 60
 /**
  * sends ACK bundled with PING, when number of gaps in the ack queue becomes no less than this threshold
  */
@@ -1025,6 +1025,10 @@ static void do_free_pn_space(struct st_quicly_pn_space_t *space)
  */
 static void drop_excess_ack_blocks(struct st_quicly_pn_space_t *space)
 {
+    /* Because quicly adds a range to ack_queue then shrinks it, the maximum number of blocks retained in ack_queue temporary
+     * exceeds QUICLY_MAX_ACK_BLOCKS by one. Therefore QUICLY_MAX_ACK_BLOCKS needs to be smaller than QUICLY_MAX_RANGES. */
+    QUICLY_BUILD_ASSERT(QUICLY_MAX_ACK_BLOCKS < QUICLY_MAX_RANGES);
+
     if (space->ack_queue.num_ranges > QUICLY_MAX_ACK_BLOCKS)
         quicly_ranges_shrink(&space->ack_queue, 0, space->ack_queue.num_ranges - QUICLY_MAX_ACK_BLOCKS);
 }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1021,13 +1021,11 @@ static int record_receipt(quicly_conn_t *conn, struct st_quicly_pn_space_t *spac
     if (space->ack_queue.num_ranges > QUICLY_ENCODE_ACK_MAX_BLOCKS)
         quicly_ranges_shrink(&space->ack_queue, 0, space->ack_queue.num_ranges - QUICLY_ENCODE_ACK_MAX_BLOCKS);
 
-    if (space->ack_queue.ranges[space->ack_queue.num_ranges - 1].end == pn + 1) {
-        /* FIXME implement deduplication at an earlier moment? */
+    /* update largest_pn_received_at (TODO implement deduplication at an earlier moment?) */
+    if (space->ack_queue.ranges[space->ack_queue.num_ranges - 1].end == pn + 1)
         space->largest_pn_received_at = now;
-    }
-    /* TODO (jri): If not ack-only packet, then maintain count of such packets that are received.
-     * Send ack immediately when this number exceeds the threshold.
-     */
+
+    /* if the received packet is ack-eliciting, update / schedule transmission of ACK */
     if (!is_ack_only) {
         space->unacked_count++;
         /* Ack after QUICLY_NUM_PACKETS_BEFORE_ACK packets or after the delayed ack timeout */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2521,12 +2521,12 @@ static int send_ack(quicly_conn_t *conn, struct st_quicly_pn_space_t *space, qui
     }
 
     /* Emit an ACK frame. When there are no less than QUICLY_NUM_ACK_BLOCKS_TO_INDUCE_ACKACK (8) gaps, we bundle PING once per every
-     * 16 packets being sent. */
+     * 4 packets being sent. */
 Emit:
     if ((ret = allocate_frame(conn, s, QUICLY_ACK_FRAME_CAPACITY)) != 0)
         return ret;
     uint8_t *dst = s->dst;
-    if (space->ack_queue.num_ranges >= QUICLY_NUM_ACK_BLOCKS_TO_INDUCE_ACKACK && conn->egress.packet_number % 16 == 0)
+    if (space->ack_queue.num_ranges >= QUICLY_NUM_ACK_BLOCKS_TO_INDUCE_ACKACK && conn->egress.packet_number % 4 == 0)
         *dst++ = QUICLY_FRAME_TYPE_PING;
     dst = quicly_encode_ack_frame(dst, s->dst_end, &space->ack_queue, ack_delay);
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -74,7 +74,7 @@
  */
 #define MIN_SEND_WINDOW 64
 /**
- * sends ACK bundled with PING, when number of gaps in the ack queue becomes no less than this threshold. This value should be much
+ * sends ACK bundled with PING, when number of gaps in the ack queue reaches or exceeds this threshold. This value should be much
  * smaller than QUICLY_MAX_RANGES.
  */
 #define QUICLY_NUM_ACK_BLOCKS_TO_INDUCE_ACKACK 8

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -73,6 +73,11 @@
  * do not try to send frames that require ACK if the send window is below this value
  */
 #define MIN_SEND_WINDOW 64
+/**
+ * maximum number of ACK blocks that quicly retains
+ */
+#define QUICLY_MAX_ACK_BLOCKS 63
+
 
 KHASH_MAP_INIT_INT64(quicly_stream_t, quicly_stream_t *)
 
@@ -1020,8 +1025,8 @@ static int record_receipt(quicly_conn_t *conn, struct st_quicly_pn_space_t *spac
 
     /* Cap the size of ranges retained by ack_queue to hard-coded threshold. We cannot check that the current size is below or equal
      * to the hard-coded maximum; it might have already gone above that value, when on_ack_ack splits a range. */
-    if (space->ack_queue.num_ranges > QUICLY_ENCODE_ACK_MAX_BLOCKS)
-        quicly_ranges_shrink(&space->ack_queue, 0, space->ack_queue.num_ranges - QUICLY_ENCODE_ACK_MAX_BLOCKS);
+    if (space->ack_queue.num_ranges > QUICLY_MAX_ACK_BLOCKS)
+        quicly_ranges_shrink(&space->ack_queue, 0, space->ack_queue.num_ranges - QUICLY_MAX_ACK_BLOCKS);
 
     /* update largest_pn_received_at (TODO implement deduplication at an earlier moment?) */
     if (space->ack_queue.ranges[space->ack_queue.num_ranges - 1].end == pn + 1)

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -588,7 +588,7 @@ static int on_invalid_ack(quicly_conn_t *conn, const quicly_sent_packet_t *packe
     return 0;
 }
 
-static uint64_t calc_next_gap_pn(ptls_context_t *tlsctx, uint64_t next_pn)
+static uint64_t calc_next_pn_to_skip(ptls_context_t *tlsctx, uint64_t next_pn)
 {
     static __thread struct {
         uint16_t values[32];

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -234,7 +234,7 @@ struct st_quicly_conn_t {
         /**
          * next PN to be skipped
          */
-        uint64_t next_gap_pn;
+        uint64_t next_pn_to_skip;
         /**
          * valid if state is CLOSING
          */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1059,7 +1059,7 @@ static int record_pn(quicly_ranges_t *ranges, uint64_t pn, int *is_out_of_order)
 
     /* slow path; we shrink then add, to avoid exceeding the QUICLY_MAX_RANGES */
     if (ranges->num_ranges == QUICLY_MAX_RANGES)
-        quicly_ranges_shrink(ranges, 0, 1);
+        quicly_ranges_drop_smallest_range(ranges);
     return quicly_ranges_add(ranges, pn, pn + 1);
 }
 
@@ -2033,7 +2033,7 @@ static int on_ack_ack(quicly_conn_t *conn, const quicly_sent_packet_t *packet, q
         /* Subtracting an ACK range might end up in splitting an existing range. By shrinking the number of ranges to MAX-1, we make
          * sure that the potential split would not lead to an error. */
         if (space->ack_queue.num_ranges == QUICLY_MAX_RANGES)
-            quicly_ranges_shrink(&space->ack_queue, 0, 1);
+            quicly_ranges_drop_smallest_range(&space->ack_queue);
         if (quicly_ranges_subtract(&space->ack_queue, sent->data.ack.range.start, sent->data.ack.range.end) != 0) {
             /* FIXME log error */
             return QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1054,7 +1054,7 @@ static int record_pn(quicly_ranges_t *ranges, uint64_t pn, int *is_reordered)
             ranges->ranges[ranges->num_ranges - 1].end = pn + 1;
             return 0;
         }
-        /* Otherwise we've found a gap. Send immediate ack in order to accelerate loss recovery on the sender. */
+        /* Otherwise we've found a gap. Send immediate ack to accelerate loss recovery at the sender. */
         *is_reordered = 1;
     }
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -65,8 +65,10 @@
 #define QUICLY_EPOCH_HANDSHAKE 2
 #define QUICLY_EPOCH_1RTT 3
 
-#define QUICLY_MAX_TOKEN_LEN 512 /* maximum length of token that we would accept */
-
+/**
+ * maximum size of token that quicly accepts
+ */
+#define QUICLY_MAX_TOKEN_LEN 512
 /**
  * do not try to send frames that require ACK if the send window is below this value
  */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1066,10 +1066,12 @@ static int record_pn(quicly_ranges_t *ranges, uint64_t pn, int *is_reordered)
 
 static int record_receipt(quicly_conn_t *conn, struct st_quicly_pn_space_t *space, uint64_t pn, int is_ack_only, size_t epoch)
 {
-    int ret, ack_now;
+    int ret, ack_now, is_reordered;
 
-    if ((ret = record_pn(&space->ack_queue, pn, &ack_now)) != 0)
+    if ((ret = record_pn(&space->ack_queue, pn, &is_reordered)) != 0)
         goto Exit;
+
+    ack_now = is_reordered && !is_ack_only;
 
     /* update largest_pn_received_at (TODO implement deduplication at an earlier moment?) */
     if (space->ack_queue.ranges[space->ack_queue.num_ranges - 1].end == pn + 1)

--- a/lib/ranges.c
+++ b/lib/ranges.c
@@ -40,7 +40,11 @@
 static int insert_at(quicly_ranges_t *ranges, uint64_t start, uint64_t end, size_t slot)
 {
     if (ranges->num_ranges == ranges->capacity) {
+        if (ranges->num_ranges == QUICLY_MAX_RANGES)
+            return -1;
         size_t new_capacity = ranges->capacity < 4 ? 4 : ranges->capacity * 2;
+        if (new_capacity > QUICLY_MAX_RANGES)
+            new_capacity = QUICLY_MAX_RANGES;
         quicly_range_t *new_ranges = malloc(new_capacity * sizeof(*new_ranges));
         if (new_ranges == NULL)
             return -1;

--- a/lib/ranges.c
+++ b/lib/ranges.c
@@ -62,6 +62,22 @@ static int insert_at(quicly_ranges_t *ranges, uint64_t start, uint64_t end, size
     return 0;
 }
 
+static void shrink_ranges(quicly_ranges_t *ranges, size_t begin_range_index, size_t end_range_index)
+{
+    assert(begin_range_index < end_range_index);
+
+    MOVE(ranges->ranges + begin_range_index, ranges->ranges + end_range_index, ranges->num_ranges - end_range_index);
+    ranges->num_ranges -= end_range_index - begin_range_index;
+    if (ranges->capacity > 4 && ranges->num_ranges * 3 <= ranges->capacity) {
+        size_t new_capacity = ranges->capacity / 2;
+        quicly_range_t *new_ranges = realloc(ranges->ranges, new_capacity * sizeof(*new_ranges));
+        if (new_ranges != NULL) {
+            ranges->ranges = new_ranges;
+            ranges->capacity = new_capacity;
+        }
+    }
+}
+
 static inline int merge_update(quicly_ranges_t *ranges, uint64_t start, uint64_t end, size_t slot, size_t end_slot)
 {
     if (start < ranges->ranges[slot].start)
@@ -69,7 +85,7 @@ static inline int merge_update(quicly_ranges_t *ranges, uint64_t start, uint64_t
     ranges->ranges[slot].end = end < ranges->ranges[end_slot].end ? ranges->ranges[end_slot].end : end;
 
     if (slot != end_slot)
-        quicly_ranges_shrink(ranges, slot + 1, end_slot + 1);
+        shrink_ranges(ranges, slot + 1, end_slot + 1);
 
     return 0;
 }
@@ -158,7 +174,7 @@ int quicly_ranges_subtract(quicly_ranges_t *ranges, uint64_t start, uint64_t end
         }
         /* remove the slot if the range has become empty */
         if (ranges->ranges[slot].start == ranges->ranges[slot].end)
-            quicly_ranges_shrink(ranges, slot, slot + 1);
+            shrink_ranges(ranges, slot, slot + 1);
         return 0;
     }
 
@@ -182,23 +198,13 @@ int quicly_ranges_subtract(quicly_ranges_t *ranges, uint64_t start, uint64_t end
 
     /* remove shrink_from..slot */
     if (shrink_from != slot)
-        quicly_ranges_shrink(ranges, shrink_from, slot);
+        shrink_ranges(ranges, shrink_from, slot);
 
     return 0;
 }
 
-void quicly_ranges_shrink(quicly_ranges_t *ranges, size_t begin_range_index, size_t end_range_index)
+void quicly_ranges_drop_smallest_range(quicly_ranges_t *ranges)
 {
-    assert(begin_range_index < end_range_index);
-
-    MOVE(ranges->ranges + begin_range_index, ranges->ranges + end_range_index, ranges->num_ranges - end_range_index);
-    ranges->num_ranges -= end_range_index - begin_range_index;
-    if (ranges->capacity > 4 && ranges->num_ranges * 3 <= ranges->capacity) {
-        size_t new_capacity = ranges->capacity / 2;
-        quicly_range_t *new_ranges = realloc(ranges->ranges, new_capacity * sizeof(*new_ranges));
-        if (new_ranges != NULL) {
-            ranges->ranges = new_ranges;
-            ranges->capacity = new_capacity;
-        }
-    }
+    assert(ranges->num_ranges != 0);
+    shrink_ranges(ranges, 0, 1);
 }

--- a/lib/ranges.c
+++ b/lib/ranges.c
@@ -187,12 +187,12 @@ int quicly_ranges_subtract(quicly_ranges_t *ranges, uint64_t start, uint64_t end
     return 0;
 }
 
-void quicly_ranges_shrink(quicly_ranges_t *ranges, size_t start, size_t end)
+void quicly_ranges_shrink(quicly_ranges_t *ranges, size_t begin_range_index, size_t end_range_index)
 {
-    assert(start < end);
+    assert(begin_range_index < end_range_index);
 
-    MOVE(ranges->ranges + start, ranges->ranges + end, ranges->num_ranges - end);
-    ranges->num_ranges -= end - start;
+    MOVE(ranges->ranges + begin_range_index, ranges->ranges + end_range_index, ranges->num_ranges - end_range_index);
+    ranges->num_ranges -= end_range_index - begin_range_index;
     if (ranges->capacity > 4 && ranges->num_ranges * 3 <= ranges->capacity) {
         size_t new_capacity = ranges->capacity / 2;
         quicly_range_t *new_ranges = realloc(ranges->ranges, new_capacity * sizeof(*new_ranges));

--- a/t/simple.c
+++ b/t/simple.c
@@ -185,6 +185,7 @@ static void test_send_then_close(void)
     ok(buffer_is(&server_streambuf->super.ingress, ""));
     quicly_streambuf_egress_shutdown(server_stream);
 
+    quic_now += QUICLY_DELAYED_ACK_TIMEOUT;
     transmit(server, client);
 
     ok(client_streambuf->is_detached);
@@ -230,6 +231,7 @@ static void test_reset_after_close(void)
 
     quicly_streambuf_egress_shutdown(server_stream);
 
+    quic_now += QUICLY_DELAYED_ACK_TIMEOUT;
     transmit(server, client);
 
     ok(client_streambuf->is_detached);

--- a/t/stream-concurrency.c
+++ b/t/stream-concurrency.c
@@ -77,6 +77,7 @@ void test_stream_concurrency(void)
     quicly_reset_stream(client_streams[i - 1], QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(123));
     quicly_request_stop(client_streams[i - 1], QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(456));
     transmit(client, server);
+    quic_now += QUICLY_DELAYED_ACK_TIMEOUT;
     transmit(server, client);
     ok(server_streambuf->error_received.reset_stream == QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(123));
     ok(server_streambuf->error_received.stop_sending == QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(456));


### PR DESCRIPTION
Fixes #216. Still WIP.

* `quicly_pn_space::ack_queue`
    * [x] send ACK+PING when the size exceeds low watermark
    * [x] drop blocks with smaller PNs when the size exceeds high watermark
* `quicy_recvstate_t::received`, `quicly_sendstate_t::acked`, `quicly_sendstate_t::pending`
    * [x] close the connection when exceeding limits
* [x] introduce PN gaps every one per 256 packets being sent (at random)