### PR TITLE
cap amount of state in `quicly_sendstate_t`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ SET(UNITTEST_SOURCE_FILES
     t/maxsender.c
     t/loss.c
     t/ranges.c
+    t/sendstate.c
     t/sentmap.c
     t/simple.c
     t/stream-concurrency.c

--- a/quicly.xcodeproj/project.pbxproj
+++ b/quicly.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		E99F8C261F4E9EBF00C26B3D /* frame.c in Sources */ = {isa = PBXBuildFile; fileRef = E99F8C251F4E9EBF00C26B3D /* frame.c */; };
 		E99F8C271F4E9F5D00C26B3D /* frame.c in Sources */ = {isa = PBXBuildFile; fileRef = E99F8C251F4E9EBF00C26B3D /* frame.c */; };
 		E99F8C291F4EAEF800C26B3D /* frame.c in Sources */ = {isa = PBXBuildFile; fileRef = E99F8C281F4EAEF800C26B3D /* frame.c */; };
+		E9B43DA72452A94E00824E51 /* sendstate.c in Sources */ = {isa = PBXBuildFile; fileRef = E9B43DA62452A94E00824E51 /* sendstate.c */; };
 		E9CC44111EB85E0B00DC7D3E /* khash.h in Headers */ = {isa = PBXBuildFile; fileRef = E9CC44101EB85E0B00DC7D3E /* khash.h */; };
 		E9CC441B1EC195DF00DC7D3E /* openssl.c in Sources */ = {isa = PBXBuildFile; fileRef = E98448271EA48D0000390927 /* openssl.c */; };
 		E9CC441C1EC195DF00DC7D3E /* picotls.c in Sources */ = {isa = PBXBuildFile; fileRef = E98448281EA48D0000390927 /* picotls.c */; };
@@ -74,7 +75,6 @@
 		E9F6A4271F3C3B050083F0B2 /* ranges.h in Headers */ = {isa = PBXBuildFile; fileRef = E9F6A4261F3C3B050083F0B2 /* ranges.h */; };
 		E9F6A42A1F3C3B7B0083F0B2 /* ranges.c in Sources */ = {isa = PBXBuildFile; fileRef = E9F6A4291F3C3B7B0083F0B2 /* ranges.c */; };
 		E9F6A42E1F41375B0083F0B2 /* sendstate.c in Sources */ = {isa = PBXBuildFile; fileRef = E9F6A42D1F41375B0083F0B2 /* sendstate.c */; };
-		E9F6A42F1F41375B0083F0B2 /* sendstate.c in Sources */ = {isa = PBXBuildFile; fileRef = E9F6A42D1F41375B0083F0B2 /* sendstate.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -159,6 +159,7 @@
 		E99F8C231F4E863200C26B3D /* frame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frame.h; sourceTree = "<group>"; };
 		E99F8C251F4E9EBF00C26B3D /* frame.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = frame.c; sourceTree = "<group>"; };
 		E99F8C281F4EAEF800C26B3D /* frame.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = frame.c; sourceTree = "<group>"; };
+		E9B43DA62452A94E00824E51 /* sendstate.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sendstate.c; sourceTree = "<group>"; };
 		E9CC44101EB85E0B00DC7D3E /* khash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = khash.h; sourceTree = "<group>"; };
 		E9CC44151EC195CA00DC7D3E /* picotest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = picotest.c; sourceTree = "<group>"; };
 		E9CC44161EC195CA00DC7D3E /* picotest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = picotest.h; sourceTree = "<group>"; };
@@ -363,6 +364,7 @@
 				E920D22F1F49EE0B00799777 /* loss.c */,
 				E99B75E61F5CF96900CF503E /* maxsender.c */,
 				E9F6A4291F3C3B7B0083F0B2 /* ranges.c */,
+				E9B43DA62452A94E00824E51 /* sendstate.c */,
 				E920D22D1F4981E500799777 /* sentmap.c */,
 				E920D2241F49412900799777 /* simple.c */,
 				E99B75E81F5D259400CF503E /* stream-concurrency.c */,
@@ -646,7 +648,6 @@
 				E920D22C1F49533800799777 /* sentmap.c in Sources */,
 				E920D2301F49EE0B00799777 /* loss.c in Sources */,
 				E99B75E71F5CF96900CF503E /* maxsender.c in Sources */,
-				E9F6A42F1F41375B0083F0B2 /* sendstate.c in Sources */,
 				E920D2251F49412900799777 /* simple.c in Sources */,
 				E920D21F1F43E05000799777 /* recvstate.c in Sources */,
 				E9CC44251EC1962700DC7D3E /* test.c in Sources */,
@@ -660,6 +661,7 @@
 				E9CC44261EC1963100DC7D3E /* picotest.c in Sources */,
 				E95E953D22904A4C00215ACD /* picotls-probes.d in Sources */,
 				E9CC441C1EC195DF00DC7D3E /* picotls.c in Sources */,
+				E9B43DA72452A94E00824E51 /* sendstate.c in Sources */,
 				E98042372244A5D7008B9745 /* defaults.c in Sources */,
 				E99F8C271F4E9F5D00C26B3D /* frame.c in Sources */,
 			);

--- a/t/sendstate.c
+++ b/t/sendstate.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020 Fastly, Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "test.h"
+#include "../lib/sendstate.c"
+
+static void test_reduction(void)
+{
+    static const size_t packet_size = 10;
+    quicly_sendstate_t s;
+    int ret;
+
+    quicly_sendstate_init(&s);
+    quicly_sendstate_activate(&s);
+
+    /* send 128 packets */
+    ret = quicly_ranges_subtract(&s.pending, 0, packet_size * max_ranges * 4);
+    assert(ret == 0);
+
+    /* sack every odd-numbered packet */
+    size_t i;
+    for (i = 0; i < max_ranges * 2; ++i) {
+        quicly_sendstate_sent_t sent = {
+            .start = i * packet_size,
+            .end = (i + 1) * packet_size,
+        };
+        if (i % 2 == 0) {
+            ret = quicly_sendstate_lost(&s, &sent);
+            ok(ret == 0);
+        } else {
+            size_t bytes_to_shift = 0x55555555;
+            ret = quicly_sendstate_acked(&s, &sent, 1, &bytes_to_shift);
+            ok(ret == 0);
+            ok(bytes_to_shift == 0);
+        }
+        ok(s.acked.num_ranges <= max_ranges);
+        ok(s.pending.num_ranges <= max_ranges);
+    }
+
+    ok(s.acked.num_ranges == max_ranges);
+    ok(s.acked.ranges[0].start == 0);
+    ok(s.acked.ranges[0].end == 0);
+    for (i = 1; i < max_ranges; ++i) {
+        ok(s.acked.ranges[i].start == (i * 2 - 1) * packet_size);
+        ok(s.acked.ranges[i].end == i * 2 * packet_size);
+    }
+
+    ok(s.pending.num_ranges == max_ranges);
+    for (i = 0; i < max_ranges - 1; ++i) {
+        ok(s.pending.ranges[i].start == i * 2 * packet_size);
+        ok(s.pending.ranges[i].end == (i * 2 + 1) * packet_size);
+    }
+    ok(s.pending.ranges[max_ranges - 1].start == (max_ranges - 1) * 2 * packet_size);
+    ok(s.pending.ranges[max_ranges - 1].end == UINT64_MAX);
+
+    quicly_sendstate_dispose(&s);
+}
+
+void test_sendstate(void)
+{
+    subtest("reduction", test_reduction);
+}

--- a/t/test.c
+++ b/t/test.c
@@ -485,6 +485,7 @@ int main(int argc, char **argv)
     subtest("ranges", test_ranges);
     subtest("frame", test_frame);
     subtest("maxsender", test_maxsender);
+    subtest("sendstate", test_sendstate);
     subtest("sentmap", test_sentmap);
     subtest("test-vector", test_vector);
     subtest("test-retry-aead", test_retry_aead);

--- a/t/test.h
+++ b/t/test.h
@@ -52,6 +52,7 @@ int max_data_is_equal(quicly_conn_t *client, quicly_conn_t *server);
 void test_ranges(void);
 void test_frame(void);
 void test_maxsender(void);
+void test_sendstate(void);
 void test_sentmap(void);
 void test_simple(void);
 void test_loss(void);


### PR DESCRIPTION
When the state becomes excessive, reduce the state by dropping SACKed ranges. This causes unnecessary retransmits, but it is better than closing the connection.

We could close the connection, but the problem of that approach is that it is hard to guess the correct number of gaps that we would see, because the number of gaps can get fairly large when exiting slow start of a high BDP connection.

Closes #278.