### PR TITLE
fix crash when receipt of ACK changes the stream to "blocked-by-stream-data" state

### DIFF
--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -280,7 +280,7 @@ static int default_stream_scheduler_can_send(quicly_stream_scheduler_t *self, qu
             /* Saturated. Lazily move such streams to the "blocked" list, at the same time checking if anything can be sent. */
             while (quicly_linklist_is_linked(&sched->active)) {
                 quicly_stream_t *stream =
-                    (void *)((char *)(sched->active.next - offsetof(quicly_stream_t, _send_aux.pending_link.default_scheduler)));
+                    (void *)((char *)sched->active.next - offsetof(quicly_stream_t, _send_aux.pending_link.default_scheduler));
                 if (quicly_sendstate_can_send(&stream->sendstate, NULL))
                     return 1;
                 quicly_linklist_unlink(&stream->_send_aux.pending_link.default_scheduler);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2008,8 +2008,11 @@ static int on_ack_stream(quicly_conn_t *conn, const quicly_sent_packet_t *packet
             return ret;
         if (bytes_to_shift != 0)
             stream->callbacks->on_send_shift(stream, bytes_to_shift);
-        if (stream_is_destroyable(stream))
+        if (stream_is_destroyable(stream)) {
             destroy_stream(stream, 0);
+        } else if (stream->_send_aux.rst.sender_state == QUICLY_SENDER_STATE_NONE) {
+            resched_stream_data(stream);
+        }
     } else {
         /* FIXME handle rto error */
         if ((ret = quicly_sendstate_lost(&stream->sendstate, &sent->data.stream.args)) != 0)


### PR DESCRIPTION
Such streams cannot be kept marked as "active" in the stream scheduler.