### PR TITLE
Calculate sentmap expiration time in a more formal way

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3821,6 +3821,8 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
 
     init_acks_iter(conn, &iter);
 
+    /* TODO log PNs being ACKed too late */
+
     size_t gap_index = frame.num_gaps;
     while (1) {
         uint64_t block_length = frame.ack_block_lengths[gap_index];


### PR DESCRIPTION
Sentmap expiration time is a local value, and it can be anything greater than all of the following:
* expected duration of late ACKs
* 3PTO (we use sentmap expiration time as a close timer)

Though, it cannot be too long, as that would increase the amount of state the endpoint is required to maintain.

This PR formalizes the expiration time to 4 PTO.