### PR TITLE
let stream callbacks communicate errors using `quicly_close`

### DIFF
--- a/examples/echo.c
+++ b/examples/echo.c
@@ -115,27 +115,23 @@ static int forward_stdin(quicly_conn_t *conn)
     }
 }
 
-static int on_stop_sending(quicly_stream_t *stream, int err)
+static void on_stop_sending(quicly_stream_t *stream, int err)
 {
     fprintf(stderr, "received STOP_SENDING: %" PRIu16 "\n", QUICLY_ERROR_GET_ERROR_CODE(err));
     quicly_close(stream->conn, QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(0), "");
-    return 0;
 }
 
-static int on_receive_reset(quicly_stream_t *stream, int err)
+static void on_receive_reset(quicly_stream_t *stream, int err)
 {
     fprintf(stderr, "received RESET_STREAM: %" PRIu16 "\n", QUICLY_ERROR_GET_ERROR_CODE(err));
     quicly_close(stream->conn, QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(0), "");
-    return 0;
 }
 
-static int on_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len)
+static void on_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len)
 {
-    int ret;
-
     /* read input to receive buffer */
-    if ((ret = quicly_streambuf_ingress_receive(stream, off, src, len)) != 0)
-        return ret;
+    if (quicly_streambuf_ingress_receive(stream, off, src, len) != 0)
+        return;
 
     /* obtain contiguous bytes from the receive buffer */
     ptls_iovec_t input = quicly_streambuf_ingress_get(stream);
@@ -159,8 +155,6 @@ static int on_receive(quicly_stream_t *stream, size_t off, const void *src, size
 
     /* remove used bytes from receive buffer */
     quicly_streambuf_ingress_shift(stream, input.len);
-
-    return 0;
 }
 
 static void process_msg(int is_client, quicly_conn_t **conns, struct msghdr *msg, size_t dgram_len)

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -528,22 +528,22 @@ typedef struct st_quicly_stream_callbacks_t {
      * As this callback is triggered by calling quicly_stream_sync_sendbuf (stream, 1) when tx data is present, it assumes data
      * to be available - that is `len` return value should be non-zero.
      */
-    int (*on_send_emit)(quicly_stream_t *stream, size_t off, void *dst, size_t *len, int *wrote_all);
+    void (*on_send_emit)(quicly_stream_t *stream, size_t off, void *dst, size_t *len, int *wrote_all);
     /**
      * called when a STOP_SENDING frame is received.  Do not call `quicly_reset_stream` in response.  The stream will be
      * automatically reset by quicly.
      */
-    int (*on_send_stop)(quicly_stream_t *stream, int err);
+    void (*on_send_stop)(quicly_stream_t *stream, int err);
     /**
      * called when data is newly received.  `off` is the offset within the buffer (the beginning position changes as the application
      * calls `quicly_stream_sync_recvbuf`.  Applications should consult `quicly_stream_t::recvstate` to see if it has contiguous
      * input.
      */
-    int (*on_receive)(quicly_stream_t *stream, size_t off, const void *src, size_t len);
+    void (*on_receive)(quicly_stream_t *stream, size_t off, const void *src, size_t len);
     /**
      * called when a RESET_STREAM frame is received
      */
-    int (*on_receive_reset)(quicly_stream_t *stream, int err);
+    void (*on_receive_reset)(quicly_stream_t *stream, int err);
 } quicly_stream_callbacks_t;
 
 struct st_quicly_stream_t {

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -978,19 +978,19 @@ void quicly_stream_noop_on_send_shift(quicly_stream_t *stream, size_t delta);
 /**
  *
  */
-int quicly_stream_noop_on_send_emit(quicly_stream_t *stream, size_t off, void *dst, size_t *len, int *wrote_all);
+void quicly_stream_noop_on_send_emit(quicly_stream_t *stream, size_t off, void *dst, size_t *len, int *wrote_all);
 /**
  *
  */
-int quicly_stream_noop_on_send_stop(quicly_stream_t *stream, int err);
+void quicly_stream_noop_on_send_stop(quicly_stream_t *stream, int err);
 /**
  *
  */
-int quicly_stream_noop_on_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len);
+void quicly_stream_noop_on_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len);
 /**
  *
  */
