### PR TITLE
add support for GSO

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -436,7 +436,7 @@ static void do_send_gso(int fd, quicly_datagram_t **packets, size_t num_packets,
 
 static void send_packets_gso(int fd, quicly_datagram_t **packets, size_t num_packets, quicly_packet_allocator_t *pa)
 {
-    /* send packets using GSO, coalescing up to 10 same-sized datagrams, with the exception that the last datagram might be of
+    /* send packets using GSO, coalescing up to MAX_BURST_PACKETS same-sized datagrams, with the exception that the last datagram might be of
      * different size */
     size_t gso_from = 0;
     for (size_t i = 1; i < num_packets; ++i) {

--- a/src/cli.c
+++ b/src/cli.c
@@ -36,6 +36,8 @@
 #include "quicly/streambuf.h"
 #include "../deps/picotls/t/util.h"
 
+#define MAX_BURST_PACKETS 10
+
 FILE *quicly_trace_fp = NULL;
 static unsigned verbosity = 0;
 static int suppress_output = 0;
@@ -441,7 +443,7 @@ static void send_packets_gso(int fd, quicly_datagram_t **packets, size_t num_pac
         if (packets[i]->data.len > packets[gso_from]->data.len) {
             do_send_gso(fd, packets + gso_from, i - gso_from, pa);
             gso_from = i;
-        } else if (packets[i]->data.len != packets[gso_from]->data.len || i + 1 - gso_from >= 10) {
+        } else if (packets[i]->data.len != packets[gso_from]->data.len || i + 1 - gso_from >= MAX_BURST_PACKETS) {
             do_send_gso(fd, packets + gso_from, i + 1 - gso_from, pa);
             gso_from = i + 1;
             i = i + 1;
@@ -482,7 +484,7 @@ static void (*send_packets)(int, quicly_datagram_t **, size_t, quicly_packet_all
 
 static int send_pending(int fd, quicly_conn_t *conn)
 {
-    quicly_datagram_t *packets[16];
+    quicly_datagram_t *packets[MAX_BURST_PACKETS];
     size_t num_packets = sizeof(packets) / sizeof(packets[0]);
     int ret;
 


### PR DESCRIPTION
This pull request adds the `-g` option to the cli command, that turns on generic segmentation offload<sup>1</sup>.

Below are the sustainable transfer rates on Intel Core m3-6Y30 (capped to 400MHz) running  ubuntu 19.10 (linux 5.3.0-40-generic), local gbe network with no additional latency:
|branch|Mbps|increase|
|:---:|:---:|:---:|
|master|332.7||
|connected socket<sup>2</sup>|356.4|+7.1%|
|gso|439.1|+32.0%|

In this benchmark, number of UDP datagrams that we coalesce into one system call was limited to 10.

Below is the profile taken while running the gso branch running the benchmark above. As can be seen, 50% of CPU cycles are consumed by sendmsg (2), 25% is devoted to crypto.
![Screen Shot 2020-03-09 at 3 06 27 PM](https://user-images.githubusercontent.com/41567/76187024-92823c80-6217-11ea-8adf-0e7f50cb4f78.png)


[1] http://vger.kernel.org/lpc_net2018_talks/willemdebruijn-lpc2018-udpgso-paper-DRAFT-1.pdf
[2] kazuho/connected-socket-serveronly branch