### PR TITLE
send CONNECTION_CLOSE at least once

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -243,6 +243,7 @@ struct st_quicly_conn_t {
             uint64_t frame_type; /* UINT64_MAX if application close */
             const char *reason_phrase;
             unsigned long num_packets_received;
+            unsigned long num_sent;
         } connection_close;
         /**
          *
@@ -3308,6 +3309,8 @@ static int send_connection_close(quicly_conn_t *conn, quicly_send_context_t *s)
     memcpy(s->dst, conn->egress.connection_close.reason_phrase, reason_phrase_len);
     s->dst += reason_phrase_len;
 
+    ++conn->egress.connection_close.num_sent;
+
     if (conn->egress.connection_close.frame_type != UINT64_MAX) {
         QUICLY_PROBE(TRANSPORT_CLOSE_SEND, conn, probe_now(), conn->egress.connection_close.error_code,
                      conn->egress.connection_close.frame_type, conn->egress.connection_close.reason_phrase);
@@ -3564,11 +3567,13 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
                  QUICLY_PROBE_HEXDUMP(conn->super.peer.cid.cid, conn->super.peer.cid.len));
 
     if (conn->super.state >= QUICLY_STATE_CLOSING) {
-        /* check if the connection can be closed now (after 3 pto) */
         quicly_sentmap_iter_t iter;
         init_acks_iter(conn, &iter);
-        if (quicly_sentmap_get(&iter)->packet_number == UINT64_MAX)
-            return QUICLY_ERROR_FREE_CONNECTION;
+        /* check if the connection can be closed now (after 3 pto) */
+        if (conn->super.state == QUICLY_STATE_DRAINING || conn->egress.connection_close.num_sent != 0) {
+            if (quicly_sentmap_get(&iter)->packet_number == UINT64_MAX)
+                return QUICLY_ERROR_FREE_CONNECTION;
+        }
         if (conn->super.state == QUICLY_STATE_CLOSING && conn->egress.send_ack_at <= now) {
             destroy_all_streams(conn, 0, 0); /* delayed until the emission of CONNECTION_CLOSE frame to allow quicly_close to be
                                               * called from a stream handler */
@@ -3587,8 +3592,9 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
             if ((ret = commit_send_packet(conn, &s, 0)) != 0)
                 return ret;
         }
-        conn->egress.send_ack_at = quicly_sentmap_get(&iter)->sent_at + get_sentmap_expiration_time(conn);
-        assert(conn->egress.send_ack_at > now);
+        /* wait at least 1ms */
+        if ((conn->egress.send_ack_at = quicly_sentmap_get(&iter)->sent_at + get_sentmap_expiration_time(conn)) <= now)
+            conn->egress.send_ack_at = now + 1;
         *num_packets = s.num_packets;
         return 0;
     }


### PR DESCRIPTION
When `quicly_close` is being called, quicly schedules an immediate timeout, and also calculates and retains `now + 3 PTO` - the moment to discard the connection.

In an unlikely event where the immediate timeout fires when or after that `now + 3 PTO`, the connection state is discarded without sending a single CONNECTION_CLOSE or destroying open streams (by calling `destroy_all_streams`).

This PR addresses the issue by remembering the number of CONNECTION_CLOSE frames being sent. When a timeout fires for the first time, quicly now sends a CONNECTION_CLOSE regardless of the time. Then, it waits for the later moment of the following two: current time + 1 ms, or, the original `now + 3 PTO`.