-int quicly_stream_noop_on_receive_reset(quicly_stream_t *stream, int err);
+void quicly_stream_noop_on_receive_reset(quicly_stream_t *stream, int err);
 
 extern const quicly_stream_callbacks_t quicly_stream_noop_callbacks;
 

--- a/include/quicly/constants.h
+++ b/include/quicly/constants.h
@@ -73,6 +73,7 @@ extern "C" {
 #define QUICLY_ERROR_FREE_CONNECTION 0xff03 /* returned by quicly_send when the connection is freeable */
 #define QUICLY_ERROR_RECEIVED_STATELESS_RESET 0xff04
 #define QUICLY_ERROR_NO_COMPATIBLE_VERSION 0xff05
+#define QUICLY_ERROR_IS_CLOSING 0xff06 /* indicates that the connection has already entered closing state */
 
 #define QUICLY_BUILD_ASSERT(condition) ((void)sizeof(char[2 * !!(!__builtin_constant_p(condition) || (condition)) - 1]))
 

--- a/include/quicly/streambuf.h
+++ b/include/quicly/streambuf.h
@@ -110,7 +110,7 @@ ptls_iovec_t quicly_recvbuf_get(quicly_stream_t *stream, ptls_buffer_t *rb);
 /**
  * The concrete function for `quicly_stream_callbacks_t::on_receive`.
  */
-void quicly_recvbuf_receive(quicly_stream_t *stream, ptls_buffer_t *rb, size_t off, const void *src, size_t len);
+int quicly_recvbuf_receive(quicly_stream_t *stream, ptls_buffer_t *rb, size_t off, const void *src, size_t len);
 
 /**
  * The simple stream buffer.  The API assumes that stream->data points to quicly_streambuf_t.  Applications can extend the structure
@@ -130,7 +130,12 @@ static int quicly_streambuf_egress_write_vec(quicly_stream_t *stream, quicly_sen
 int quicly_streambuf_egress_shutdown(quicly_stream_t *stream);
 static void quicly_streambuf_ingress_shift(quicly_stream_t *stream, size_t delta);
 static ptls_iovec_t quicly_streambuf_ingress_get(quicly_stream_t *stream);
-void quicly_streambuf_ingress_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len);
+/**
+ * Writes given data into `quicly_stream_buf_t::ingress` and returns 0 if successful. Upon failure, `quicly_close` is called
+ * automatically, and a non-zero value is returned. Applications can ignore the returned value, or use it to find out if it can use
+ * the information stored in the ingress buffer.
+ */
+int quicly_streambuf_ingress_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len);
 
 /* inline definitions */
 

