### PR TITLE
Sentmap refactorisation

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -590,7 +590,7 @@ static void assert_consistency(quicly_conn_t *conn, int timer_must_be_in_future)
         assert(now < conn->egress.loss.alarm_at);
 }
 
-static int on_invalid_ack(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent,
+static int on_invalid_ack(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_frame_t *sent,
                           quicly_sentmap_event_t event)
 {
     if (event == QUICLY_SENTMAP_EVENT_ACKED)
@@ -2032,7 +2032,8 @@ static int decrypt_packet(ptls_cipher_context_t *header_protection,
     return 0;
 }
 
-static int on_ack_ack(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent, quicly_sentmap_event_t event)
+static int on_ack_ack(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_frame_t *sent,
+                      quicly_sentmap_event_t event)
 {
     /* TODO log */
 
@@ -2069,7 +2070,8 @@ static int on_ack_ack(quicly_conn_t *conn, const quicly_sent_packet_t *packet, q
     return 0;
 }
 
-static int on_ack_stream(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent, quicly_sentmap_event_t event)
+static int on_ack_stream(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_frame_t *sent,
+                         quicly_sentmap_event_t event)
 {
     quicly_stream_t *stream;
     int ret;
@@ -2112,7 +2114,7 @@ static int on_ack_stream(quicly_conn_t *conn, const quicly_sent_packet_t *packet
     return 0;
 }
 
-static int on_ack_max_stream_data(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent,
+static int on_ack_max_stream_data(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_frame_t *sent,
                                   quicly_sentmap_event_t event)
 {
     quicly_stream_t *stream;
@@ -2139,7 +2141,7 @@ static int on_ack_max_stream_data(quicly_conn_t *conn, const quicly_sent_packet_
     return 0;
 }
 
-static int on_ack_max_data(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent,
+static int on_ack_max_data(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_frame_t *sent,
                            quicly_sentmap_event_t event)
 {
     switch (event) {
@@ -2156,7 +2158,7 @@ static int on_ack_max_data(quicly_conn_t *conn, const quicly_sent_packet_t *pack
     return 0;
 }
 
-static int on_ack_max_streams(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent,
+static int on_ack_max_streams(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_frame_t *sent,
                               quicly_sentmap_event_t event)
 {
     quicly_maxsender_t *maxsender = sent->data.max_streams.uni ? conn->ingress.max_streams.uni : conn->ingress.max_streams.bidi;
@@ -2181,7 +2183,7 @@ static void on_ack_stream_state_sender(quicly_sender_state_t *sender_state, int 
     *sender_state = acked ? QUICLY_SENDER_STATE_ACKED : QUICLY_SENDER_STATE_SEND;
 }
 
-static int on_ack_reset_stream(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent,
+static int on_ack_reset_stream(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_frame_t *sent,
                                quicly_sentmap_event_t event)
 {
     if (event != QUICLY_SENTMAP_EVENT_EXPIRED) {
@@ -2196,7 +2198,7 @@ static int on_ack_reset_stream(quicly_conn_t *conn, const quicly_sent_packet_t *
     return 0;
 }
 
-static int on_ack_stop_sending(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent,
+static int on_ack_stop_sending(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_frame_t *sent,
                                quicly_sentmap_event_t event)
 {
     if (event != QUICLY_SENTMAP_EVENT_EXPIRED) {
@@ -2211,7 +2213,7 @@ static int on_ack_stop_sending(quicly_conn_t *conn, const quicly_sent_packet_t *
     return 0;
 }
 
-static int on_ack_streams_blocked(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent,
+static int on_ack_streams_blocked(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_frame_t *sent,
                                   quicly_sentmap_event_t event)
 {
     struct st_quicly_max_streams_t *m =
@@ -2231,7 +2233,7 @@ static int on_ack_streams_blocked(quicly_conn_t *conn, const quicly_sent_packet_
     return 0;
 }
 
-static int on_ack_handshake_done(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent,
+static int on_ack_handshake_done(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_frame_t *sent,
                                  quicly_sentmap_event_t event)
 {
     /* When HANDSHAKE_DONE is deemed lost, schedule retransmission. */
@@ -2240,7 +2242,7 @@ static int on_ack_handshake_done(quicly_conn_t *conn, const quicly_sent_packet_t
     return 0;
 }
 
-static int on_ack_new_token(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent,
+static int on_ack_new_token(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_frame_t *sent,
                             quicly_sentmap_event_t event)
 {
     if (sent->data.new_token.is_inflight) {
@@ -2455,7 +2457,7 @@ static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, int
         int ret;
         if ((ret = quicly_sentmap_prepare(&conn->egress.sentmap, conn->egress.packet_number, now, QUICLY_EPOCH_1RTT)) != 0)
             return ret;
-        if (quicly_sentmap_allocate(&conn->egress.sentmap, on_invalid_ack) == NULL)
+        if (quicly_sentmap_allocate_frame(&conn->egress.sentmap, on_invalid_ack) == NULL)
             return PTLS_ERROR_NO_MEMORY;
         quicly_sentmap_commit(&conn->egress.sentmap, 0);
         ++conn->egress.packet_number;
@@ -2587,14 +2589,14 @@ static int allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, size_t 
     return _do_allocate_frame(conn, s, min_space, 0);
 }
 
-static int allocate_ack_eliciting_frame(quicly_conn_t *conn, quicly_send_context_t *s, size_t min_space, quicly_sent_t **sent,
+static int allocate_ack_eliciting_frame(quicly_conn_t *conn, quicly_send_context_t *s, size_t min_space, quicly_sent_frame_t **sent,
                                         quicly_sent_acked_cb acked)
 {
     int ret;
 
     if ((ret = _do_allocate_frame(conn, s, min_space, 1)) != 0)
         return ret;
-    if ((*sent = quicly_sentmap_allocate(&conn->egress.sentmap, acked)) == NULL)
+    if ((*sent = quicly_sentmap_allocate_frame(&conn->egress.sentmap, acked)) == NULL)
         return PTLS_ERROR_NO_MEMORY;
 
     /* TODO return the remaining window that the sender can use */
@@ -2647,8 +2649,8 @@ Emit: /* emit an ACK frame */
     { /* save what's inflight */
         size_t i;
         for (i = 0; i != space->ack_queue.num_ranges; ++i) {
-            quicly_sent_t *sent;
-            if ((sent = quicly_sentmap_allocate(&conn->egress.sentmap, on_ack_ack)) == NULL)
+            quicly_sent_frame_t *sent;
+            if ((sent = quicly_sentmap_allocate_frame(&conn->egress.sentmap, on_ack_ack)) == NULL)
                 return PTLS_ERROR_NO_MEMORY;
             sent->data.ack.range = space->ack_queue.ranges[i];
         }
@@ -2662,7 +2664,7 @@ Emit: /* emit an ACK frame */
 static int prepare_stream_state_sender(quicly_stream_t *stream, quicly_sender_state_t *sender, quicly_send_context_t *s,
                                        size_t min_space, quicly_sent_acked_cb ack_cb)
 {
-    quicly_sent_t *sent;
+    quicly_sent_frame_t *sent;
     int ret;
 
     if ((ret = allocate_ack_eliciting_frame(stream->conn, s, min_space, &sent, ack_cb)) != 0)
@@ -2689,7 +2691,7 @@ static int send_stream_control_frames(quicly_stream_t *stream, quicly_send_conte
     /* send MAX_STREAM_DATA if necessary */
     if (should_send_max_stream_data(stream)) {
         uint64_t new_value = stream->recvstate.data_off + stream->_recv_aux.window;
-        quicly_sent_t *sent;
+        quicly_sent_frame_t *sent;
         /* prepare */
         if ((ret = allocate_ack_eliciting_frame(stream->conn, s, QUICLY_MAX_STREAM_DATA_FRAME_CAPACITY, &sent,
                                                 on_ack_max_stream_data)) != 0)
@@ -2727,7 +2729,7 @@ int quicly_can_send_stream_data(quicly_conn_t *conn, quicly_send_context_t *s)
 int quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t *s)
 {
     uint64_t off = stream->sendstate.pending.ranges[0].start, end_off;
-    quicly_sent_t *sent;
+    quicly_sent_frame_t *sent;
     uint8_t *frame_type_at;
     size_t capacity, len;
     int ret, wrote_all, is_fin;
@@ -3004,7 +3006,7 @@ static int send_max_streams(quicly_conn_t *conn, int uni, quicly_send_context_t 
         (uni ? conn->super.ctx->transport_params.max_streams_uni : conn->super.ctx->transport_params.max_streams_bidi) -
         group->num_streams;
 
-    quicly_sent_t *sent;
+    quicly_sent_frame_t *sent;
     if ((ret = allocate_ack_eliciting_frame(conn, s, QUICLY_MAX_STREAMS_FRAME_CAPACITY, &sent, on_ack_max_streams)) != 0)
         return ret;
     s->dst = quicly_encode_max_streams_frame(s->dst, uni, new_count);
@@ -3032,7 +3034,7 @@ static int send_streams_blocked(quicly_conn_t *conn, int uni, quicly_send_contex
     if (!quicly_maxsender_should_send_blocked(&max_streams->blocked_sender, max_streams->count))
         return 0;
 
-    quicly_sent_t *sent;
+    quicly_sent_frame_t *sent;
     if ((ret = allocate_ack_eliciting_frame(conn, s, QUICLY_STREAMS_BLOCKED_FRAME_CAPACITY, &sent, on_ack_streams_blocked)) != 0)
         return ret;
     s->dst = quicly_encode_streams_blocked_frame(s->dst, uni, max_streams->count);
@@ -3075,7 +3077,7 @@ static void open_blocked_streams(quicly_conn_t *conn, int uni)
 
 static int send_handshake_done(quicly_conn_t *conn, quicly_send_context_t *s)
 {
-    quicly_sent_t *sent;
+    quicly_sent_frame_t *sent;
     int ret;
 
     if ((ret = allocate_ack_eliciting_frame(conn, s, 1, &sent, on_ack_handshake_done)) != 0)
@@ -3094,7 +3096,7 @@ static int send_resumption_token(quicly_conn_t *conn, quicly_send_context_t *s)
     quicly_address_token_plaintext_t token;
     ptls_buffer_t tokenbuf;
     uint8_t tokenbuf_small[128];
-    quicly_sent_t *sent;
+    quicly_sent_frame_t *sent;
     int ret;
 
     ptls_buffer_init(&tokenbuf, tokenbuf_small, sizeof(tokenbuf_small));
@@ -3526,7 +3528,7 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
                     goto Exit;
                 /* send connection-level flow control frame */
                 if (should_send_max_data(conn)) {
-                    quicly_sent_t *sent;
+                    quicly_sent_frame_t *sent;
                     if ((ret = allocate_ack_eliciting_frame(conn, s, QUICLY_MAX_DATA_FRAME_CAPACITY, &sent, on_ack_max_data)) != 0)
                         goto Exit;
                     uint64_t new_value = conn->ingress.max_data.bytes_consumed + conn->super.ctx->transport_params.max_data;
@@ -3728,7 +3730,7 @@ int quicly_send_resumption_token(quicly_conn_t *conn)
     return 0;
 }
 
-static int on_end_closing(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent,
+static int on_end_closing(quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_frame_t *sent,
                           quicly_sentmap_event_t event)
 {
     /* we stop accepting frames by the time this ack callback is being registered */
@@ -3747,7 +3749,7 @@ static int enter_close(quicly_conn_t *conn, int host_is_initiating, int wait_dra
         return ret;
     if ((ret = quicly_sentmap_prepare(&conn->egress.sentmap, conn->egress.packet_number, now, QUICLY_EPOCH_INITIAL)) != 0)
         return ret;
-    if (quicly_sentmap_allocate(&conn->egress.sentmap, on_end_closing) == NULL)
+    if (quicly_sentmap_allocate_frame(&conn->egress.sentmap, on_end_closing) == NULL)
         return PTLS_ERROR_NO_MEMORY;
     quicly_sentmap_commit(&conn->egress.sentmap, 0);
     ++conn->egress.packet_number;

--- a/lib/sentmap.c
+++ b/lib/sentmap.c
@@ -21,156 +21,140 @@
  */
 #include <assert.h>
 #include <stdlib.h>
+#include <string.h>
 #include "picotls.h"
 #include "quicly/sentmap.h"
 
-const quicly_sent_t quicly_sentmap__end_iter = {quicly_sentmap__type_packet, {{UINT64_MAX, INT64_MAX}}};
-
-static void next_entry(quicly_sentmap_iter_t *iter)
+void quicly_sentmap_init(quicly_sentmap_t *map)
 {
-    if (--iter->count != 0) {
-        ++iter->p;
-    } else if (*(iter->ref = &(*iter->ref)->next) == NULL) {
-        iter->p = (quicly_sent_t *)&quicly_sentmap__end_iter;
-        iter->count = 0;
-        return;
-    } else {
-        assert((*iter->ref)->num_entries != 0);
-        iter->count = (*iter->ref)->num_entries;
-        iter->p = (*iter->ref)->entries;
-    }
-    while (iter->p->acked == NULL)
-        ++iter->p;
+    *map = (quicly_sentmap_t){NULL};
+    map->_.pkt_list.next = &(map->_.pkt_list);
+    map->_.pkt_list.prev = &(map->_.pkt_list);
+    map->_.packet_number = UINT64_MAX;
+    map->_.sent_at = INT64_MAX;
 }
 
-static struct st_quicly_sent_block_t **free_block(quicly_sentmap_t *map, struct st_quicly_sent_block_t **ref)
+void quicly_sentmap_commit(quicly_sentmap_t *map, uint16_t bytes_in_flight)
 {
-    static const struct st_quicly_sent_block_t dummy = {NULL};
-    static const struct st_quicly_sent_block_t *const dummy_ref = &dummy;
-    struct st_quicly_sent_block_t *block = *ref;
+    assert(quicly_sentmap_is_open(map));
 
-    if (block->next != NULL) {
-        *ref = block->next;
-        assert((*ref)->num_entries != 0);
-    } else {
-        assert(block == map->tail);
-        if (ref == &map->head) {
-            map->head = NULL;
-            map->tail = NULL;
-        } else {
-            map->tail = (void *)((char *)ref - offsetof(struct st_quicly_sent_block_t, next));
-            map->tail->next = NULL;
-        }
-        ref = (struct st_quicly_sent_block_t **)&dummy_ref;
+    if (bytes_in_flight != 0) {
+        quicly_sent_packet_t *p = (quicly_sent_packet_t *)map->_.pkt_list.prev;
+        p->ack_eliciting = 1;
+        p->bytes_in_flight = bytes_in_flight;
+        map->bytes_in_flight += bytes_in_flight;
     }
-
-    free(block);
-    return ref;
+    map->is_open = 0;
 }
 
-static void discard_entry(quicly_sentmap_t *map, quicly_sentmap_iter_t *iter)
+static inline quicly_sent_packet_t *allocate_packet(uint16_t frames)
 {
-    assert(iter->p->acked != NULL);
-    iter->p->acked = NULL;
-
-    struct st_quicly_sent_block_t *block = *iter->ref;
-    if (--block->num_entries == 0) {
-        iter->ref = free_block(map, iter->ref);
-        block = *iter->ref;
-        iter->p = block->entries - 1;
-        iter->count = block->num_entries + 1;
-    }
+    quicly_sent_packet_t *packet = calloc(1, offsetof(quicly_sent_packet_t, frames) + frames * sizeof(quicly_sent_frame_t));
+    if (packet == NULL)
+        return NULL;
+    packet->frame_capacity = frames;
+    return packet;
 }
 
-void quicly_sentmap_dispose(quicly_sentmap_t *map)
+quicly_sent_frame_t *quicly_sentmap_allocate_frame(quicly_sentmap_t *map, quicly_sent_acked_cb acked)
 {
-    struct st_quicly_sent_block_t *block;
+    assert(quicly_sentmap_is_open(map));
 
-    while ((block = map->head) != NULL) {
-        map->head = block->next;
-        free(block);
+    quicly_sent_packet_t *p = (quicly_sent_packet_t *)map->_.pkt_list.prev;
+    /* grow the packet if it is full */
+    if (p->used_frames == p->frame_capacity) {
+        quicly_sent_packet_t *new_p = allocate_packet(p->frame_capacity * 2);
+        if (!new_p)
+            return NULL;
+        memcpy(new_p, p, offsetof(quicly_sent_packet_t, frames) + p->frame_capacity * sizeof(quicly_sent_frame_t));
+        new_p->frame_capacity = p->frame_capacity * 2;
+        p->pkt_list.prev->next = &(new_p->pkt_list);
+        p->pkt_list.next->prev = &(new_p->pkt_list);
+        p = new_p;
     }
+
+    assert(p->used_frames < p->frame_capacity);
+    quicly_sent_frame_t *frame = &p->frames[p->used_frames];
+    p->used_frames++;
+    frame->acked = acked;
+    return frame;
 }
 
 int quicly_sentmap_prepare(quicly_sentmap_t *map, uint64_t packet_number, int64_t now, uint8_t ack_epoch)
 {
-    assert(map->_pending_packet == NULL);
+    assert(!quicly_sentmap_is_open(map));
 
-    if ((map->_pending_packet = quicly_sentmap_allocate(map, quicly_sentmap__type_packet)) == NULL)
+    quicly_sent_packet_t *new_packet = allocate_packet(QUICLY_SENTMAP_DEFAULT_FRAMES_PER_PACKET);
+    if (new_packet == NULL) {
         return PTLS_ERROR_NO_MEMORY;
-    map->_pending_packet->data.packet = (quicly_sent_packet_t){packet_number, now, ack_epoch};
+    }
+    new_packet->packet_number = packet_number;
+    new_packet->sent_at = now;
+    new_packet->ack_epoch = ack_epoch;
+
+    map->_.pkt_list.prev->next = &(new_packet->pkt_list);
+    new_packet->pkt_list.prev = map->_.pkt_list.prev;
+    map->_.pkt_list.prev = &(new_packet->pkt_list);
+    new_packet->pkt_list.next = &(map->_.pkt_list);
+
+    map->is_open = 1;
     return 0;
 }
 
-struct st_quicly_sent_block_t *quicly_sentmap__new_block(quicly_sentmap_t *map)
+static inline void discard_packet(quicly_sentmap_t *map, quicly_sent_packet_t *packet)
 {
-    struct st_quicly_sent_block_t *block;
+    assert(packet);
+    assert(&(packet->pkt_list) != &(map->_.pkt_list)); /* not the end of the list */
 
-    if ((block = malloc(sizeof(*block))) == NULL)
-        return NULL;
+    packet->pkt_list.prev->next = packet->pkt_list.next;
+    packet->pkt_list.next->prev = packet->pkt_list.prev;
 
-    block->next = NULL;
-    block->num_entries = 0;
-    block->next_insert_at = 0;
-    if (map->tail != NULL) {
-        map->tail->next = block;
-        map->tail = block;
-    } else {
-        map->head = map->tail = block;
-    }
-
-    return block;
-}
-
-void quicly_sentmap_skip(quicly_sentmap_iter_t *iter)
-{
-    do {
-        next_entry(iter);
-    } while (iter->p->acked != quicly_sentmap__type_packet);
+    free(packet);
 }
 
 int quicly_sentmap_update(quicly_sentmap_t *map, quicly_sentmap_iter_t *iter, quicly_sentmap_event_t event,
                           struct st_quicly_conn_t *conn)
 {
-    quicly_sent_packet_t packet;
-    int notify_lost = 0, ret = 0;
+    quicly_sent_packet_t *packet;
+    int notify_lost = 0, ret = 0, i = 0;
 
-    assert(iter->p != &quicly_sentmap__end_iter);
-    assert(iter->p->acked == quicly_sentmap__type_packet);
+    assert(!quicly_sentmap_iter_is_end(iter));
 
-    /* copy packet info */
-    packet = iter->p->data.packet;
+    /* save packet pointer */
+    packet = (quicly_sent_packet_t *)iter->p;
 
     /* update packet-level metrics (make adjustments to notify the loss when discarding a packet that is still deemed inflight) */
-    if (packet.bytes_in_flight != 0) {
+    if (packet->bytes_in_flight != 0) {
         if (event == QUICLY_SENTMAP_EVENT_EXPIRED)
             notify_lost = 1;
-        assert(map->bytes_in_flight >= packet.bytes_in_flight);
-        map->bytes_in_flight -= packet.bytes_in_flight;
+        assert(map->bytes_in_flight >= packet->bytes_in_flight);
+        map->bytes_in_flight -= packet->bytes_in_flight;
     }
-    iter->p->data.packet.bytes_in_flight = 0;
+    packet->bytes_in_flight = 0;
 
-    /* Remove entry from sentmap, unless packet is deemed lost. If lost, then hold on to this packet until removed by a
-     * QUICLY_SENTMAP_EVENT_EXPIRED event. */
-    if (event != QUICLY_SENTMAP_EVENT_LOST)
-        discard_entry(map, iter);
+    /* move iterator to next packet */
+    quicly_sentmap_skip(iter);
 
     /* iterate through the frames */
-    for (next_entry(iter); iter->p->acked != quicly_sentmap__type_packet; next_entry(iter)) {
+    for (i = 0; i < packet->used_frames; i++) {
+        quicly_sent_frame_t *frame = &packet->frames[i];
         if (notify_lost && ret == 0)
-            ret = iter->p->acked(conn, &packet, iter->p, QUICLY_SENTMAP_EVENT_LOST);
+            ret = frame->acked(conn, packet, frame, QUICLY_SENTMAP_EVENT_LOST);
         if (ret == 0)
-            ret = iter->p->acked(conn, &packet, iter->p, event);
-        if (event != QUICLY_SENTMAP_EVENT_LOST)
-            discard_entry(map, iter);
+            ret = frame->acked(conn, packet, frame, event);
     }
+
+    /* Remove packet from sentmap, unless it is deemed lost. If lost, then hold on to this packet until removed by a
+     * QUICLY_SENTMAP_EVENT_EXPIRED event. */
+    if (event != QUICLY_SENTMAP_EVENT_LOST)
+        discard_packet(map, packet);
 
     return ret;
 }
 
-int quicly_sentmap__type_packet(struct st_quicly_conn_t *conn, const quicly_sent_packet_t *packet, quicly_sent_t *sent,
-                                quicly_sentmap_event_t event)
+void quicly_sentmap_dispose(quicly_sentmap_t *map)
 {
-    assert(!"quicly_sentmap__type_packet cannot be called");
-    return QUICLY_TRANSPORT_ERROR_INTERNAL;
+    while (map->_.pkt_list.next != &(map->_.pkt_list)) {
+        discard_packet(map, (quicly_sent_packet_t *)map->_.pkt_list.next);
+    }
 }


### PR DESCRIPTION
Hi Kazuho,

I looked at the performance of Quicly yesterday and noticed a bottleneck in the sentmap at high throughputs. This PR proposes a new structure based on a dlist of packets for the sentmap, which improves the throughput by 5-7% in our tests.