### PR TITLE
Fix busyloop

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3221,7 +3221,7 @@ Exit:
     return packet;
 }
 
-static int send_handshake_flow(quicly_conn_t *conn, size_t epoch, quicly_send_context_t *s, int send_probe)
+static int send_handshake_flow(quicly_conn_t *conn, size_t epoch, quicly_send_context_t *s, int ack_only, int send_probe)
 {
     struct st_quicly_pn_space_t *ack_space = NULL;
     int ret = 0;
@@ -3249,22 +3249,24 @@ static int send_handshake_flow(quicly_conn_t *conn, size_t epoch, quicly_send_co
         if ((ret = send_ack(conn, ack_space, s)) != 0)
             goto Exit;
 
-    /* send data */
-    while ((conn->pending.flows & (uint8_t)(1 << epoch)) != 0) {
-        quicly_stream_t *stream = quicly_get_stream(conn, -(quicly_stream_id_t)(1 + epoch));
-        assert(stream != NULL);
-        if ((ret = quicly_send_stream(stream, s)) != 0)
-            goto Exit;
-        resched_stream_data(stream);
-        send_probe = 0;
-    }
+    if (!ack_only) {
+        /* send data */
+        while ((conn->pending.flows & (uint8_t)(1 << epoch)) != 0) {
+            quicly_stream_t *stream = quicly_get_stream(conn, -(quicly_stream_id_t)(1 + epoch));
+            assert(stream != NULL);
+            if ((ret = quicly_send_stream(stream, s)) != 0)
+                goto Exit;
+            resched_stream_data(stream);
+            send_probe = 0;
+        }
 
-    /* send probe if requested */
-    if (send_probe) {
-        if ((ret = _do_allocate_frame(conn, s, 1, 1)) != 0)
-            goto Exit;
-        *s->dst++ = QUICLY_FRAME_TYPE_PING;
-        conn->egress.last_retransmittable_sent_at = now;
+        /* send probe if requested */
+        if (send_probe) {
+            if ((ret = _do_allocate_frame(conn, s, 1, 1)) != 0)
+                goto Exit;
+            *s->dst++ = QUICLY_FRAME_TYPE_PING;
+            conn->egress.last_retransmittable_sent_at = now;
+        }
     }
 
 Exit:
@@ -3394,7 +3396,7 @@ static int update_traffic_key_cb(ptls_update_traffic_key_t *self, ptls_t *tls, i
 
 static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
 {
-    int restrict_sending = 0, ret;
+    int restrict_sending = 0, ack_only = 0, ret;
     size_t min_packets_to_send = 0;
 
     /* handle timeouts */
@@ -3427,103 +3429,101 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
     }
 
     s->send_window = calc_send_window(conn, min_packets_to_send * conn->super.ctx->max_packet_size, restrict_sending);
-    if (s->send_window == 0) {
-        ret = 0;
-        goto Exit;
-    }
+    if (s->send_window == 0)
+        ack_only = 1;
 
     /* send handshake flows */
-    if ((ret = send_handshake_flow(conn, QUICLY_EPOCH_INITIAL, s,
+    if ((ret = send_handshake_flow(conn, QUICLY_EPOCH_INITIAL, s, ack_only,
                                    restrict_sending ||
                                        (conn->super.peer.address_validation.send_probe && conn->handshake == NULL))) != 0)
         goto Exit;
-    if ((ret = send_handshake_flow(conn, QUICLY_EPOCH_HANDSHAKE, s,
+    if ((ret = send_handshake_flow(conn, QUICLY_EPOCH_HANDSHAKE, s, ack_only,
                                    restrict_sending || conn->super.peer.address_validation.send_probe)) != 0)
         goto Exit;
 
     /* send encrypted frames */
     if (conn->application != NULL && (s->current.cipher = &conn->application->cipher.egress.key)->header_protection != NULL) {
         s->current.first_byte = conn->application->one_rtt_writable ? QUICLY_QUIC_BIT : QUICLY_PACKET_TYPE_0RTT;
-        /* PTO, always send PING. This is the easiest thing to do in terms of timer control. */
-        if (restrict_sending) {
-            if ((ret = _do_allocate_frame(conn, s, 1, 1)) != 0)
+        /* acks */
+        if (conn->application->one_rtt_writable && conn->egress.send_ack_at <= now && conn->application->super.unacked_count != 0) {
+            if ((ret = send_ack(conn, &conn->application->super, s)) != 0)
                 goto Exit;
-            *s->dst++ = QUICLY_FRAME_TYPE_PING;
         }
-        /* take actions only permitted for short header packets */
-        if (conn->application->one_rtt_writable) {
-            /* send HANDSHAKE_DONE */
-            if ((conn->pending.flows & QUICLY_PENDING_FLOW_HANDSHAKE_DONE_BIT) != 0 && (ret = send_handshake_done(conn, s)) != 0)
-                goto Exit;
-            /* acks */
-            if (conn->egress.send_ack_at <= now && conn->application->super.unacked_count != 0) {
-                if ((ret = send_ack(conn, &conn->application->super, s)) != 0)
+        if (!ack_only) {
+            /* PTO, always send PING. This is the easiest thing to do in terms of timer control. */
+            if (restrict_sending) {
+                if ((ret = _do_allocate_frame(conn, s, 1, 1)) != 0)
                     goto Exit;
+                *s->dst++ = QUICLY_FRAME_TYPE_PING;
             }
-            /* post-handshake messages */
-            if ((conn->pending.flows & (uint8_t)(1 << QUICLY_EPOCH_1RTT)) != 0) {
-                quicly_stream_t *stream = quicly_get_stream(conn, -(1 + QUICLY_EPOCH_1RTT));
-                assert(stream != NULL);
-                if ((ret = quicly_send_stream(stream, s)) != 0)
+            /* take actions only permitted for short header packets */
+            if (conn->application->one_rtt_writable) {
+                /* send HANDSHAKE_DONE */
+                if ((conn->pending.flows & QUICLY_PENDING_FLOW_HANDSHAKE_DONE_BIT) != 0 && (ret = send_handshake_done(conn, s)) != 0)
                     goto Exit;
-                resched_stream_data(stream);
-            }
-            /* respond to all pending received PATH_CHALLENGE frames */
-            if (conn->egress.path_challenge.head != NULL) {
-                do {
-                    struct st_quicly_pending_path_challenge_t *c = conn->egress.path_challenge.head;
-                    if ((ret = allocate_frame(conn, s, QUICLY_PATH_CHALLENGE_FRAME_CAPACITY)) != 0)
+                /* post-handshake messages */
+                if ((conn->pending.flows & (uint8_t)(1 << QUICLY_EPOCH_1RTT)) != 0) {
+                    quicly_stream_t *stream = quicly_get_stream(conn, -(1 + QUICLY_EPOCH_1RTT));
+                    assert(stream != NULL);
+                    if ((ret = quicly_send_stream(stream, s)) != 0)
                         goto Exit;
-                    s->dst = quicly_encode_path_challenge_frame(s->dst, c->is_response, c->data);
-                    conn->egress.path_challenge.head = c->next;
-                    free(c);
-                } while (conn->egress.path_challenge.head != NULL);
-                conn->egress.path_challenge.tail_ref = &conn->egress.path_challenge.head;
-            }
-            /* send max_streams frames */
-            if ((ret = send_max_streams(conn, 1, s)) != 0)
-                goto Exit;
-            if ((ret = send_max_streams(conn, 0, s)) != 0)
-                goto Exit;
-            /* send connection-level flow control frame */
-            if (should_send_max_data(conn)) {
-                quicly_sent_t *sent;
-                if ((ret = allocate_ack_eliciting_frame(conn, s, QUICLY_MAX_DATA_FRAME_CAPACITY, &sent, on_ack_max_data)) != 0)
+                    resched_stream_data(stream);
+                }
+                /* respond to all pending received PATH_CHALLENGE frames */
+                if (conn->egress.path_challenge.head != NULL) {
+                    do {
+                        struct st_quicly_pending_path_challenge_t *c = conn->egress.path_challenge.head;
+                        if ((ret = allocate_frame(conn, s, QUICLY_PATH_CHALLENGE_FRAME_CAPACITY)) != 0)
+                            goto Exit;
+                        s->dst = quicly_encode_path_challenge_frame(s->dst, c->is_response, c->data);
+                        conn->egress.path_challenge.head = c->next;
+                        free(c);
+                    } while (conn->egress.path_challenge.head != NULL);
+                    conn->egress.path_challenge.tail_ref = &conn->egress.path_challenge.head;
+                }
+                /* send max_streams frames */
+                if ((ret = send_max_streams(conn, 1, s)) != 0)
                     goto Exit;
-                uint64_t new_value = conn->ingress.max_data.bytes_consumed + conn->super.ctx->transport_params.max_data;
-                s->dst = quicly_encode_max_data_frame(s->dst, new_value);
-                quicly_maxsender_record(&conn->ingress.max_data.sender, new_value, &sent->data.max_data.args);
-                QUICLY_PROBE(MAX_DATA_SEND, conn, probe_now(), new_value);
+                if ((ret = send_max_streams(conn, 0, s)) != 0)
+                    goto Exit;
+                /* send connection-level flow control frame */
+                if (should_send_max_data(conn)) {
+                    quicly_sent_t *sent;
+                    if ((ret = allocate_ack_eliciting_frame(conn, s, QUICLY_MAX_DATA_FRAME_CAPACITY, &sent, on_ack_max_data)) != 0)
+                        goto Exit;
+                    uint64_t new_value = conn->ingress.max_data.bytes_consumed + conn->super.ctx->transport_params.max_data;
+                    s->dst = quicly_encode_max_data_frame(s->dst, new_value);
+                    quicly_maxsender_record(&conn->ingress.max_data.sender, new_value, &sent->data.max_data.args);
+                    QUICLY_PROBE(MAX_DATA_SEND, conn, probe_now(), new_value);
+                }
+                /* send streams_blocked frames */
+                if ((ret = send_streams_blocked(conn, 1, s)) != 0)
+                    goto Exit;
+                if ((ret = send_streams_blocked(conn, 0, s)) != 0)
+                    goto Exit;
+                /* send NEW_TOKEN */
+                if ((conn->pending.flows & QUICLY_PENDING_FLOW_NEW_TOKEN_BIT) != 0 && (ret = send_resumption_token(conn, s)) != 0)
+                    goto Exit;
             }
-            /* send streams_blocked frames */
-            if ((ret = send_streams_blocked(conn, 1, s)) != 0)
-                goto Exit;
-            if ((ret = send_streams_blocked(conn, 0, s)) != 0)
-                goto Exit;
-            /* send NEW_TOKEN */
-            if ((conn->pending.flows & QUICLY_PENDING_FLOW_NEW_TOKEN_BIT) != 0 && (ret = send_resumption_token(conn, s)) != 0)
+            /* send stream-level control frames */
+            while (s->num_packets != s->max_packets && quicly_linklist_is_linked(&conn->pending.streams.control)) {
+                quicly_stream_t *stream =
+                    (void *)((char *)conn->pending.streams.control.next - offsetof(quicly_stream_t, _send_aux.pending_link.control));
+                if ((ret = send_stream_control_frames(stream, s)) != 0)
+                    goto Exit;
+                quicly_linklist_unlink(&stream->_send_aux.pending_link.control);
+            }
+            /* send STREAM frames */
+            if ((ret = conn->super.ctx->stream_scheduler->do_send(conn->super.ctx->stream_scheduler, conn, s)) != 0)
                 goto Exit;
         }
-        /* send stream-level control frames */
-        while (s->num_packets != s->max_packets && quicly_linklist_is_linked(&conn->pending.streams.control)) {
-            quicly_stream_t *stream =
-                (void *)((char *)conn->pending.streams.control.next - offsetof(quicly_stream_t, _send_aux.pending_link.control));
-            if ((ret = send_stream_control_frames(stream, s)) != 0)
-                goto Exit;
-            quicly_linklist_unlink(&stream->_send_aux.pending_link.control);
-        }
-        /* send STREAM frames */
-        if ((ret = conn->super.ctx->stream_scheduler->do_send(conn->super.ctx->stream_scheduler, conn, s)) != 0)
-            goto Exit;
     }
 
-    if (s->target.packet != NULL)
-        commit_send_packet(conn, s, 0);
-
-    ret = 0;
 Exit:
     if (ret == QUICLY_ERROR_SENDBUF_FULL)
         ret = 0;
+    if (ret == 0 && s->target.packet != NULL)
+        commit_send_packet(conn, s, 0);
     if (ret == 0) {
         if (conn->application == NULL || conn->application->super.unacked_count == 0)
             conn->egress.send_ack_at = INT64_MAX; /* we have sent ACKs for every epoch (or before address validation) */


### PR DESCRIPTION
Fixes two conditions under with `quicly_get_first_timeout` returns "now" but `quicly_send` fails to make progress. The two conditions are:
* Ack timer fires but available send window is zero. We should be sending ACK-only packets, but we send nothing, and ack timer does not get updated.
* There is data to be sent, there is nothing to be ACKed, and available send window is non-zero but below 64 bytes. `_do_allocate_frame` refuses to build a new packet in such case, and nothing gets sent. The condition stays the same (i.e., there is data to be sent and *some* send window is available).

Note: When available send window is no less than 64 bytes, we are sending at most one full-sized packet. We might want to better. But that can go in as a separate PR.