--- a/include/quicly/streambuf.h
+++ b/include/quicly/streambuf.h
@@ -87,7 +87,7 @@ void quicly_sendbuf_shift(quicly_stream_t *stream, quicly_sendbuf_t *sb, size_t 
 /**
  * The concrete function for `quicly_stream_callbacks_t::on_send_emit`.
  */
-int quicly_sendbuf_emit(quicly_stream_t *stream, quicly_sendbuf_t *sb, size_t off, void *dst, size_t *len, int *wrote_all);
+void quicly_sendbuf_emit(quicly_stream_t *stream, quicly_sendbuf_t *sb, size_t off, void *dst, size_t *len, int *wrote_all);
 /**
  * Appends some bytes to the send buffer.  The data being appended is copied.
  */
@@ -110,7 +110,7 @@ ptls_iovec_t quicly_recvbuf_get(quicly_stream_t *stream, ptls_buffer_t *rb);
 /**
  * The concrete function for `quicly_stream_callbacks_t::on_receive`.
  */
-int quicly_recvbuf_receive(quicly_stream_t *stream, ptls_buffer_t *rb, size_t off, const void *src, size_t len);
+void quicly_recvbuf_receive(quicly_stream_t *stream, ptls_buffer_t *rb, size_t off, const void *src, size_t len);
 
 /**
  * The simple stream buffer.  The API assumes that stream->data points to quicly_streambuf_t.  Applications can extend the structure
@@ -124,13 +124,13 @@ typedef struct st_quicly_streambuf_t {
 int quicly_streambuf_create(quicly_stream_t *stream, size_t sz);
 void quicly_streambuf_destroy(quicly_stream_t *stream, int err);
 static void quicly_streambuf_egress_shift(quicly_stream_t *stream, size_t delta);
-int quicly_streambuf_egress_emit(quicly_stream_t *stream, size_t off, void *dst, size_t *len, int *wrote_all);
+void quicly_streambuf_egress_emit(quicly_stream_t *stream, size_t off, void *dst, size_t *len, int *wrote_all);
 static int quicly_streambuf_egress_write(quicly_stream_t *stream, const void *src, size_t len);
 static int quicly_streambuf_egress_write_vec(quicly_stream_t *stream, quicly_sendbuf_vec_t *vec);
 int quicly_streambuf_egress_shutdown(quicly_stream_t *stream);
 static void quicly_streambuf_ingress_shift(quicly_stream_t *stream, size_t delta);
 static ptls_iovec_t quicly_streambuf_ingress_get(quicly_stream_t *stream);
-int quicly_streambuf_ingress_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len);
+void quicly_streambuf_ingress_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len);
 
 /* inline definitions */
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -764,8 +764,7 @@ void crypto_stream_receive(quicly_stream_t *stream, size_t off, const void *src,
     ptls_iovec_t input;
     ptls_buffer_t output;
 
-    quicly_streambuf_ingress_receive(stream, off, src, len);
-    if (conn->super.state >= QUICLY_STATE_CLOSING)
+    if (quicly_streambuf_ingress_receive(stream, off, src, len) != 0)
         return;
 
     ptls_buffer_init(&output, "", 0);

--- a/lib/streambuf.c
+++ b/lib/streambuf.c
@@ -24,6 +24,20 @@
 #include <string.h>
 #include "quicly/streambuf.h"
 
+static void convert_error(quicly_stream_t *stream, int err)
+{
+    assert(err != 0);
+    if (QUICLY_ERROR_IS_QUIC_APPLICATION(err)) {
+        if (quicly_stream_has_send_side(quicly_is_client(stream->conn), stream->stream_id) &&
+            quicly_sendstate_is_open(&stream->sendstate))
+            quicly_reset_stream(stream, err);
+        if (quicly_stream_has_receive_side(quicly_is_client(stream->conn), stream->stream_id))
+            quicly_request_stop(stream, err);
+    } else {
+        quicly_close(stream->conn, QUICLY_ERROR_IS_QUIC_TRANSPORT(err) ? err : QUICLY_TRANSPORT_ERROR_INTERNAL, NULL);
+    }
+}
+
 void quicly_sendbuf_dispose(quicly_sendbuf_t *sb)
 {
     size_t i;
@@ -67,7 +81,7 @@ void quicly_sendbuf_shift(quicly_stream_t *stream, quicly_sendbuf_t *sb, size_t 
     quicly_stream_sync_sendbuf(stream, 0);
 }
 
-int quicly_sendbuf_emit(quicly_stream_t *stream, quicly_sendbuf_t *sb, size_t off, void *dst, size_t *len, int *wrote_all)
+void quicly_sendbuf_emit(quicly_stream_t *stream, quicly_sendbuf_t *sb, size_t off, void *dst, size_t *len, int *wrote_all)
 {
     size_t vec_index, capacity = *len;
     int ret;
@@ -82,8 +96,10 @@ int quicly_sendbuf_emit(quicly_stream_t *stream, quicly_sendbuf_t *sb, size_t of
                 bytes_flatten = capacity;
                 partial = 1;
             }
-            if ((ret = vec->cb->flatten_vec(vec, dst, off, bytes_flatten)) != 0)
-                return ret;
+            if ((ret = vec->cb->flatten_vec(vec, dst, off, bytes_flatten)) != 0) {
+                convert_error(stream, ret);
+                return;
+            }
             dst = (uint8_t *)dst + bytes_flatten;
             capacity -= bytes_flatten;
             off = 0;
@@ -100,8 +116,6 @@ int quicly_sendbuf_emit(quicly_stream_t *stream, quicly_sendbuf_t *sb, size_t of
         *len = *len - capacity;
         *wrote_all = 1;
     }
-
-    return 0;
 }
 
 static int flatten_raw(quicly_sendbuf_vec_t *vec, void *dst, size_t off, size_t len)
@@ -179,17 +193,18 @@ ptls_iovec_t quicly_recvbuf_get(quicly_stream_t *stream, ptls_buffer_t *rb)
     return ptls_iovec_init(rb->base, avail);
 }
 
-int quicly_recvbuf_receive(quicly_stream_t *stream, ptls_buffer_t *rb, size_t off, const void *src, size_t len)
+void quicly_recvbuf_receive(quicly_stream_t *stream, ptls_buffer_t *rb, size_t off, const void *src, size_t len)
 {
     if (len != 0) {
         int ret;
-        if ((ret = ptls_buffer_reserve(rb, off + len - rb->off)) != 0)
-            return ret;
+        if ((ret = ptls_buffer_reserve(rb, off + len - rb->off)) != 0) {
+            convert_error(stream, ret);
+            return;
+        }
         memcpy(rb->base + off, src, len);
         if (rb->off < off + len)
             rb->off = off + len;
     }
-    return 0;
 }
 
 int quicly_streambuf_create(quicly_stream_t *stream, size_t sz)
@@ -220,10 +235,10 @@ void quicly_streambuf_destroy(quicly_stream_t *stream, int err)
     stream->data = NULL;
 }
 
-int quicly_streambuf_egress_emit(quicly_stream_t *stream, size_t off, void *dst, size_t *len, int *wrote_all)
+void quicly_streambuf_egress_emit(quicly_stream_t *stream, size_t off, void *dst, size_t *len, int *wrote_all)
 {
     quicly_streambuf_t *sbuf = stream->data;
-    return quicly_sendbuf_emit(stream, &sbuf->egress, off, dst, len, wrote_all);
+    quicly_sendbuf_emit(stream, &sbuf->egress, off, dst, len, wrote_all);
 }
 
 int quicly_streambuf_egress_shutdown(quicly_stream_t *stream)
@@ -233,8 +248,8 @@ int quicly_streambuf_egress_shutdown(quicly_stream_t *stream)
     return quicly_stream_sync_sendbuf(stream, 1);
 }
 
