### PR TITLE
[placeholder for bug reproduction] incorrect assumptions when PTO timer fires lead to assertion failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,12 @@ matrix:
       before_install: &bs_osx
         - curl -L https://cpanmin.us | perl - --self-upgrade --sudo
         - cpanm --sudo --installdeps --notest .
-      script:
+      script: &script_osx64
         - cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl .
         - make && make check
     - os: osx
       env:
-        - label=osx10.10/i386
+        - label=osx10.13/i386
       before_install: *bs_osx
       script:
         - curl -O https://www.openssl.org/source/openssl-1.1.0i.tar.gz
@@ -61,3 +61,20 @@ matrix:
         - cd ..
         - cmake -DCMAKE_C_FLAGS=-m32 -DOPENSSL_ROOT_DIR=$HOME/openssl-build -DWITH_DTRACE=OFF .
         - make && make check
+    - os: osx
+      env:
+        - label=osx10.13/x86_64
+      before_install: *bs_osx
+      script: *script_osx64
+    - os: osx
+      osx_image: xcode9.2
+      env:
+        - label=osx10.12/x86_64
+      before_install: *bs_osx
+      script: *script_osx64
+    - os: osx
+      osx_image: xcode11.3
+      env:
+        - label=osx10.14/x86_64
+      before_install: *bs_osx
+      script: *script_osx64

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -88,7 +88,6 @@ typedef struct st_quicly_datagram_t {
 typedef struct st_quicly_cid_t quicly_cid_t;
 typedef struct st_quicly_cid_plaintext_t quicly_cid_plaintext_t;
 typedef struct st_quicly_context_t quicly_context_t;
-typedef struct st_quicly_conn_t quicly_conn_t;
 typedef struct st_quicly_stream_t quicly_stream_t;
 typedef struct st_quicly_send_context_t quicly_send_context_t;
 typedef struct st_quicly_address_token_plaintext_t quicly_address_token_plaintext_t;

--- a/include/quicly/constants.h
+++ b/include/quicly/constants.h
@@ -75,7 +75,15 @@ extern "C" {
 
 typedef int64_t quicly_stream_id_t;
 
-extern char debug_log[32768];
+typedef struct st_quicly_conn_t quicly_conn_t;
+
+/**
+ * used for emitting arbitrary debug message through probes
+ */
+void quicly__debug_printf(struct st_quicly_conn_t *conn, const char *function, int line, const char *fmt, ...)
+    __attribute__((format(printf, 4, 5)));
+
+#define quicly_debug_printf(conn, ...) quicly__debug_printf((conn), __FUNCTION__, __LINE__, __VA_ARGS__)
 
 #ifdef __cplusplus
 }

--- a/include/quicly/constants.h
+++ b/include/quicly/constants.h
@@ -75,6 +75,8 @@ extern "C" {
 
 typedef int64_t quicly_stream_id_t;
 
+extern char debug_log[32768];
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/quicly/constants.h
+++ b/include/quicly/constants.h
@@ -78,7 +78,8 @@ typedef int64_t quicly_stream_id_t;
 typedef struct st_quicly_conn_t quicly_conn_t;
 
 /**
- * used for emitting arbitrary debug message through probes
+ * Used for emitting arbitrary debug message through probes. The debug message might get emitted unescaped as a JSON string,
+ * therefore cannot contain characters that are required to be escaped as a JSON string (e.g., `\n`, `"`).
  */
 void quicly__debug_printf(struct st_quicly_conn_t *conn, const char *function, int line, const char *fmt, ...)
     __attribute__((format(printf, 4, 5)));

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -200,7 +200,7 @@ typedef struct st_quicly_stop_sending_frame_t {
 
 static int quicly_decode_stop_sending_frame(const uint8_t **src, const uint8_t *end, quicly_stop_sending_frame_t *frame);
 
-#define QUICLY_ENCODE_ACK_MAX_BLOCKS 63 /* exclusive, see encode_ack_frame */
+#define QUICLY_ENCODE_ACK_MAX_BLOCKS 63
 uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t *ranges, uint64_t ack_delay);
 
 typedef struct st_quicly_ack_frame_t {

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -200,7 +200,6 @@ typedef struct st_quicly_stop_sending_frame_t {
 
 static int quicly_decode_stop_sending_frame(const uint8_t **src, const uint8_t *end, quicly_stop_sending_frame_t *frame);
 
-#define QUICLY_ENCODE_ACK_MAX_BLOCKS 63
 uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t *ranges, uint64_t ack_delay);
 
 typedef struct st_quicly_ack_frame_t {

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -204,7 +204,7 @@ inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, u
 inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last_retransmittable_sent_at, int has_outstanding,
                                      int can_send_stream_data, uint64_t total_bytes_sent)
 {
-    quicly_debug_printf(NULL, "last_retransmittable_sent_at=%" PRId64 ", has_outstanding=%d, can_send_stream_data=%d, total_bytes_sent=%" PRIu64 "\n", last_retransmittable_sent_at, has_outstanding, can_send_stream_data, total_bytes_sent);
+    quicly_debug_printf(NULL, "last_retransmittable_sent_at=%" PRId64 ", has_outstanding=%d, can_send_stream_data=%d, total_bytes_sent=%" PRIu64, last_retransmittable_sent_at, has_outstanding, can_send_stream_data, total_bytes_sent);
 
     if (!has_outstanding) {
         /* Do not set alarm if there's no data oustanding */
@@ -217,10 +217,10 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
     if (r->loss_time != INT64_MAX) {
         /* time-threshold loss detection */
         alarm_duration = r->loss_time - last_retransmittable_sent_at;
-        quicly_debug_printf(NULL, "time-threshold loss detection, alarm_duration=%" PRId64 "\n", alarm_duration);
+        quicly_debug_printf(NULL, "time-threshold loss detection, alarm_duration=%" PRId64, alarm_duration);
     } else if (r->rtt.smoothed == 0) {
         alarm_duration = 2 * r->rtt.latest; /* should contain initial rtt */
-        quicly_debug_printf(NULL, "smoothed_RTT=0, alarm_duration=%" PRId64 "\n", alarm_duration);
+        quicly_debug_printf(NULL, "smoothed_RTT=0, alarm_duration=%" PRId64, alarm_duration);
     } else {
         /* PTO alarm */
         /* the bitshift below is fine; it would take more than a millenium to overflow either alarm_duration or pto_count, even when
@@ -244,7 +244,7 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
             r->total_bytes_sent = total_bytes_sent;
         }
         alarm_duration = quicly_rtt_get_pto(&r->rtt, *r->max_ack_delay, r->conf->min_pto);
-        quicly_debug_printf(NULL, "calculated from PTO, alarm_duration=%" PRId64 "\n", alarm_duration);
+        quicly_debug_printf(NULL, "calculated from PTO, alarm_duration=%" PRId64, alarm_duration);
         if (r->pto_count < 0 && !can_send_stream_data) {
             /* Speculative probes sent under an RTT do not need to account for ack delay, since there is no expectation
              * of an ack being received before the probe is sent. */
@@ -252,17 +252,17 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
             alarm_duration >>= -r->pto_count;
             if (alarm_duration < r->conf->min_pto)
                 alarm_duration = r->conf->min_pto;
-            quicly_debug_printf(NULL, "adjusted alarm_duration=%" PRId64 "\n", alarm_duration);
+            quicly_debug_printf(NULL, "adjusted alarm_duration=%" PRId64, alarm_duration);
         } else if (r->pto_count >= 0) {
             alarm_duration <<= r->pto_count;
-            quicly_debug_printf(NULL, "adjusted alarm_duration=%" PRId64 "\n", alarm_duration);
+            quicly_debug_printf(NULL, "adjusted alarm_duration=%" PRId64, alarm_duration);
         }
     }
     r->alarm_at = last_retransmittable_sent_at + alarm_duration;
-    quicly_debug_printf(NULL, "alarm_at=%" PRId64 "\n", r->alarm_at);
+    quicly_debug_printf(NULL, "alarm_at=%" PRId64, r->alarm_at);
     if (r->alarm_at < now)
         r->alarm_at = now;
-    quicly_debug_printf(NULL, "alarm_at=%" PRId64 "\n", r->alarm_at);
+    quicly_debug_printf(NULL, "alarm_at=%" PRId64, r->alarm_at);
 }
 
 inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, int64_t now, int64_t sent_at,
@@ -299,11 +299,11 @@ inline int quicly_loss_on_alarm(quicly_loss_t *r, uint64_t largest_sent, uint64_
     *min_packets_to_send = 1;
     if (r->loss_time != INT64_MAX) {
         /* Time threshold loss detection. Send at least 1 packet, but no restrictions on sending otherwise. */
-        quicly_debug_printf(NULL, "time threshold loss detection\n");
+        quicly_debug_printf(NULL, "time threshold loss detection");
         *restrict_sending = 0;
         int ret = quicly_loss_detect_loss(r, largest_acked, do_detect);
         if (ret == 0)
-            quicly_debug_printf(NULL, "alarm_at changing from %" PRId64 " to %" PRId64 ", delta %" PRId64 "\n",
+            quicly_debug_printf(NULL, "alarm_at changing from %" PRId64 " to %" PRId64 ", delta %" PRId64,
                     this_alarm_at, r->alarm_at, r->alarm_at - this_alarm_at);
         return ret;
     }
@@ -313,7 +313,7 @@ inline int quicly_loss_on_alarm(quicly_loss_t *r, uint64_t largest_sent, uint64_
     if (r->pto_count > 0)
         *min_packets_to_send = 2;
 
-    quicly_debug_printf(NULL, "PTO, pto_count=%" PRIu8 "\n", r->pto_count);
+    quicly_debug_printf(NULL, "PTO, pto_count=%" PRIu8, r->pto_count);
     return 0;
 }
 

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -204,8 +204,7 @@ inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, u
 inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last_retransmittable_sent_at, int has_outstanding,
                                      int can_send_stream_data, uint64_t total_bytes_sent)
 {
-    sprintf(debug_log + strlen(debug_log), "%s:%d last_retransmittable_sent_at=%" PRId64 ", has_outstanding=%d, can_send_stream_data=%d, total_bytes_sent=%" PRIu64 "\n",
-    __FUNCTION__, __LINE__, last_retransmittable_sent_at, has_outstanding, can_send_stream_data, total_bytes_sent);
+    quicly_debug_printf(NULL, "last_retransmittable_sent_at=%" PRId64 ", has_outstanding=%d, can_send_stream_data=%d, total_bytes_sent=%" PRIu64 "\n", last_retransmittable_sent_at, has_outstanding, can_send_stream_data, total_bytes_sent);
 
     if (!has_outstanding) {
         /* Do not set alarm if there's no data oustanding */
@@ -218,10 +217,10 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
     if (r->loss_time != INT64_MAX) {
         /* time-threshold loss detection */
         alarm_duration = r->loss_time - last_retransmittable_sent_at;
-        sprintf(debug_log + strlen(debug_log), "%s:%d time-threshold loss detection, alarm_duration=%" PRId64 "\n", __FUNCTION__, __LINE__, alarm_duration);
+        quicly_debug_printf(NULL, "time-threshold loss detection, alarm_duration=%" PRId64 "\n", alarm_duration);
     } else if (r->rtt.smoothed == 0) {
         alarm_duration = 2 * r->rtt.latest; /* should contain initial rtt */
-        sprintf(debug_log + strlen(debug_log), "%s:%d smoothed_RTT=0, alarm_duration=%" PRId64 "\n", __FUNCTION__, __LINE__, alarm_duration);
+        quicly_debug_printf(NULL, "smoothed_RTT=0, alarm_duration=%" PRId64 "\n", alarm_duration);
     } else {
         /* PTO alarm */
         /* the bitshift below is fine; it would take more than a millenium to overflow either alarm_duration or pto_count, even when
@@ -245,7 +244,7 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
             r->total_bytes_sent = total_bytes_sent;
         }
         alarm_duration = quicly_rtt_get_pto(&r->rtt, *r->max_ack_delay, r->conf->min_pto);
-        sprintf(debug_log + strlen(debug_log), "%s:%d calculated from PTO, alarm_duration=%" PRId64 "\n", __FUNCTION__, __LINE__, alarm_duration);
+        quicly_debug_printf(NULL, "calculated from PTO, alarm_duration=%" PRId64 "\n", alarm_duration);
         if (r->pto_count < 0 && !can_send_stream_data) {
             /* Speculative probes sent under an RTT do not need to account for ack delay, since there is no expectation
              * of an ack being received before the probe is sent. */
@@ -253,17 +252,17 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
             alarm_duration >>= -r->pto_count;
             if (alarm_duration < r->conf->min_pto)
                 alarm_duration = r->conf->min_pto;
-            sprintf(debug_log + strlen(debug_log), "%s:%d adjusted alarm_duration=%" PRId64 "\n", __FUNCTION__, __LINE__, alarm_duration);
+            quicly_debug_printf(NULL, "adjusted alarm_duration=%" PRId64 "\n", alarm_duration);
         } else if (r->pto_count >= 0) {
             alarm_duration <<= r->pto_count;
-            sprintf(debug_log + strlen(debug_log), "%s:%d adjusted alarm_duration=%" PRId64 "\n", __FUNCTION__, __LINE__, alarm_duration);
+            quicly_debug_printf(NULL, "adjusted alarm_duration=%" PRId64 "\n", alarm_duration);
         }
     }
     r->alarm_at = last_retransmittable_sent_at + alarm_duration;
-    sprintf(debug_log + strlen(debug_log), "%s:%d alarm_at=%" PRId64 "\n", __FUNCTION__, __LINE__, r->alarm_at);
+    quicly_debug_printf(NULL, "alarm_at=%" PRId64 "\n", r->alarm_at);
     if (r->alarm_at < now)
         r->alarm_at = now;
-    sprintf(debug_log + strlen(debug_log), "%s:%d alarm_at=%" PRId64 "\n", __FUNCTION__, __LINE__, r->alarm_at);
+    quicly_debug_printf(NULL, "alarm_at=%" PRId64 "\n", r->alarm_at);
 }
 
 inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, int64_t now, int64_t sent_at,
@@ -300,11 +299,11 @@ inline int quicly_loss_on_alarm(quicly_loss_t *r, uint64_t largest_sent, uint64_
     *min_packets_to_send = 1;
     if (r->loss_time != INT64_MAX) {
         /* Time threshold loss detection. Send at least 1 packet, but no restrictions on sending otherwise. */
-        sprintf(debug_log + strlen(debug_log), "%s:%d time threshold loss detection\n", __FUNCTION__, __LINE__);
+        quicly_debug_printf(NULL, "time threshold loss detection\n");
         *restrict_sending = 0;
         int ret = quicly_loss_detect_loss(r, largest_acked, do_detect);
         if (ret == 0)
-            sprintf(debug_log + strlen(debug_log), "%s:%d alarm_at changing from %" PRId64 " to %" PRId64 ", delta %" PRId64 "\n", __FUNCTION__, __LINE__,
+            quicly_debug_printf(NULL, "alarm_at changing from %" PRId64 " to %" PRId64 ", delta %" PRId64 "\n",
                     this_alarm_at, r->alarm_at, r->alarm_at - this_alarm_at);
         return ret;
     }
@@ -314,7 +313,7 @@ inline int quicly_loss_on_alarm(quicly_loss_t *r, uint64_t largest_sent, uint64_
     if (r->pto_count > 0)
         *min_packets_to_send = 2;
 
-    sprintf(debug_log + strlen(debug_log), "%s:%d PTO, pto_count=%" PRIu8 "\n", __FUNCTION__, __LINE__, r->pto_count);
+    quicly_debug_printf(NULL, "PTO, pto_count=%" PRIu8 "\n", r->pto_count);
     return 0;
 }
 

--- a/include/quicly/ranges.h
+++ b/include/quicly/ranges.h
@@ -30,6 +30,8 @@ extern "C" {
 #include <stdint.h>
 #include <stdlib.h>
 
+#define QUICLY_MAX_RANGES 64
+
 typedef struct st_quicly_range_t {
     uint64_t start;
     uint64_t end; /* non-inclusive */

--- a/include/quicly/ranges.h
+++ b/include/quicly/ranges.h
@@ -30,7 +30,11 @@ extern "C" {
 #include <stdint.h>
 #include <stdlib.h>
 
-#define QUICLY_MAX_RANGES 64
+/**
+ * maximum number of ranges (inclusive) that can be contained by quicly_ranges_t.  Functions would report error if the requested
+ * operation causes the structure to exceed that limit.
+ */
+#define QUICLY_MAX_RANGES 63
 
 typedef struct st_quicly_range_t {
     uint64_t start;
@@ -43,11 +47,29 @@ typedef struct st_quicly_ranges_t {
     quicly_range_t _initial;
 } quicly_ranges_t;
 
+/**
+ * initializes the structure
+ */
 static void quicly_ranges_init(quicly_ranges_t *ranges);
+/**
+ * initializes the structure, registering given range
+ */
 int quicly_ranges_init_with_range(quicly_ranges_t *ranges, uint64_t start, uint64_t end);
+/**
+ * clears the structure
+ */
 static void quicly_ranges_clear(quicly_ranges_t *ranges);
+/**
+ * adds given range, returns 0 if successful
+ */
 int quicly_ranges_add(quicly_ranges_t *ranges, uint64_t start, uint64_t end);
+/**
+ * subtracts given range, returns 0 if sucessful
+ */
 int quicly_ranges_subtract(quicly_ranges_t *ranges, uint64_t start, uint64_t end);
+/**
+ * removes ranges specified by the range indexes
+ */
 void quicly_ranges_shrink(quicly_ranges_t *ranges, size_t start, size_t end);
 
 /* inline functions */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4973,6 +4973,7 @@ const quicly_stream_callbacks_t quicly_stream_noop_callbacks = {
 
 void quicly__debug_printf(quicly_conn_t *conn, const char *function, int line, const char *fmt, ...)
 {
+#if QUICLY_USE_EMBEDDED_PROBES || QUICLY_USE_DTRACE
     char buf[1024];
     va_list args;
 
@@ -4984,4 +4985,5 @@ void quicly__debug_printf(quicly_conn_t *conn, const char *function, int line, c
     va_end(args);
 
     QUICLY_DEBUG_MESSAGE(conn, function, line, buf);
+#endif
 }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -74,9 +74,9 @@
  */
 #define MIN_SEND_WINDOW 64
 /**
- * maximum number of ACK blocks that quicly retains
+ * maximum number of ACK blocks that quicly retains (should be smaller than QUICLY_MAX_RANGES)
  */
-#define QUICLY_MAX_ACK_BLOCKS 63
+#define QUICLY_MAX_ACK_BLOCKS 60
 /**
  * sends ACK bundled with PING, when number of gaps in the ack queue becomes no less than this threshold
  */
@@ -1025,6 +1025,10 @@ static void do_free_pn_space(struct st_quicly_pn_space_t *space)
  */
 static void drop_excess_ack_blocks(struct st_quicly_pn_space_t *space)
 {
+    /* Because quicly adds a range to ack_queue then shrinks it, the maximum number of blocks retained in ack_queue temporary
+     * exceeds QUICLY_MAX_ACK_BLOCKS by one. Therefore QUICLY_MAX_ACK_BLOCKS needs to be smaller than QUICLY_MAX_RANGES. */
+    QUICLY_BUILD_ASSERT(QUICLY_MAX_ACK_BLOCKS < QUICLY_MAX_RANGES);
+
     if (space->ack_queue.num_ranges > QUICLY_MAX_ACK_BLOCKS)
         quicly_ranges_shrink(&space->ack_queue, 0, space->ack_queue.num_ranges - QUICLY_MAX_ACK_BLOCKS);
 }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1021,13 +1021,11 @@ static int record_receipt(quicly_conn_t *conn, struct st_quicly_pn_space_t *spac
     if (space->ack_queue.num_ranges > QUICLY_ENCODE_ACK_MAX_BLOCKS)
         quicly_ranges_shrink(&space->ack_queue, 0, space->ack_queue.num_ranges - QUICLY_ENCODE_ACK_MAX_BLOCKS);
 
-    if (space->ack_queue.ranges[space->ack_queue.num_ranges - 1].end == pn + 1) {
-        /* FIXME implement deduplication at an earlier moment? */
+    /* update largest_pn_received_at (TODO implement deduplication at an earlier moment?) */
+    if (space->ack_queue.ranges[space->ack_queue.num_ranges - 1].end == pn + 1)
         space->largest_pn_received_at = now;
-    }
-    /* TODO (jri): If not ack-only packet, then maintain count of such packets that are received.
-     * Send ack immediately when this number exceeds the threshold.
-     */
+
+    /* if the received packet is ack-eliciting, update / schedule transmission of ACK */
     if (!is_ack_only) {
         space->unacked_count++;
         /* Ack after QUICLY_NUM_PACKETS_BEFORE_ACK packets or after the delayed ack timeout */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2521,12 +2521,12 @@ static int send_ack(quicly_conn_t *conn, struct st_quicly_pn_space_t *space, qui
     }
 
     /* Emit an ACK frame. When there are no less than QUICLY_NUM_ACK_BLOCKS_TO_INDUCE_ACKACK (8) gaps, we bundle PING once per every
-     * 16 packets being sent. */
+     * 4 packets being sent. */
 Emit:
     if ((ret = allocate_frame(conn, s, QUICLY_ACK_FRAME_CAPACITY)) != 0)
         return ret;
     uint8_t *dst = s->dst;
-    if (space->ack_queue.num_ranges >= QUICLY_NUM_ACK_BLOCKS_TO_INDUCE_ACKACK && conn->egress.packet_number % 16 == 0)
+    if (space->ack_queue.num_ranges >= QUICLY_NUM_ACK_BLOCKS_TO_INDUCE_ACKACK && conn->egress.packet_number % 4 == 0)
         *dst++ = QUICLY_FRAME_TYPE_PING;
     dst = quicly_encode_ack_frame(dst, s->dst_end, &space->ack_queue, ack_delay);
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -73,6 +73,11 @@
  * do not try to send frames that require ACK if the send window is below this value
  */
 #define MIN_SEND_WINDOW 64
+/**
+ * maximum number of ACK blocks that quicly retains
+ */
+#define QUICLY_MAX_ACK_BLOCKS 63
+
 
 KHASH_MAP_INIT_INT64(quicly_stream_t, quicly_stream_t *)
 
@@ -1020,8 +1025,8 @@ static int record_receipt(quicly_conn_t *conn, struct st_quicly_pn_space_t *spac
 
     /* Cap the size of ranges retained by ack_queue to hard-coded threshold. We cannot check that the current size is below or equal
      * to the hard-coded maximum; it might have already gone above that value, when on_ack_ack splits a range. */
-    if (space->ack_queue.num_ranges > QUICLY_ENCODE_ACK_MAX_BLOCKS)
-        quicly_ranges_shrink(&space->ack_queue, 0, space->ack_queue.num_ranges - QUICLY_ENCODE_ACK_MAX_BLOCKS);
+    if (space->ack_queue.num_ranges > QUICLY_MAX_ACK_BLOCKS)
+        quicly_ranges_shrink(&space->ack_queue, 0, space->ack_queue.num_ranges - QUICLY_MAX_ACK_BLOCKS);
 
     /* update largest_pn_received_at (TODO implement deduplication at an earlier moment?) */
     if (space->ack_queue.ranges[space->ack_queue.num_ranges - 1].end == pn + 1)

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4979,3 +4979,18 @@ int quicly_stream_noop_on_receive_reset(quicly_stream_t *stream, int err)
 const quicly_stream_callbacks_t quicly_stream_noop_callbacks = {
     quicly_stream_noop_on_destroy,   quicly_stream_noop_on_send_shift, quicly_stream_noop_on_send_emit,
     quicly_stream_noop_on_send_stop, quicly_stream_noop_on_receive,    quicly_stream_noop_on_receive_reset};
+
+void quicly__debug_printf(quicly_conn_t *conn, const char *function, int line, const char *fmt, ...)
+{
+    char buf[1024];
+    va_list args;
+
+    if (!QUICLY_DEBUG_MESSAGE_ENABLED())
+        return;
+
+    va_start(args, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+
+    QUICLY_DEBUG_MESSAGE(conn, function, line, buf);
+}

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -65,8 +65,10 @@
 #define QUICLY_EPOCH_HANDSHAKE 2
 #define QUICLY_EPOCH_1RTT 3
 
-#define QUICLY_MAX_TOKEN_LEN 512 /* maximum length of token that we would accept */
-
+/**
+ * maximum size of token that quicly accepts
+ */
+#define QUICLY_MAX_TOKEN_LEN 512
 /**
  * do not try to send frames that require ACK if the send window is below this value
  */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2110,8 +2110,11 @@ static int on_ack_max_stream_data(quicly_conn_t *conn, const quicly_sent_packet_
             break;
         case QUICLY_SENTMAP_EVENT_LOST:
             quicly_maxsender_lost(&stream->_send_aux.max_stream_data_sender, &sent->data.max_stream_data.args);
-            if (should_send_max_stream_data(stream))
+            sprintf(debug_log + strlen(debug_log), "%s:%d lost (sent=%" PRIu64 ", max_acked=%" PRIu64 "\n", __FUNCTION__, __LINE__, sent->data.max_stream_data.args.value, stream->_send_aux.max_stream_data_sender.max_acked);
+            if (should_send_max_stream_data(stream)) {
+                sprintf(debug_log + strlen(debug_log), "%s:%d scheduling stream control message\n", __FUNCTION__, __LINE__);
                 sched_stream_control(stream);
+            }
             break;
         default:
             break;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2101,9 +2101,9 @@ static int on_ack_max_stream_data(quicly_conn_t *conn, const quicly_sent_packet_
             break;
         case QUICLY_SENTMAP_EVENT_LOST:
             quicly_maxsender_lost(&stream->_send_aux.max_stream_data_sender, &sent->data.max_stream_data.args);
-            quicly_debug_printf(conn, "lost (sent=%" PRIu64 ", max_acked=%" PRIu64 "\n", sent->data.max_stream_data.args.value, stream->_send_aux.max_stream_data_sender.max_acked);
+            quicly_debug_printf(conn, "lost (sent=%" PRIu64 ", max_acked=%" PRIu64 ")", sent->data.max_stream_data.args.value, stream->_send_aux.max_stream_data_sender.max_acked);
             if (should_send_max_stream_data(stream)) {
-                quicly_debug_printf(conn, "scheduling stream control message\n");
+                quicly_debug_printf(conn, "scheduling stream control message");
                 sched_stream_control(stream);
             }
             break;
@@ -2557,7 +2557,7 @@ static int send_ack(quicly_conn_t *conn, struct st_quicly_pn_space_t *space, qui
 
     if (space->ack_queue.num_ranges == 0) {
         assert(space->unacked_count == 0);
-        quicly_debug_printf(conn, "bailing out, as num_ranges==0\n");
+        quicly_debug_printf(conn, "bailing out, as num_ranges==0");
         return 0;
     }
 
@@ -2606,7 +2606,7 @@ Emit:
     }
 
     space->unacked_count = 0;
-    quicly_debug_printf(conn, "ack sent\n");
+    quicly_debug_printf(conn, "ack sent");
 
     return ret;
 }
@@ -2868,7 +2868,7 @@ static int mark_packets_as_lost(quicly_conn_t *conn, size_t count)
             assert(conn->egress.sentmap.bytes_in_flight == 0);
             break;
         }
-        quicly_debug_printf(conn, "marking pn %" PRIu64 " lost, bytes: %" PRIu16 "\n", pn, sent->bytes_in_flight);
+        quicly_debug_printf(conn, "marking pn %" PRIu64 " lost, bytes: %" PRIu16, pn, sent->bytes_in_flight);
         if (sent->bytes_in_flight != 0)
             --count;
         if ((ret = quicly_sentmap_update(&conn->egress.sentmap, &iter, QUICLY_SENTMAP_EVENT_LOST, conn)) != 0)
@@ -2891,7 +2891,7 @@ static int do_detect_loss(quicly_loss_t *ld, uint64_t largest_acked, uint32_t de
     uint64_t largest_newly_lost_pn = UINT64_MAX;
     int ret;
 
-    quicly_debug_printf(conn, "delay_until_lost=%" PRIu32 "\n", delay_until_lost);
+    quicly_debug_printf(conn, "delay_until_lost=%" PRIu32, delay_until_lost);
 
     *loss_time = INT64_MAX;
 
@@ -2935,7 +2935,7 @@ static int do_detect_loss(quicly_loss_t *ld, uint64_t largest_acked, uint32_t de
         sent = quicly_sentmap_get(&iter);
     }
 
-    quicly_debug_printf(conn, "loss_time=%" PRId64 ", earliest_sent_at=%" PRId64 "\n", *loss_time, *loss_time != INT64_MAX ? *loss_time - delay_until_lost : INT64_MAX);
+    quicly_debug_printf(conn, "loss_time=%" PRId64 ", earliest_sent_at=%" PRId64, *loss_time, *loss_time != INT64_MAX ? *loss_time - delay_until_lost : INT64_MAX);
 
     return 0;
 }
@@ -3200,7 +3200,7 @@ static int send_handshake_flow(quicly_conn_t *conn, size_t epoch, quicly_send_co
 
     /* send ACK */
     if (ack_space != NULL && ack_space->unacked_count != 0) {
-        quicly_debug_printf(conn, "sending ACK of epoch %zu\n", epoch);
+        quicly_debug_printf(conn, "sending ACK of epoch %zu", epoch);
         if ((ret = send_ack(conn, ack_space, s)) != 0)
             goto Exit;
     }
@@ -3356,7 +3356,7 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
     int restrict_sending = 0, ret;
     size_t min_packets_to_send = 0;
 
-    quicly_debug_printf(conn, "loss.alarm_at: %" PRId64 ", last_retransmittable_sent_at: %" PRId64 "\n", conn->egress.loss.alarm_at, conn->egress.last_retransmittable_sent_at);
+    quicly_debug_printf(conn, "loss.alarm_at: %" PRId64 ", last_retransmittable_sent_at: %" PRId64, conn->egress.loss.alarm_at, conn->egress.last_retransmittable_sent_at);
 
     /* handle timeouts */
     if (conn->egress.loss.alarm_at <= now) {
@@ -3364,7 +3364,7 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
                                         conn->egress.loss.largest_acked_packet_plus1 - 1, do_detect_loss, &min_packets_to_send,
                                         &restrict_sending)) != 0)
             goto Exit;
-        quicly_debug_printf(conn, "loss.alarm_at: %" PRId64 "\n", conn->egress.loss.alarm_at);
+        quicly_debug_printf(conn, "loss.alarm_at: %" PRId64, conn->egress.loss.alarm_at);
         assert(min_packets_to_send > 0);
         assert(min_packets_to_send <= s->max_packets);
 
@@ -3407,7 +3407,7 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
             s->current.first_byte = QUICLY_QUIC_BIT; /* short header */
             /* acks */
             if (conn->egress.send_ack_at <= now && conn->application->super.unacked_count != 0) {
-                quicly_debug_printf(conn, "sending ACK of epoch 1RTT\n");
+                quicly_debug_printf(conn, "sending ACK of epoch 1RTT");
                 if ((ret = send_ack(conn, &conn->application->super, s)) != 0)
                     goto Exit;
             }
@@ -3479,20 +3479,20 @@ Exit:
         ret = 0;
     if (ret == 0) {
         if (conn->application == NULL) {
-            quicly_debug_printf(conn, "application=NULL\n");
+            quicly_debug_printf(conn, "application=NULL");
         } else {
-            quicly_debug_printf(conn, "1-RTT unacked_count: %" PRIu32 "\n", conn->application->super.unacked_count);
+            quicly_debug_printf(conn, "1-RTT unacked_count: %" PRIu32, conn->application->super.unacked_count);
         }
         if (conn->application == NULL || conn->application->super.unacked_count == 0) {
-            quicly_debug_printf(conn, "resetting send_ack_at\n");
+            quicly_debug_printf(conn, "resetting send_ack_at");
             conn->egress.send_ack_at = INT64_MAX; /* we have sent ACKs for every epoch (or before address validation) */
         }
         update_loss_alarm(conn);
-        quicly_debug_printf(conn, "updated loss alarm to %" PRId64 "\n", conn->egress.loss.alarm_at);
+        quicly_debug_printf(conn, "updated loss alarm to %" PRId64, conn->egress.loss.alarm_at);
         if (s->num_packets != 0)
             update_idle_timeout(conn, 0);
     }
-    quicly_debug_printf(conn, "returning %d\n", ret);
+    quicly_debug_printf(conn, "returning %d", ret);
     return ret;
 }
 
@@ -3503,7 +3503,7 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
 
     update_now(conn->super.ctx);
 
-    quicly_debug_printf(conn, "In quicly_send; role: %s\nstate: %d\nnow: %" PRId64 "\nfirst-timeout: %" PRId64 "\nsend_ack_at: %" PRId64 ", loss.alarm_at: %" PRId64 "\n",
+    quicly_debug_printf(conn, "In quicly_send; role: %s, state: %d, now: %" PRId64 ", first-timeout: %" PRId64 ", send_ack_at: %" PRId64 ", loss.alarm_at: %" PRId64,
             quicly_is_client(conn) ? "client" : "server", conn->super.state, now, quicly_get_first_timeout(conn),
             conn->egress.send_ack_at, conn->egress.loss.alarm_at);
 

--- a/lib/ranges.c
+++ b/lib/ranges.c
@@ -40,7 +40,11 @@
 static int insert_at(quicly_ranges_t *ranges, uint64_t start, uint64_t end, size_t slot)
 {
     if (ranges->num_ranges == ranges->capacity) {
+        if (ranges->num_ranges == QUICLY_MAX_RANGES)
+            return -1;
         size_t new_capacity = ranges->capacity < 4 ? 4 : ranges->capacity * 2;
+        if (new_capacity > QUICLY_MAX_RANGES)
+            new_capacity = QUICLY_MAX_RANGES;
         quicly_range_t *new_ranges = malloc(new_capacity * sizeof(*new_ranges));
         if (new_ranges == NULL)
             return -1;

--- a/misc/annotate-backtrace-symbols
+++ b/misc/annotate-backtrace-symbols
@@ -1,0 +1,28 @@
+#! /bin/sh
+exec ${H2O_PERL:-perl} -x $0 "$@"
+#! perl
+
+use strict;
+use warnings;
+
+my $ppid = getppid;
+
+while (my $line = <STDIN>) {
+    chomp $line;
+    if ($line =~ m{^([^\(\[]+)(.*?)\[(0x[0-9A-Fa-f]+)\]}) {
+        my ($exe, $info, $addr) = ($1, $2, $3);
+        my $resolved = addr2line($exe, $addr);
+        $line = "$exe${info}[$addr] $resolved"
+            if $resolved;
+    }
+    print "[$ppid] $line\n";
+}
+
+sub addr2line {
+    my ($exe, $addr) = @_;
+    open my $fh, "-|", qw(addr2line -pif -e), $exe, $addr
+        or return;
+    my $resolved = <$fh>;
+    chomp $resolved;
+    $resolved;
+}

--- a/misc/probe2trace.pl
+++ b/misc/probe2trace.pl
@@ -86,11 +86,11 @@ for my $probe (@probes) {
         if ($type eq 'struct st_quicly_conn_t *') {
             push @fmt, '"conn":%u';
             if ($arch eq 'linux') {
-                push @ap, '((struct st_quicly_conn_t *)arg' . $i . ')->master_id';
+                push @ap, 'arg ' . $i . ' != NULL ? ((struct st_quicly_conn_t *)arg' . $i . ')->master_id : 0';
             } elsif ($arch eq 'darwin') {
-                push @ap, '*(uint32_t *)copyin(arg' . $i . ' + 16, 4)';
+                push @ap, 'arg ' . $i . ' != NULL ? *(uint32_t *)copyin(arg' . $i . ' + 16, 4) : 0';
             } else {
-                push @ap, "((struct _st_quicly_conn_public_t *)arg$i)->master_id.master_id";
+                push @ap, "arg$i != NULL ? ((struct _st_quicly_conn_public_t *)arg$i)->master_id.master_id : 0";
             }
         } elsif ($type eq 'struct st_quicly_stream_t *') {
             push @fmt, '"stream-id":%d';

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -96,4 +96,6 @@ provider quicly {
     probe quictrace_lost(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
     probe quictrace_cc_ack(struct st_quicly_conn_t *conn, int64_t at, struct quicly_rtt_t *rtt, uint32_t cwnd, size_t inflight);
     probe quictrace_cc_lost(struct st_quicly_conn_t *conn, int64_t at, struct quicly_rtt_t *rtt, uint32_t cwnd, size_t inflight);
+
+    probe debug_message(struct st_quicly_conn_t *conn, const char *function, int line, const char *message);
 };

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -208,7 +208,7 @@ subtest "key-update" => sub {
         } else {
             is $num_key_updates, 0;
         }
-        system "misc/annotate-backtrace-symbols < $tempdir/errlog";
+        system "tail -1000 $tempdir/errlog | misc/annotate-backtrace-symbols";
     };
     subtest "none" => sub {
         $doit->([], [], undef);

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -190,7 +190,7 @@ subtest "key-update" => sub {
         my ($server_opts, $client_opts, $doing_updates) = @_;
         my $guard = spawn_server(@$server_opts, "-e", "$tempdir/events");
         # ensure at least 30 round-trips
-        my $resp = `exec $cli -p /120000 -M 4000 @{[join " ", @$client_opts]} 127.0.0.1 $port`;
+        my $resp = `exec $cli -p /120000 -M 4000 @{[join " ", @$client_opts]} 127.0.0.1 $port 2> $tempdir/errlog`;
         is $resp, "hello world\n" x 10000;
         undef $guard;
         my $num_key_updates = do {
@@ -207,6 +207,7 @@ subtest "key-update" => sub {
         } else {
             is $num_key_updates, 0;
         }
+        system "misc/annotate-backtrace-symbols < $tempdir/errlog";
     };
     subtest "none" => sub {
         $doit->([], [], undef);

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -38,6 +38,7 @@ subtest "hello" => sub {
     is $resp, "hello world\n";
     subtest "events" => sub {
         my $events = slurp_file("$tempdir/events");
+        $events =~ s/(^|\n)[^\n]*"type":"debug-message",.*?\n/$1/sg;
         complex $events, sub {
             $_ =~ /"type":"transport-close-send",.*?"type":"([^\"]*)",.*?"type":"([^\"]*)",.*?"type":"([^\"]*)",.*?"type":"([^\"]*)"/s
                 and $1 eq 'packet-commit' and $2 eq 'quictrace-sent' and $3 eq 'send' and $4 eq 'free';

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -191,7 +191,7 @@ subtest "key-update" => sub {
         my ($server_opts, $client_opts, $doing_updates) = @_;
         my $guard = spawn_server(@$server_opts, "-e", "$tempdir/events");
         # ensure at least 30 round-trips
-        my $resp = `exec $cli -p /120000 -M 4000 @{[join " ", @$client_opts]} 127.0.0.1 $port 2> $tempdir/errlog`;
+        my $resp = `exec $cli -e /dev/stderr -p /120000 -M 4000 @{[join " ", @$client_opts]} 127.0.0.1 $port 2> $tempdir/errlog`;
         is $resp, "hello world\n" x 10000;
         undef $guard;
         my $num_key_updates = do {

--- a/t/simple.c
+++ b/t/simple.c
@@ -185,6 +185,7 @@ static void test_send_then_close(void)
     ok(buffer_is(&server_streambuf->super.ingress, ""));
     quicly_streambuf_egress_shutdown(server_stream);
 
+    quic_now += QUICLY_DELAYED_ACK_TIMEOUT;
     transmit(server, client);
 
     ok(client_streambuf->is_detached);
@@ -230,6 +231,7 @@ static void test_reset_after_close(void)
 
     quicly_streambuf_egress_shutdown(server_stream);
 
+    quic_now += QUICLY_DELAYED_ACK_TIMEOUT;
     transmit(server, client);
 
     ok(client_streambuf->is_detached);

--- a/t/stream-concurrency.c
+++ b/t/stream-concurrency.c
@@ -77,6 +77,7 @@ void test_stream_concurrency(void)
     quicly_reset_stream(client_streams[i - 1], QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(123));
     quicly_request_stop(client_streams[i - 1], QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(456));
     transmit(client, server);
+    quic_now += QUICLY_DELAYED_ACK_TIMEOUT;
     transmit(server, client);
     ok(server_streambuf->error_received.reset_stream == QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(123));
     ok(server_streambuf->error_received.stop_sending == QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(456));


### PR DESCRIPTION
**This PR is intended to be a placeholder of a bug, so that we can retain the commits and revisit the details whenever necessary.**

Our assumption has been that when PTO fires, once we deem two previously sent ACK-eliciting packets as lost, we would either have some data to be sent, or there would be nothing inflight.

This assumption is incorrect.

For example, if there were four ACK-eliciting packets inflight, first three of them carrying STREAM frames and the last one carrying a RESET_STREAM frame, all of them designating a single stream, cancelling the first two packets will not trigger emission of any ACK-eliciting packets, because a reset is inflight.

In our case, the issue was with MAX_STREAM_DATA frame.

The test had the stream receive window set to 4KB, that led the receiver to send MAX_STREAM_DATA for every 2KB. Due to bug #248, the receiver was seeing packet drops every once a RTT or so.

These conditions led to something like follows: consider the case where we have sent five packets, each of them carrying MAX_STREAM_DATA.

When the first PTO fires, after PTOsec since `last_retransmittable_sent_at`, the first two of those packets are marked as lost. But because a MAX_STREAM_DATA frame carrying a greater value is inflight, there is nothing more ACK-eliciting to be sent.

The outcome is that `last_retransmittable_sent_at` remains a time in the past, and depending on how delayed the timer invocation is (due to the OS not waking up the thread immediately), `last_retransmittable_sent_at` + PTO * pto_count could point to a time in the past.

And thanks to us having an assertion, we noticed the bug the hard way.

For those interested, the full event log (with bunch of debug messages) can be found at https://gist.github.com/kazuho/3a1ac21cb4f4dcd33afdf3b6f386ee3e. This was taken by running commit c2232da.

Commit a706bcf is considered the correct fix.