### PR TITLE
Fix invalid loss.alarm_at == now in quicly_send

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3628,10 +3628,14 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
      * progress (i.e. due to the payload of lost packet being cancelled), then PTO for the previously sent packet.  To accomodate
      * that, we allow to rerun the do_send function just once.
      */
-    if (s.num_packets == 0 && conn->egress.loss.alarm_at <= now) {
+    if (conn->egress.loss.alarm_at <= now) {
         assert(conn->egress.loss.alarm_at == now);
-        if ((ret = do_send(conn, &s)) != 0)
-            return ret;
+        if (s.num_packets == 0) {
+            if ((ret = do_send(conn, &s)) != 0)
+                return ret;
+        } else {
+            conn->egress.loss.alarm_at = now + 1;
+        }
     }
     assert_consistency(conn, 1);
 


### PR DESCRIPTION
- This condition happens in the FD.io VPP quic
  implementation when occasionally loss.alarm_at is updated
  in do_send() to be equal to now triggering
  assert_consistency() assertion that loss.alarm_at > now.
  In VPP, the case where do_send() is repeated has not been
  observed.

Signed-off-by: Dave Wallace <dwallacelf@gmail.com>

Note: This issue may be related to https://github.com/h2o/quicly/issues/234 which had previously been opened and later closed by @sknat.  The version of quicly code used to debug and verify this PR is https://github.com/vpp-quic/quicly/releases/tag/v0.1.0-vpp