-int quicly_streambuf_ingress_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len)
+void quicly_streambuf_ingress_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len)
 {
     quicly_streambuf_t *sbuf = stream->data;
-    return quicly_recvbuf_receive(stream, &sbuf->ingress, off, src, len);
+    quicly_recvbuf_receive(stream, &sbuf->ingress, off, src, len);
 }

--- a/lib/streambuf.c
+++ b/lib/streambuf.c
@@ -193,18 +193,19 @@ ptls_iovec_t quicly_recvbuf_get(quicly_stream_t *stream, ptls_buffer_t *rb)
     return ptls_iovec_init(rb->base, avail);
 }
 
-void quicly_recvbuf_receive(quicly_stream_t *stream, ptls_buffer_t *rb, size_t off, const void *src, size_t len)
+int quicly_recvbuf_receive(quicly_stream_t *stream, ptls_buffer_t *rb, size_t off, const void *src, size_t len)
 {
     if (len != 0) {
         int ret;
         if ((ret = ptls_buffer_reserve(rb, off + len - rb->off)) != 0) {
             convert_error(stream, ret);
-            return;
+            return -1;
         }
         memcpy(rb->base + off, src, len);
         if (rb->off < off + len)
             rb->off = off + len;
     }
+    return 0;
 }
 
 int quicly_streambuf_create(quicly_stream_t *stream, size_t sz)
@@ -248,8 +249,8 @@ int quicly_streambuf_egress_shutdown(quicly_stream_t *stream)
     return quicly_stream_sync_sendbuf(stream, 1);
 }
 
-void quicly_streambuf_ingress_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len)
+int quicly_streambuf_ingress_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len)
 {
     quicly_streambuf_t *sbuf = stream->data;
-    quicly_recvbuf_receive(stream, &sbuf->ingress, off, src, len);
+    return quicly_recvbuf_receive(stream, &sbuf->ingress, off, src, len);
 }

