### PR TITLE
fix issues in closing state

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -242,6 +242,7 @@ struct st_quicly_conn_t {
             uint16_t error_code;
             uint64_t frame_type; /* UINT64_MAX if application close */
             const char *reason_phrase;
+            unsigned long num_packets_received;
         } connection_close;
         /**
          *
@@ -4398,7 +4399,10 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     switch (conn->super.state) {
     case QUICLY_STATE_CLOSING:
         conn->super.state = QUICLY_STATE_DRAINING;
-        conn->egress.send_ack_at = 0; /* send CONNECTION_CLOSE */
+        ++conn->egress.connection_close.num_packets_received;
+        /* respond with a CONNECTION_CLOSE frame using exponential back-off */
+        if (__builtin_popcountl(conn->egress.connection_close.num_packets_received) == 1)
+            conn->egress.send_ack_at = 0;
         ret = 0;
         goto Exit;
     case QUICLY_STATE_DRAINING:

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2268,6 +2268,9 @@ static size_t calc_send_window(quicly_conn_t *conn, size_t min_bytes_to_send, in
 
 int64_t quicly_get_first_timeout(quicly_conn_t *conn)
 {
+    if (conn->super.state >= QUICLY_STATE_CLOSING)
+        return conn->egress.send_ack_at;
+
     if (calc_send_window(conn, 0, 0) > 0) {
         if (conn->pending.flows != 0)
             return 0;


### PR DESCRIPTION
#### Fix busy loop in CLOSING state
In `quicly_get_first_timeout`, we consult several values when trying to determine when the first timeout is. For example, if send window is available, and if any of the CRYPTO streams have data to be sent immediately (`conn->pending.flows`), we return 0 so that `quicly_send` is invoked as soon as possible. The problem is that these code paths of the `quicly_get_first_timeout` remains active in CLOSING state. In case of `conn->pending.flows`, when the connection is closed while there is inflight data in one of the crypto streams (this typically happens when under loss for Initial and Handshake packets), `conn->pending.flows` is kept non-zero.

The fix is to check the connection state in `quicly_get_first_timeout` and only consult the `send_ack_at` timeout (which, when in CLOSING state, indicates the moment a CONNECTION_CLOSE frame should be sent or when the connection can be discarded).

See commit 5c233d4.

### Exponential back-off

The transport draft requires a QUIC stack that does not decrypt incoming packets in the CLOSING state to exponentially reduce the frequency in which it sends a packet containing a close frame in response. e0e69ba finally implements that.