### PR TITLE
push down the timer misuse check that leads to infinite loop

### DIFF
--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -133,7 +133,8 @@ static void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, u
                              uint8_t *ack_delay_exponent);
 
 static void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last_retransmittable_sent_at, int has_outstanding,
-                                     int can_send_stream_data, int handshake_is_in_progress, uint64_t total_bytes_sent);
+                                     int can_send_stream_data, int handshake_is_in_progress, uint64_t total_bytes_sent,
+                                     int is_after_send);
 
 /* called when an ACK is received
  */
@@ -209,7 +210,8 @@ inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, u
 }
 
 inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last_retransmittable_sent_at, int has_outstanding,
-                                     int can_send_stream_data, int handshake_is_in_progress, uint64_t total_bytes_sent)
+                                     int can_send_stream_data, int handshake_is_in_progress, uint64_t total_bytes_sent,
+                                     int is_after_send)
 {
     if (!has_outstanding) {
         /* Do not set alarm if there's no data oustanding */
@@ -218,50 +220,63 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
         return;
     }
     assert(last_retransmittable_sent_at != INT64_MAX);
-    int64_t alarm_duration;
+
+#define SET_ALARM(t)                                                                                                               \
+    do {                                                                                                                           \
+        int64_t _t = (t);                                                                                                          \
+        if (is_after_send) {                                                                                                       \
+            assert(now < _t);                                                                                                      \
+        } else if (_t < now) {                                                                                                     \
+            _t = now;                                                                                                              \
+        }                                                                                                                          \
+        r->alarm_at = _t;                                                                                                          \
+    } while (0)
+
+    /* time-threshold loss detection */
     if (r->loss_time != INT64_MAX) {
-        /* time-threshold loss detection */
-        alarm_duration = r->loss_time - last_retransmittable_sent_at;
-    } else {
-        /* PTO alarm */
-        assert(r->pto_count < 63);
-        /* Probes are sent with a modified backoff to minimize latency of recovery. For instance, with num_speculative_ptos set to
-         * 2, the backoff pattern is as follows:
-         *   * when there's a tail: 0.25, 0.5, 1, 2, 4, 8, ...
-         *   * when mid-transfer: 1, 1, 1, 2, 4, 8, ...
-         * The first 2 probes in this case (and num_speculative_ptos, more generally), or the probes sent when pto_count < 0, are
-         * the speculative ones, which add potentially redundant retransmissions at a tail to reduce the cost of potential tail
-         * losses.
-         *
-         * FIXME: use of `can_send_stream_data` and `bytes_sent` is not entirely correct, it does not take things like MAX_ frames
-         * and pending.flows into consideration.
-         */
-        if (r->conf->num_speculative_ptos > 0 && r->pto_count <= 0 && !handshake_is_in_progress && !can_send_stream_data &&
-            r->total_bytes_sent < total_bytes_sent) {
-            /* New tail, defined as (i) sender is not in PTO recovery, (ii) there is no stream data to send, and
-             * (iii) new application data was sent since the last tail. Move the pto_count back to kick off speculative probing. */
-            if (r->pto_count == 0)
-                /*  kick off speculative probing if not already in progress */
-                r->pto_count = -r->conf->num_speculative_ptos;
-            r->total_bytes_sent = total_bytes_sent;
-        }
-        if (r->pto_count < 0) {
-            /* Speculative probes sent under an RTT do not need to account for ack delay, since there is no expectation
-             * of an ack being received before the probe is sent. */
-            alarm_duration = quicly_rtt_get_pto(&r->rtt, 0, r->conf->min_pto);
-            alarm_duration >>= -r->pto_count;
-            if (alarm_duration < r->conf->min_pto)
-                alarm_duration = r->conf->min_pto;
-        } else {
-            /* Ordinary PTO. The bitshift below is fine; it would take more than a millenium to overflow either alarm_duration or
-             * pto_count, even when the timer granularity is nanosecond */
-            alarm_duration = quicly_rtt_get_pto(&r->rtt, handshake_is_in_progress ? 0 : *r->max_ack_delay, r->conf->min_pto);
-            alarm_duration <<= r->pto_count;
-        }
+        SET_ALARM(r->loss_time);
+        return;
     }
-    r->alarm_at = last_retransmittable_sent_at + alarm_duration;
-    if (r->alarm_at < now)
-        r->alarm_at = now;
+
+    /* PTO alarm */
+    int64_t alarm_duration;
+    assert(r->pto_count < 63);
+    /* Probes are sent with a modified backoff to minimize latency of recovery. For instance, with num_speculative_ptos set to
+     * 2, the backoff pattern is as follows:
+     *   * when there's a tail: 0.25, 0.5, 1, 2, 4, 8, ...
+     *   * when mid-transfer: 1, 1, 1, 2, 4, 8, ...
+     * The first 2 probes in this case (and num_speculative_ptos, more generally), or the probes sent when pto_count < 0, are
+     * the speculative ones, which add potentially redundant retransmissions at a tail to reduce the cost of potential tail
+     * losses.
+     *
+     * FIXME: use of `can_send_stream_data` and `bytes_sent` is not entirely correct, it does not take things like MAX_ frames
+     * and pending.flows into consideration.
+     */
+    if (r->conf->num_speculative_ptos > 0 && r->pto_count <= 0 && !handshake_is_in_progress && !can_send_stream_data &&
+        r->total_bytes_sent < total_bytes_sent) {
+        /* New tail, defined as (i) sender is not in PTO recovery, (ii) there is no stream data to send, and
+         * (iii) new application data was sent since the last tail. Move the pto_count back to kick off speculative probing. */
+        if (r->pto_count == 0)
+            /*  kick off speculative probing if not already in progress */
+            r->pto_count = -r->conf->num_speculative_ptos;
+        r->total_bytes_sent = total_bytes_sent;
+    }
+    if (r->pto_count < 0) {
+        /* Speculative probes sent under an RTT do not need to account for ack delay, since there is no expectation
+         * of an ack being received before the probe is sent. */
+        alarm_duration = quicly_rtt_get_pto(&r->rtt, 0, r->conf->min_pto);
+        alarm_duration >>= -r->pto_count;
+        if (alarm_duration < r->conf->min_pto)
+            alarm_duration = r->conf->min_pto;
+    } else {
+        /* Ordinary PTO. The bitshift below is fine; it would take more than a millenium to overflow either alarm_duration or
+         * pto_count, even when the timer granularity is nanosecond */
+        alarm_duration = quicly_rtt_get_pto(&r->rtt, handshake_is_in_progress ? 0 : *r->max_ack_delay, r->conf->min_pto);
+        alarm_duration <<= r->pto_count;
+    }
+    SET_ALARM(last_retransmittable_sent_at + alarm_duration);
+
+#undef SET_ALARM
 }
 
 inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, int64_t now, int64_t sent_at,

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3624,15 +3624,7 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
     /* emit packets */
     if ((ret = do_send(conn, &s)) != 0)
         return ret;
