### PR TITLE
calculate amplification limit at the datagram level

### DIFF
--- a/examples/echo.c
+++ b/examples/echo.c
@@ -159,12 +159,12 @@ static void on_receive(quicly_stream_t *stream, size_t off, const void *src, siz
 
 static void process_msg(int is_client, quicly_conn_t **conns, struct msghdr *msg, size_t dgram_len)
 {
-    size_t off, packet_len, i;
+    size_t off = 0, i;
 
     /* split UDP datagram into multiple QUIC packets */
-    for (off = 0; off < dgram_len; off += packet_len) {
+    while (off < dgram_len) {
         quicly_decoded_packet_t decoded;
-        if ((packet_len = quicly_decode_packet(&ctx, &decoded, msg->msg_iov[0].iov_base + off, dgram_len - off)) == SIZE_MAX)
+        if (quicly_decode_packet(&ctx, &decoded, msg->msg_iov[0].iov_base, dgram_len, &off) == SIZE_MAX)
             return;
         /* find the corresponding connection (TODO handle version negotiation, rebinding, retry, etc.) */
         for (i = 0; conns[i] != NULL; ++i)

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -404,6 +404,9 @@ struct st_quicly_conn_streamgroup_state_t {
         uint64_t late_acked;                                                                                                       \
     } num_packets;                                                                                                                 \
     struct {                                                                                                                       \
+        /**                                                                                                                        \
+         * This value is calculated at UDP datagram-level, and used for determining the amplification limit.                       \
+         */                                                                                                                        \
         uint64_t received;                                                                                                         \
         uint64_t sent;                                                                                                             \
     } num_bytes
@@ -680,7 +683,7 @@ typedef struct st_quicly_decoded_packet_t {
      */
     size_t encrypted_off;
     /**
-     * size of the datagram
+     * size of the UDP datagram; set to zero if this is not the first QUIC packet within the datagram
      */
     size_t datagram_size;
     /**
@@ -723,7 +726,7 @@ struct st_quicly_address_token_plaintext_t {
 /**
  *
  */
-size_t quicly_decode_packet(quicly_context_t *ctx, quicly_decoded_packet_t *packet, const uint8_t *src, size_t len);
+size_t quicly_decode_packet(quicly_context_t *ctx, quicly_decoded_packet_t *packet, const uint8_t *src, size_t len, size_t *off);
 /**
  *
  */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -736,7 +736,8 @@ struct st_quicly_address_token_plaintext_t {
  *         handle_quic_packet(&packet);
  *     }
  */
-size_t quicly_decode_packet(quicly_context_t *ctx, quicly_decoded_packet_t *packet, const uint8_t *src, size_t len, size_t *off);
+size_t quicly_decode_packet(quicly_context_t *ctx, quicly_decoded_packet_t *packet, const uint8_t *datagram, size_t datagram_size,
+                            size_t *off);
 /**
  *
  */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -724,7 +724,17 @@ struct st_quicly_address_token_plaintext_t {
 };
 
 /**
+ * Extracts QUIC packets from a datagram pointed to by `src` and `len`. If successful, the function returns the size of the QUIC
+ * packet being decoded. Otherwise, SIZE_MAX is returned.
+ * `off` is an I/O argument that takes starting offset of the QUIC packet to be decoded as input, and returns the starting offset of
+ * the next QUIC packet. A typical loop that handles an UDP datagram would look like:
  *
+ *     size_t off = 0;
+ *     while (off < dgram.size) {
+ *         if (quicly_decode_packet(ctx, &packet, dgram.bytes, dgram.size, &off) == SIZE_MAX)
+ *             break;
+ *         handle_quic_packet(&packet);
+ *     }
  */
 size_t quicly_decode_packet(quicly_context_t *ctx, quicly_decoded_packet_t *packet, const uint8_t *src, size_t len, size_t *off);
 /**

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -498,14 +498,17 @@ static void ack_frequency_set_next_update_at(quicly_conn_t *conn)
         conn->egress.ack_frequency.update_at = now + get_sentmap_expiration_time(conn);
 }
 
-size_t quicly_decode_packet(quicly_context_t *ctx, quicly_decoded_packet_t *packet, const uint8_t *src, size_t len, size_t *off)
+size_t quicly_decode_packet(quicly_context_t *ctx, quicly_decoded_packet_t *packet, const uint8_t *datagram, size_t datagram_size,
+                            size_t *off)
 {
-    const uint8_t *src_end = src + len;
+    const uint8_t *src = datagram, *src_end = datagram + datagram_size;
 
-    packet->octets = ptls_iovec_init(src + *off, len - *off);
+    assert(*off <= datagram_size);
+
+    packet->octets = ptls_iovec_init(src + *off, datagram_size - *off);
     if (packet->octets.len < 2)
         goto Error;
-    packet->datagram_size = *off == 0 ? len : 0;
+    packet->datagram_size = *off == 0 ? datagram_size : 0;
     packet->token = ptls_iovec_init(NULL, 0);
     packet->decrypted.pn = UINT64_MAX;
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -589,11 +589,9 @@ static int run_client(int fd, struct sockaddr *sa, const char *host)
                 size_t off = 0;
                 while (off != rret) {
                     quicly_decoded_packet_t packet;
-                    size_t plen = quicly_decode_packet(&ctx, &packet, buf + off, rret - off);
-                    if (plen == SIZE_MAX)
+                    if (quicly_decode_packet(&ctx, &packet, buf, rret, &off) == SIZE_MAX)
                         break;
                     quicly_receive(conn, NULL, &sa, &packet);
-                    off += plen;
                 }
             }
         }
@@ -762,8 +760,7 @@ static int run_server(int fd, struct sockaddr *sa, socklen_t salen)
                 size_t off = 0;
                 while (off != rret) {
                     quicly_decoded_packet_t packet;
-                    size_t plen = quicly_decode_packet(&ctx, &packet, buf + off, rret - off);
-                    if (plen == SIZE_MAX)
+                    if (quicly_decode_packet(&ctx, &packet, buf, rret, &off) == SIZE_MAX)
                         break;
                     if (QUICLY_PACKET_IS_LONG_HEADER(packet.octets.base[0])) {
                         if (packet.version != QUICLY_PROTOCOL_VERSION) {
@@ -844,7 +841,6 @@ static int run_server(int fd, struct sockaddr *sa, socklen_t salen)
                             send_packets(fd, &dgram, 1, ctx.packet_allocator);
                         }
                     }
-                    off += plen;
                 }
             }
         }


### PR DESCRIPTION
This PR changes the calculation of amplification limit from QUIC packet-level to UDP datagram-level, which is now a required behavior of the specification.

To be specific, the changes introduced in this PR are:

* __\[API Change\]__ `quicly_decode_packet` is our function that decodes a UDP datagram to a series of QUIC packets. Previously, this function received the remainder of the to-be-decoded portion of a UDP datagram as the argument, and therefore it was impossible for the function to set `quicly_decoded_packet_t::datagram_size` depending on the position of the QUIC packet being decoded within the datagram. __Now the function takes as arguments a vector indicating the UDP datagram, and an I/O argument indicating the current decoding position.__
* `quicly_decode_packet_t::datagram_size` is set to the size of the datagram when and only when the decoded QUIC packet was at the beginning of a UDP datagram. Previously, the value was never used.
* Anti-amplification counter is updated when `quicly_accept` creates a new connection context, or when `quicly_receive` is given a QUIC packet that is located at the beginning of a UDP datagram.