### PR TITLE
Add more probes

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4079,11 +4079,22 @@ static int handle_path_challenge_frame(quicly_conn_t *conn, struct st_quicly_han
 
     if ((ret = quicly_decode_path_challenge_frame(&state->src, state->end, &frame)) != 0)
         return ret;
+
+    QUICLY_PROBE(PATH_CHALLENGE_RECEIVE, conn, probe_now(), frame.data);
+
     return schedule_path_challenge(conn, 1, frame.data);
 }
 
 static int handle_path_response_frame(quicly_conn_t *conn, struct st_quicly_handle_payload_state_t *state)
 {
+    quicly_path_challenge_frame_t frame;
+    int ret;
+
+    if ((ret = quicly_decode_path_challenge_frame(&state->src, state->end, &frame)) != 0)
+        return ret;
+
+    QUICLY_PROBE(PATH_RESPONSE_RECEIVE, conn, probe_now(), frame.data);
+
     return QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION;
 }
 

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -87,8 +87,10 @@ provider quicly {
     probe new_token_receive(struct st_quicly_conn_t *conn, int64_t at, uint8_t *token, size_t len);
 
     probe path_challenge_send(struct st_quicly_conn_t *conn, int64_t at, uint8_t *data);
+    probe path_challenge_receive(struct st_quicly_conn_t *conn, int64_t at, uint8_t *data);
 
     probe path_response_send(struct st_quicly_conn_t *conn, int64_t at, uint8_t *data);
+    probe path_response_receive(struct st_quicly_conn_t *conn, int64_t at, uint8_t *data);
 
     probe handshake_done_send(struct st_quicly_conn_t *conn, int64_t at);
     probe handshake_done_receive(struct st_quicly_conn_t *conn, int64_t at);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -90,11 +90,11 @@ provider quicly {
     probe new_token_acked(struct st_quicly_conn_t *conn, int64_t at, uint64_t generation);
     probe new_token_receive(struct st_quicly_conn_t *conn, int64_t at, uint8_t *token, size_t len);
 
-    probe path_challenge_send(struct st_quicly_conn_t *conn, int64_t at, uint8_t *data);
-    probe path_challenge_receive(struct st_quicly_conn_t *conn, int64_t at, uint8_t *data);
+    probe path_challenge_send(struct st_quicly_conn_t *conn, int64_t at, const uint8_t *data);
+    probe path_challenge_receive(struct st_quicly_conn_t *conn, int64_t at, const uint8_t *data);
 
-    probe path_response_send(struct st_quicly_conn_t *conn, int64_t at, uint8_t *data);
-    probe path_response_receive(struct st_quicly_conn_t *conn, int64_t at, uint8_t *data);
+    probe path_response_send(struct st_quicly_conn_t *conn, int64_t at, const uint8_t *data);
+    probe path_response_receive(struct st_quicly_conn_t *conn, int64_t at, const uint8_t *data);
 
     probe handshake_done_send(struct st_quicly_conn_t *conn, int64_t at);
     probe handshake_done_receive(struct st_quicly_conn_t *conn, int64_t at);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -60,6 +60,13 @@ provider quicly {
     probe application_close_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t error_code, const char *reason_phrase);
     probe application_close_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t error_code, const char *reason_phrase);
 
+    probe ack_send(struct st_quicly_conn_t *conn, int64_t at, int has_ping_bundled);
+
+    probe reset_stream_send(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, unsigned error_code,
+                            uint64_t final_size);
+
+    probe stop_sending_send(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, unsigned error_code);
+
     probe stream_send(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off, size_t len,
                       int is_fin);
     probe stream_receive(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off, size_t len);
@@ -78,6 +85,10 @@ provider quicly {
     probe new_token_send(struct st_quicly_conn_t *conn, int64_t at, uint8_t *token, size_t len, uint64_t generation);
     probe new_token_acked(struct st_quicly_conn_t *conn, int64_t at, uint64_t generation);
     probe new_token_receive(struct st_quicly_conn_t *conn, int64_t at, uint8_t *token, size_t len);
+
+    probe path_challenge_send(struct st_quicly_conn_t *conn, int64_t at, uint8_t *data);
+
+    probe path_response_send(struct st_quicly_conn_t *conn, int64_t at, uint8_t *data);
 
     probe handshake_done_send(struct st_quicly_conn_t *conn, int64_t at);
     probe handshake_done_receive(struct st_quicly_conn_t *conn, int64_t at);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -64,8 +64,12 @@ provider quicly {
 
     probe reset_stream_send(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, unsigned error_code,
                             uint64_t final_size);
+    probe reset_stream_receive(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t stream_id,
+                               unsigned error_code, uint64_t final_size);
 
     probe stop_sending_send(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, unsigned error_code);
+    probe stop_sending_receive(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t stream_id,
+                               unsigned error_code);
 
     probe stream_send(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off, size_t len,
                       int is_fin);


### PR DESCRIPTION
Generally speaking, we should have probe when any frame is sent, acked or received, regardless of the frame type. That would give us clear view of what is happening.

This PR is an attempt to do that.