### PR TITLE
feat: make misc/quictrace-adapter to generate multiple QTR sources at once

### DIFF
--- a/misc/find-cids.py
+++ b/misc/find-cids.py
@@ -1,10 +1,11 @@
+#!/usr/bin/env python
 import sys
 import json
 
 if len(sys.argv) != 2:
-    print "Usage: python find-cids.py inTrace"
+    print "Usage: find-cids.py inTrace.jsonl"
     sys.exit(1)
-    
+
 cids = {}
 f = open(sys.argv[1], 'r')
 for line in f:


### PR DESCRIPTION
To make [QTR](https://github.com/google/quic-trace) sources easily, I'd like to generate them with single command at once.

@janaiyengar What do you think of it?

example:

```
$ misc/quictrace-adapter.py log.jsonl tmp
Transforming tmp/2020-04-09T02:10:18Z-365690.json
Transforming tmp/2020-04-09T02:10:19Z-365691.json
Transforming tmp/2020-04-09T02:10:20Z-365692.json
Transforming tmp/2020-04-09T02:10:20Z-365693.json
Transforming tmp/2020-04-09T02:10:21Z-365694.json
```