--- a/src/cli.c
+++ b/src/cli.c
@@ -284,8 +284,7 @@ static void server_on_receive(quicly_stream_t *stream, size_t off, const void *s
     if (!quicly_sendstate_is_open(&stream->sendstate))
         return;
 
-    quicly_streambuf_ingress_receive(stream, off, src, len);
-    if (quicly_get_state(stream->conn) >= QUICLY_STATE_CLOSING)
+    if (quicly_streambuf_ingress_receive(stream, off, src, len) != 0)
         return;
 
     if (!parse_request(quicly_streambuf_ingress_get(stream), &path, &is_http1)) {
@@ -320,8 +319,7 @@ static void client_on_receive(quicly_stream_t *stream, size_t off, const void *s
     struct st_stream_data_t *stream_data = stream->data;
     ptls_iovec_t input;
 
-    quicly_streambuf_ingress_receive(stream, off, src, len);
-    if (quicly_get_state(stream->conn) >= QUICLY_STATE_CLOSING)
+    if (quicly_streambuf_ingress_receive(stream, off, src, len) != 0)
         return;
 
     if ((input = quicly_streambuf_ingress_get(stream)).len != 0) {

--- a/t/test.c
+++ b/t/test.c
@@ -85,13 +85,14 @@
 
 static void on_destroy(quicly_stream_t *stream, int err);
 static void on_egress_stop(quicly_stream_t *stream, int err);
+static void on_ingress_receive(quicly_stream_t *stream,  size_t off, const void *src, size_t len);
 static void on_ingress_reset(quicly_stream_t *stream, int err);
 
 quicly_address_t fake_address;
 int64_t quic_now;
 quicly_context_t quic_ctx;
 quicly_stream_callbacks_t stream_callbacks = {on_destroy,     quicly_streambuf_egress_shift,    quicly_streambuf_egress_emit,
-                                              on_egress_stop, quicly_streambuf_ingress_receive, on_ingress_reset};
+                                              on_egress_stop, on_ingress_receive, on_ingress_reset};
 size_t on_destroy_callcnt;
 
 static int64_t get_now_cb(quicly_now_t *self)
@@ -113,6 +114,11 @@ void on_egress_stop(quicly_stream_t *stream, int err)
     assert(QUICLY_ERROR_IS_QUIC_APPLICATION(err));
     test_streambuf_t *sbuf = stream->data;
     sbuf->error_received.stop_sending = err;
+}
+
+void on_ingress_receive(quicly_stream_t *stream,  size_t off, const void *src, size_t len)
+{
+    quicly_streambuf_ingress_receive(stream, off, src, len);
 }
 
 void on_ingress_reset(quicly_stream_t *stream, int err)

--- a/t/test.c
+++ b/t/test.c
@@ -84,8 +84,8 @@
     "-----END CERTIFICATE-----\n"
 
 static void on_destroy(quicly_stream_t *stream, int err);
-static int on_egress_stop(quicly_stream_t *stream, int err);
-static int on_ingress_reset(quicly_stream_t *stream, int err);
+static void on_egress_stop(quicly_stream_t *stream, int err);
+static void on_ingress_reset(quicly_stream_t *stream, int err);
 
 quicly_address_t fake_address;
 int64_t quic_now;
@@ -108,20 +108,18 @@ void on_destroy(quicly_stream_t *stream, int err)
     ++on_destroy_callcnt;
 }
 
-int on_egress_stop(quicly_stream_t *stream, int err)
+void on_egress_stop(quicly_stream_t *stream, int err)
 {
     assert(QUICLY_ERROR_IS_QUIC_APPLICATION(err));
     test_streambuf_t *sbuf = stream->data;
     sbuf->error_received.stop_sending = err;
-    return 0;
 }
 
-int on_ingress_reset(quicly_stream_t *stream, int err)
+void on_ingress_reset(quicly_stream_t *stream, int err)
 {
     assert(QUICLY_ERROR_IS_QUIC_APPLICATION(err));
     test_streambuf_t *sbuf = stream->data;
     sbuf->error_received.reset_stream = err;
-    return 0;
 }
 
 const quicly_cid_plaintext_t *new_master_id(void)


### PR DESCRIPTION
Until now, we have two ways of indicating connection errors from applications:
* call `quicly_close`
* return an error code in one of the stream-level callbacks defined in `quicly_stream_callbacks_t`

Note in contrast, there has been only one way of communicating stream resets (through `quicly_reset_stream`).

It is needlessly complex to have two ways of communicating the same thing. Hence this PR for fixing the issue. `quicly_close` would be the only API for closing the connection.