### PR TITLE
Update states when receiving HANDSHAKE_DONE (amends #255)

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -578,7 +578,7 @@ static void assert_consistency(quicly_conn_t *conn, int timer_must_be_in_future)
         return;
     }
 
-    if (conn->egress.sentmap.bytes_in_flight != 0) {
+    if (conn->egress.sentmap.bytes_in_flight != 0 || conn->super.peer.address_validation.send_probe) {
         assert(conn->egress.loss.alarm_at != INT64_MAX);
     } else {
         assert(conn->egress.loss.loss_time == INT64_MAX);


### PR DESCRIPTION
* Previously, we stopped sending probes when receiving a Handshake ACK. Now, we need to do that for HANDSHAKE_DONE too, as a server might send HANSHAKE_DONE without ACKing any of the Handshake packets.
* Receipt of HANDSHAKE_DONE might cause the eviction of a Handshake packet that is still considered inflight. Call `update_loss_alarm` to compenstate for the state change.