### PR TITLE
provide next_expected_pn

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -796,6 +796,10 @@ int quicly_close(quicly_conn_t *conn, int err, const char *reason_phrase);
  */
 int64_t quicly_get_first_timeout(quicly_conn_t *conn);
 /**
+ *
+ */
+uint64_t quicly_get_next_expected_packet_number(quicly_conn_t *conn);
+/**
  * returns if the connection is currently capped by connection-level flow control.
  */
 int quicly_is_flow_capped(quicly_conn_t *conn);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2291,6 +2291,14 @@ int64_t quicly_get_first_timeout(quicly_conn_t *conn)
     return at;
 }
 
+uint64_t quicly_get_next_expected_packet_number(quicly_conn_t *conn)
+{
+    if(!conn->application)
+         return UINT64_MAX;
+
+    return conn->application->super.next_expected_packet_number;
+}
+
 /* data structure that is used during one call through quicly_send()
  */
 struct st_quicly_send_context_t {


### PR DESCRIPTION
As explained here https://github.com/h2o/quicly/issues/245 we need to have access to the next expected packet number in order to properly offload packet encryption