### PR TITLE
Do not record packet receive once the connection enters closing state.

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4462,7 +4462,7 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     /* handle the payload */
     if ((ret = handle_payload(conn, epoch, payload.base, payload.len, &offending_frame_type, &is_ack_only)) != 0)
         goto Exit;
-    if (*space != NULL) {
+    if (*space != NULL && conn->super.state < QUICLY_STATE_CLOSING) {
         if ((ret = record_receipt(conn, *space, pn, is_ack_only, epoch)) != 0)
             goto Exit;
     }


### PR DESCRIPTION
This change prevents the application from entering busy state that was caused by the `record_receipt` function overwriting `send_ack_at` that is set at 3PTO+now to now (or now+max_ack_delay). As there is nothing to be sent in the closing state, the timer set to now led to
the application busy looping until the 3PTO timer expires.