### PR TITLE
Limit number of stream-level receive ranges

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -620,6 +620,10 @@ struct st_quicly_stream_t {
          * size of the receive window
          */
         uint32_t window;
+        /**
+         * maximum number of ranges (i.e. gaps + 1) permitted in `recvstate.ranges`
+         */
+        uint32_t max_ranges;
     } _recv_aux;
 };
 

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -75,6 +75,11 @@ extern "C" {
 #define QUICLY_PATH_CHALLENGE_FRAME_CAPACITY (1 + 8)
 #define QUICLY_STREAM_FRAME_CAPACITY (1 + 8 + 8 + 1)
 
+/**
+ * maximum number of ACK blocks (inclusive)
+ */
+#define QUICLY_MAX_ACK_BLOCKS 64
+
 static uint16_t quicly_decode16(const uint8_t **src);
 static uint32_t quicly_decode24(const uint8_t **src);
 static uint32_t quicly_decode32(const uint8_t **src);

--- a/include/quicly/ranges.h
+++ b/include/quicly/ranges.h
@@ -30,12 +30,6 @@ extern "C" {
 #include <stdint.h>
 #include <stdlib.h>
 
-/**
- * maximum number of ranges (inclusive) that can be contained by quicly_ranges_t.  Functions would report error if the requested
- * operation causes the structure to exceed that limit.
- */
-#define QUICLY_MAX_RANGES 63
-
 typedef struct st_quicly_range_t {
     uint64_t start;
     uint64_t end; /* non-inclusive */
@@ -68,9 +62,9 @@ int quicly_ranges_add(quicly_ranges_t *ranges, uint64_t start, uint64_t end);
  */
 int quicly_ranges_subtract(quicly_ranges_t *ranges, uint64_t start, uint64_t end);
 /**
- * removes the smallest range (e.g., the old ACK range)
+ * removes ranges->ranges[I] where begin_index <= I && I < end_index
  */
-void quicly_ranges_drop_smallest_range(quicly_ranges_t *ranges);
+void quicly_ranges_drop_by_range_indices(quicly_ranges_t *ranges, size_t begin_index, size_t end_index);
 
 /* inline functions */
 

--- a/include/quicly/recvstate.h
+++ b/include/quicly/recvstate.h
@@ -51,7 +51,12 @@ void quicly_recvstate_init_closed(quicly_recvstate_t *state);
 void quicly_recvstate_dispose(quicly_recvstate_t *state);
 static int quicly_recvstate_transfer_complete(quicly_recvstate_t *state);
 static size_t quicly_recvstate_bytes_available(quicly_recvstate_t *state);
-int quicly_recvstate_update(quicly_recvstate_t *state, uint64_t off, size_t *len, int is_fin);
+/**
+ * Records that the range identified by (off, *len) has been received. When 0 (success) is returned, *len contains the number of
+ * bytes that might have been newly received and therefore need to be written to the receive buffer (this number of bytes counts
+ * backward from the end of given range).
+ */
+int quicly_recvstate_update(quicly_recvstate_t *state, uint64_t off, size_t *len, int is_fin, size_t max_ranges);
 int quicly_recvstate_reset(quicly_recvstate_t *state, uint64_t eos_at, uint64_t *bytes_missing);
 
 /* inline definitions */

--- a/lib/frame.c
+++ b/lib/frame.c
@@ -50,7 +50,7 @@ uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t
     *dst++ = QUICLY_FRAME_TYPE_ACK;
     dst = quicly_encodev(dst, ranges->ranges[range_index].end - 1); /* largest acknowledged */
     dst = quicly_encodev(dst, ack_delay);                           /* ack delay */
-    QUICLY_BUILD_ASSERT(QUICLY_MAX_RANGES - 1 <= 63);
+    QUICLY_BUILD_ASSERT(QUICLY_MAX_ACK_BLOCKS - 1 <= 63);
     *dst++ = (uint8_t)(ranges->num_ranges - 1); /* ack blocks */
 
     while (1) {


### PR DESCRIPTION
Fixes #278.

As discussed in the issue,
* maximum number of ranges in the stream-level receive buffer is capped to `max(63, receive_window_in_bytes / 1024)`,
* there is no cap on number of ranges for stream-level send buffer
* maximum number of ranges retained in ACK queue continues to be 63
