### PR TITLE
Don't drop the first incoming packet using updated key

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -396,6 +396,7 @@ struct st_quicly_conn_streamgroup_state_t {
 #define QUICLY_STATS_PREBUILT_FIELDS                                                                                               \
     struct {                                                                                                                       \
         uint64_t received;                                                                                                         \
+        uint64_t decryption_failed;                                                                                                \
         uint64_t sent;                                                                                                             \
         uint64_t lost;                                                                                                             \
         uint64_t ack_received;                                                                                                     \

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4428,8 +4428,10 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
 
     /* decrypt */
     if ((ret = decrypt_packet(header_protection, aead.cb, aead.ctx, &(*space)->next_expected_packet_number, packet, &pn,
-                              &payload)) != 0)
+                              &payload)) != 0) {
+        ++conn->super.stats.num_packets.decryption_failed;
         goto Exit;
+    }
 
     QUICLY_PROBE(CRYPTO_DECRYPT, conn, pn, payload.base, payload.len);
     QUICLY_PROBE(QUICTRACE_RECV, conn, probe_now(), pn);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1875,8 +1875,10 @@ static int do_decrypt_packet(ptls_cipher_context_t *header_protection,
     int ret;
 
     /* decipher the header protection, as well as obtaining pnbits, pnlen */
-    if (encrypted_len < header_protection->algo->iv_size + QUICLY_MAX_PN_SIZE)
+    if (encrypted_len < header_protection->algo->iv_size + QUICLY_MAX_PN_SIZE) {
+        *pn = UINT64_MAX;
         return QUICLY_ERROR_PACKET_IGNORED;
+    }
     ptls_cipher_init(header_protection, packet->octets.base + packet->encrypted_off + QUICLY_MAX_PN_SIZE);
     ptls_cipher_encrypt(header_protection, hpmask, hpmask, sizeof(hpmask));
     packet->octets.base[0] ^= hpmask[0] & (QUICLY_PACKET_IS_LONG_HEADER(packet->octets.base[0]) ? 0xf : 0x1f);
@@ -1914,6 +1916,7 @@ static int decrypt_packet(ptls_cipher_context_t *header_protection,
             return ret;
     } else {
         *payload = ptls_iovec_init(packet->octets.base + packet->encrypted_off, packet->octets.len - packet->encrypted_off);
+        *pn = packet->decrypted.pn;
         if (aead_cb == aead_decrypt_1rtt) {
             quicly_conn_t *conn = aead_ctx;
             if (conn->application->cipher.ingress.key_phase.decrypted < packet->decrypted.key_phase) {
@@ -1921,7 +1924,6 @@ static int decrypt_packet(ptls_cipher_context_t *header_protection,
                     return ret;
             }
         }
-        *pn = packet->decrypted.pn;
         if (*next_expected_pn < *pn)
             *next_expected_pn = *pn + 1;
     }
@@ -4430,6 +4432,7 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     if ((ret = decrypt_packet(header_protection, aead.cb, aead.ctx, &(*space)->next_expected_packet_number, packet, &pn,
                               &payload)) != 0) {
         ++conn->super.stats.num_packets.decryption_failed;
+        QUICLY_PROBE(CRYPTO_DECRYPT, conn, pn, NULL, 0);
         goto Exit;
     }
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -118,10 +118,10 @@ static void dump_stats(FILE *fp, quicly_conn_t *conn)
 
     quicly_get_stats(conn, &stats);
     fprintf(fp,
-            "packets-received: %" PRIu64 ", packets-sent: %" PRIu64 ", packets-lost: %" PRIu64 ", ack-received: %" PRIu64
-            ", bytes-received: %" PRIu64 ", bytes-sent: %" PRIu64 ", srtt: %" PRIu32 "\n",
-            stats.num_packets.received, stats.num_packets.sent, stats.num_packets.lost, stats.num_packets.ack_received,
-            stats.num_bytes.received, stats.num_bytes.sent, stats.rtt.smoothed);
+            "packets-received: %" PRIu64 ", packets-decryption-failed: %" PRIu64 ", packets-sent: %" PRIu64 ", packets-lost: %"
+            PRIu64 ", ack-received: %" PRIu64 ", bytes-received: %" PRIu64 ", bytes-sent: %" PRIu64 ", srtt: %" PRIu32 "\n",
+            stats.num_packets.received, stats.num_packets.decryption_failed, stats.num_packets.sent, stats.num_packets.lost,
+            stats.num_packets.ack_received, stats.num_bytes.received, stats.num_bytes.sent, stats.rtt.smoothed);
 }
 
 static int validate_path(const char *path)


### PR DESCRIPTION
We need to decrypt an incoming packet twice when handling a key update, first using the key at epoch N, then using the one at epoch N+2.

However, because we do in-place decryption, the second decryption (using the key at epoch N+2) always failed, ending up in droping that packet. As we retain the new key once it is generated, following packets were handled as expected.

This PR fixes the issue by unrolling the in-place decryption before retrying the AEAD decryption using the new key. It also adds a check to the test case that key updates do not result in decryption failures.