-    /* We might see the timer going back to the past, if time-threshold loss timer fires first without being able to make any
-     * progress (i.e. due to the payload of lost packet being cancelled), then PTO for the previously sent packet.  To accomodate
-     * that, we allow to rerun the do_send function just once.
-     */
-    if (s.num_packets == 0 && conn->egress.loss.alarm_at <= now) {
-        assert(conn->egress.loss.alarm_at == now);
-        if ((ret = do_send(conn, &s)) != 0)
-            return ret;
-    }
+
     assert_consistency(conn, 1);
 
     *num_packets = s.num_packets;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2980,6 +2980,7 @@ static int do_detect_loss(quicly_loss_t *ld, uint64_t largest_acked, uint32_t de
     /* schedule time-threshold alarm if there is a packet outstanding that is smaller than largest_acked */
     while (sent->packet_number < largest_acked && sent->sent_at != INT64_MAX) {
         if (sent->bytes_in_flight != 0) {
+            assert(now < sent->sent_at + delay_until_lost);
             *loss_time = sent->sent_at + delay_until_lost;
             break;
         }


### PR DESCRIPTION
When exitting from `quicly_send`, the loss timers have to be set at some point in the future. Otherwise, the application might continue calling `quicly_send`, and we might end up in a busy loop without making progress.

At the moment, we have a function called `assert_consistency` that checks if this requirement is met, however it is hard to see what when wrong, as it is invoked at the very end of `quicly_send`.

This PR is an attempt to move the checks to where those timers are updated. Hopefully, we will find out the reason why the consistency check fails occasionally.

The PR also does the following:
* Makes sure that `now` gets not updated inside `quicly_send`, as there is chance that applications might invoke public functions of quicly that update `now` inside callbacks invoked by `quicly_send`.
* No longer calls `do_send` twice. The behavior was introduced in #175 to handle the case where PTO timer fires and there's nothing to be sent. However, as of #257 we send PING in such case, therefore there is no reason to make the second call.