### PR TITLE
applications supply packet buffers (rather than through the alloc_packet callback)

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -853,19 +853,20 @@ size_t quicly_send_retry(quicly_context_t *ctx, ptls_aead_context_t *token_encry
                          ptls_iovec_t token_prefix, ptls_iovec_t appdata, ptls_aead_context_t **retry_aead_cache, uint8_t *payload);
 /**
  * Builds UDP datagrams to be sent for given connection.
- * @param [out] dest            destination address
- * @param [out] src             source address
- * @param [out] packets         vector of iovecs pointing to the payloads of UDP datagrams. Each iovec represens a single UDP
- *                              datagram.
- * @param [in,out] num_packets  Upon entry, the application provides the number of entries that the `packets` vector can contain.
- *                              Upon return, contains the number of packet vectors emitted by `quicly_send`.
- * @param buf                   buffer used for building UDP datagrams. It is guaranteed that the first datagram would be built from
- *                              the address provided by `buf`, and that succeeding packets (if any) will be contiguously laid out.
- *                              This constraint reduces the number of vectors that need to be passed to the kernel when using GSO.
+ * @param [out] dest              destination address
+ * @param [out] src               source address
+ * @param [out] datagrams         vector of iovecs pointing to the payloads of UDP datagrams. Each iovec represens a single UDP
+ *                                datagram.
+ * @param [in,out] num_datagrams  Upon entry, the application provides the number of entries that the `packets` vector can contain.
+ *                                Upon return, contains the number of packet vectors emitted by `quicly_send`.
+ * @param buf                     buffer used for building UDP datagrams. It is guaranteed that the first datagram would be built
+ *                                from the address provided by `buf`, and that succeeding packets (if any) will be contiguously laid
+ *                                out. This constraint reduces the number of vectors that need to be passed to the kernel when using
+ *                                GSO.
  * @return 0 if successful, otherwise an error. When an error is returned, the caller must call `quicly_close` to discard the
  *         connection context.
  */
-int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *src, struct iovec *packets, size_t *num_packets,
+int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *src, struct iovec *datagrams, size_t *num_datagrams,
                 void *buf, size_t bufsize);
 /**
  *

--- a/include/quicly/defaults.h
+++ b/include/quicly/defaults.h
@@ -32,10 +32,6 @@ extern const quicly_context_t quicly_spec_context;
 extern const quicly_context_t quicly_performant_context;
 
 /**
- *
- */
-extern quicly_packet_allocator_t quicly_default_packet_allocator;
-/**
  * Instantiates a CID cipher.
  * The CID cipher MUST be a block cipher. It MAY be a 64-bit block cipher (e.g., blowfish) when `quicly_cid_plaintext_t::node_id` is
  * not utilized by the application. Otherwise, it MUST be a 128-bit block cipher (e.g., AES).

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -42,7 +42,6 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                               0, /* enforce_version_negotiation */
                                               0, /* is_clustered */
                                               0, /* enlarge_client_hello */
-                                              &quicly_default_packet_allocator,
                                               NULL,
                                               NULL, /* on_stream_open */
                                               &quicly_default_stream_scheduler,
@@ -67,7 +66,6 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                     0, /* enforce_version_negotiation */
                                                     0, /* is_clustered */
                                                     0, /* enlarge_client_hello */
-                                                    &quicly_default_packet_allocator,
                                                     NULL,
                                                     NULL, /* on_stream_open */
                                                     &quicly_default_stream_scheduler,
@@ -76,24 +74,6 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                     NULL,
                                                     NULL,
                                                     &quicly_default_crypto_engine};
-
-static quicly_datagram_t *default_alloc_packet(quicly_packet_allocator_t *self, size_t payloadsize)
-{
-    quicly_datagram_t *packet;
-
-    if ((packet = malloc(sizeof(*packet) + payloadsize)) == NULL)
-        return NULL;
-    packet->data.base = (uint8_t *)packet + sizeof(*packet);
-
-    return packet;
-}
-
-static void default_free_packet(quicly_packet_allocator_t *self, quicly_datagram_t *packet)
-{
-    free(packet);
-}
-
-quicly_packet_allocator_t quicly_default_packet_allocator = {default_alloc_packet, default_free_packet};
 
 /**
  * The context of the default CID encryptor.  All the contexts being used here are ECB ciphers and therefore stateless - they can be
@@ -432,17 +412,17 @@ Exit:
 
 static void default_finalize_send_packet(quicly_crypto_engine_t *engine, quicly_conn_t *conn,
                                          ptls_cipher_context_t *header_protect_ctx, ptls_aead_context_t *packet_protect_ctx,
-                                         quicly_datagram_t *packet, size_t first_byte_at, size_t payload_from, int coalesced)
+                                         ptls_iovec_t datagram, size_t first_byte_at, size_t payload_from, int coalesced)
 {
     uint8_t hpmask[1 + QUICLY_SEND_PN_SIZE] = {0};
     size_t i;
 
-    ptls_cipher_init(header_protect_ctx, packet->data.base + payload_from - QUICLY_SEND_PN_SIZE + QUICLY_MAX_PN_SIZE);
+    ptls_cipher_init(header_protect_ctx, datagram.base + payload_from - QUICLY_SEND_PN_SIZE + QUICLY_MAX_PN_SIZE);
     ptls_cipher_encrypt(header_protect_ctx, hpmask, hpmask, sizeof(hpmask));
 
-    packet->data.base[first_byte_at] ^= hpmask[0] & (QUICLY_PACKET_IS_LONG_HEADER(packet->data.base[first_byte_at]) ? 0xf : 0x1f);
+    datagram.base[first_byte_at] ^= hpmask[0] & (QUICLY_PACKET_IS_LONG_HEADER(datagram.base[first_byte_at]) ? 0xf : 0x1f);
     for (i = 0; i != QUICLY_SEND_PN_SIZE; ++i)
-        packet->data.base[payload_from + i - QUICLY_SEND_PN_SIZE] ^= hpmask[i + 1];
+        datagram.base[payload_from + i - QUICLY_SEND_PN_SIZE] ^= hpmask[i + 1];
 }
 
 quicly_crypto_engine_t quicly_default_crypto_engine = {default_setup_cipher, default_finalize_send_packet};

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2450,18 +2450,21 @@ uint64_t quicly_get_next_expected_packet_number(quicly_conn_t *conn)
     return conn->application->super.next_expected_packet_number;
 }
 
-/* data structure that is used during one call through quicly_send()
+/**
+ * data structure that is used during one call through quicly_send()
  */
 struct st_quicly_send_context_t {
-    /* current encryption context */
+    /**
+     * current encryption context
+     */
     struct {
         struct st_quicly_cipher_context_t *cipher;
         uint8_t first_byte;
     } current;
-
-    /* packet under construction */
+    /**
+     * packet under construction
+     */
     struct {
-        quicly_datagram_t *packet;
         struct st_quicly_cipher_context_t *cipher;
         /**
          * points to the first byte of the target QUIC packet. It will not point to packet->octets.base[0] when the datagram
@@ -2470,26 +2473,46 @@ struct st_quicly_send_context_t {
         uint8_t *first_byte_at;
         uint8_t ack_eliciting : 1;
     } target;
-
-    /* output buffer into which list of datagrams is written */
-    quicly_datagram_t **packets;
-    /* max number of datagrams that can be stored in |packets| */
+    /**
+     * output buffer into which list of datagrams is written
+     */
+    struct iovec *packets;
+    /**
+     * max number of datagrams that can be stored in |packets|
+     */
     size_t max_packets;
-    /* number of datagrams currently stored in |packets| */
+    /**
+     * number of datagrams currently stored in |packets|
+     */
     size_t num_packets;
-    /* the currently available window for sending (in bytes) */
+    /**
+     * buffer in which packets are built
+     */
+    struct {
+        uint8_t *datagram, *end;
+    } payload_buf;
+
+    /**
+     * the currently available window for sending (in bytes)
+     */
     ssize_t send_window;
-    /* location where next frame should be written */
+    /**
+     * location where next frame should be written
+     */
     uint8_t *dst;
-    /* end of the payload area, beyond which frames cannot be written */
+    /**
+     * end of the payload area, beyond which frames cannot be written
+     */
     uint8_t *dst_end;
-    /* address at which payload starts */
+    /**
+     * address at which payload starts
+     */
     uint8_t *dst_payload_from;
 };
 
 static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, int coalesced)
 {
-    size_t packet_bytes_in_flight;
+    size_t datagram_size, packet_bytes_in_flight;
 
     assert(s->target.cipher->aead != NULL);
 
@@ -2501,12 +2524,12 @@ static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, int
 
     /* the last packet of the first-flight datagrams is padded to become max_udp_payload_size bytes */
     if (!coalesced && quicly_is_client(conn) &&
-        (s->target.packet->data.base[0] & QUICLY_PACKET_TYPE_BITMASK) == QUICLY_PACKET_TYPE_INITIAL) {
+        (s->payload_buf.datagram[0] & QUICLY_PACKET_TYPE_BITMASK) == QUICLY_PACKET_TYPE_INITIAL) {
         const size_t max_size = conn->egress.max_udp_payload_size - QUICLY_AEAD_TAG_SIZE;
         assert(quicly_is_client(conn));
-        assert(s->dst - s->target.packet->data.base <= max_size);
-        memset(s->dst, QUICLY_FRAME_TYPE_PADDING, s->target.packet->data.base + max_size - s->dst);
-        s->dst = s->target.packet->data.base + max_size;
+        assert(s->dst - s->payload_buf.datagram <= max_size);
+        memset(s->dst, QUICLY_FRAME_TYPE_PADDING, s->payload_buf.datagram + max_size - s->dst);
+        s->dst = s->payload_buf.datagram + max_size;
     }
 
     /* encode packet size, packet number, key-phase */
@@ -2530,12 +2553,13 @@ static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, int
     s->dst = s->dst_payload_from + ptls_aead_encrypt(s->target.cipher->aead, s->dst_payload_from, s->dst_payload_from,
                                                      s->dst - s->dst_payload_from, conn->egress.packet_number,
                                                      s->target.first_byte_at, s->dst_payload_from - s->target.first_byte_at);
-    s->target.packet->data.len = s->dst - s->target.packet->data.base;
-    assert(s->target.packet->data.len <= conn->egress.max_udp_payload_size);
+    datagram_size = s->dst - s->payload_buf.datagram;
+    assert(datagram_size <= conn->egress.max_udp_payload_size);
 
     conn->super.ctx->crypto_engine->finalize_send_packet(
-        conn->super.ctx->crypto_engine, conn, s->target.cipher->header_protection, s->target.cipher->aead, s->target.packet,
-        s->target.first_byte_at - s->target.packet->data.base, s->dst_payload_from - s->target.packet->data.base, coalesced);
+        conn->super.ctx->crypto_engine, conn, s->target.cipher->header_protection, s->target.cipher->aead,
+        ptls_iovec_init(s->payload_buf.datagram, datagram_size), s->target.first_byte_at - s->payload_buf.datagram,
+        s->dst_payload_from - s->payload_buf.datagram, coalesced);
 
     /* update CC, commit sentmap */
     if (s->target.ack_eliciting) {
@@ -2556,9 +2580,9 @@ static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, int
     ++conn->super.stats.num_packets.sent;
 
     if (!coalesced) {
-        conn->super.stats.num_bytes.sent += s->target.packet->data.len;
-        s->packets[s->num_packets++] = s->target.packet;
-        s->target.packet = NULL;
+        conn->super.stats.num_bytes.sent += datagram_size;
+        s->packets[s->num_packets++] = (struct iovec){.iov_base = s->payload_buf.datagram, .iov_len = datagram_size};
+        s->payload_buf.datagram += datagram_size;
         s->target.cipher = NULL;
         s->target.first_byte_at = NULL;
     }
@@ -2608,7 +2632,7 @@ static int _do_allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, siz
     }
 
     /* commit at the same time determining if we will coalesce the packets */
-    if (s->target.packet != NULL) {
+    if (s->target.first_byte_at != NULL) {
         if (coalescible) {
             size_t overhead =
                 1 /* type */ + conn->super.peer.cid.len + QUICLY_SEND_PN_SIZE + s->current.cipher->aead->algo->tag_size;
@@ -2638,14 +2662,11 @@ static int _do_allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, siz
         s->send_window = round_send_window(s->send_window);
         if (ack_eliciting && s->send_window < (ssize_t)min_space)
             return QUICLY_ERROR_SENDBUF_FULL;
-        if ((s->target.packet = conn->super.ctx->packet_allocator->alloc_packet(conn->super.ctx->packet_allocator,
-                                                                                conn->egress.max_udp_payload_size)) == NULL)
-            return PTLS_ERROR_NO_MEMORY;
-        s->target.packet->dest = conn->super.peer.address;
-        s->target.packet->src = conn->super.host.address;
+        if (s->payload_buf.end - s->payload_buf.datagram < conn->egress.max_udp_payload_size)
+            return QUICLY_ERROR_SENDBUF_FULL;
         s->target.cipher = s->current.cipher;
-        s->dst = s->target.packet->data.base;
-        s->dst_end = s->target.packet->data.base + conn->egress.max_udp_payload_size;
+        s->dst = s->payload_buf.datagram;
+        s->dst_end = s->dst + conn->egress.max_udp_payload_size;
     }
     s->target.ack_eliciting = 0;
 
@@ -2759,7 +2780,7 @@ Emit: /* emit an ACK frame */
         /* [rare case] A coalesced packet might not have enough space to hold only an ACK. If so, pad it, as that's easier than
          * rolling back. */
         if (s->dst == s->dst_payload_from) {
-            assert(s->target.first_byte_at != s->target.packet->data.base);
+            assert(s->target.first_byte_at != s->payload_buf.datagram);
             *s->dst++ = QUICLY_FRAME_TYPE_PADDING;
         }
         if ((ret = commit_send_packet(conn, s, 0)) != 0)
@@ -3247,17 +3268,10 @@ Exit:
     return ret;
 }
 
-quicly_datagram_t *quicly_send_version_negotiation(quicly_context_t *ctx, struct sockaddr *dest_addr, ptls_iovec_t dest_cid,
-                                                   struct sockaddr *src_addr, ptls_iovec_t src_cid)
+size_t quicly_send_version_negotiation(quicly_context_t *ctx, struct sockaddr *dest_addr, ptls_iovec_t dest_cid,
+                                       struct sockaddr *src_addr, ptls_iovec_t src_cid, void *payload)
 {
-    quicly_datagram_t *packet;
-    uint8_t *dst;
-
-    if ((packet = ctx->packet_allocator->alloc_packet(ctx->packet_allocator, QUICLY_MIN_CLIENT_INITIAL_SIZE)) == NULL)
-        return NULL;
-    set_address(&packet->dest, dest_addr);
-    set_address(&packet->src, src_addr);
-    dst = packet->data.base;
+    uint8_t *dst = payload;
 
     /* type_flags */
     ctx->tls->random_bytes(dst, 1);
@@ -3279,9 +3293,7 @@ quicly_datagram_t *quicly_send_version_negotiation(quicly_context_t *ctx, struct
     /* supported_versions */
     dst = quicly_encode32(dst, QUICLY_PROTOCOL_VERSION);
 
-    packet->data.len = dst - packet->data.base;
-
-    return packet;
+    return dst - (uint8_t *)payload;
 }
 
 int quicly_retry_calc_cidpair_hash(ptls_hash_algorithm_t *sha256, ptls_iovec_t client_cid, ptls_iovec_t server_cid, uint64_t *value)
@@ -3304,12 +3316,11 @@ int quicly_retry_calc_cidpair_hash(ptls_hash_algorithm_t *sha256, ptls_iovec_t c
     return 0;
 }
 
-quicly_datagram_t *quicly_send_retry(quicly_context_t *ctx, ptls_aead_context_t *token_encrypt_ctx, struct sockaddr *dest_addr,
-                                     ptls_iovec_t dest_cid, struct sockaddr *src_addr, ptls_iovec_t src_cid, ptls_iovec_t odcid,
-                                     ptls_iovec_t token_prefix, ptls_iovec_t appdata, ptls_aead_context_t **retry_aead_cache)
+size_t quicly_send_retry(quicly_context_t *ctx, ptls_aead_context_t *token_encrypt_ctx, struct sockaddr *dest_addr,
+                         ptls_iovec_t dest_cid, struct sockaddr *src_addr, ptls_iovec_t src_cid, ptls_iovec_t odcid,
+                         ptls_iovec_t token_prefix, ptls_iovec_t appdata, ptls_aead_context_t **retry_aead_cache, uint8_t *datagram)
 {
     quicly_address_token_plaintext_t token;
-    quicly_datagram_t *packet = NULL;
     ptls_buffer_t buf;
     int ret;
 
@@ -3330,11 +3341,7 @@ quicly_datagram_t *quicly_send_retry(quicly_context_t *ctx, ptls_aead_context_t 
     }
 
     /* start building the packet */
-    if ((packet = ctx->packet_allocator->alloc_packet(ctx->packet_allocator, QUICLY_MIN_CLIENT_INITIAL_SIZE)) == NULL)
-        goto Exit;
-    set_address(&packet->dest, dest_addr);
-    set_address(&packet->src, src_addr);
-    ptls_buffer_init(&buf, packet->data.base, QUICLY_MIN_CLIENT_INITIAL_SIZE);
+    ptls_buffer_init(&buf, datagram, QUICLY_MIN_CLIENT_INITIAL_SIZE);
 
     /* first generate a pseudo packet */
     ptls_buffer_push_block(&buf, 1, { ptls_buffer_pushv(&buf, odcid.base, odcid.len); });
@@ -3373,15 +3380,10 @@ quicly_datagram_t *quicly_send_retry(quicly_context_t *ctx, ptls_aead_context_t 
     memmove(buf.base, buf.base + odcid.len + 1, buf.off - (odcid.len + 1));
     buf.off -= odcid.len + 1;
 
-    packet->data.len = buf.off;
     ret = 0;
 
 Exit:
-    if (ret != 0) {
-        if (packet != NULL)
-            ctx->packet_allocator->free_packet(ctx->packet_allocator, packet);
-    }
-    return packet;
+    return ret == 0 ? buf.off : SIZE_MAX;
 }
 
 static int send_handshake_flow(quicly_conn_t *conn, size_t epoch, quicly_send_context_t *s, int ack_only, int send_probe)
@@ -3683,7 +3685,7 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
 Exit:
     if (ret == QUICLY_ERROR_SENDBUF_FULL)
         ret = 0;
-    if (ret == 0 && s->target.packet != NULL)
+    if (ret == 0 && s->target.first_byte_at != NULL)
         commit_send_packet(conn, s, 0);
     if (ret == 0) {
         if (conn->application == NULL || conn->application->super.unacked_count == 0)
@@ -3695,9 +3697,10 @@ Exit:
     return ret;
 }
 
-int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_packets)
+int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *src, struct iovec *packets, size_t *num_packets,
+                void *buf, size_t bufsize)
 {
-    quicly_send_context_t s = {{NULL, -1}, {NULL, NULL, NULL}, packets, *num_packets};
+    quicly_send_context_t s = {{NULL, -1}, {}, packets, *num_packets, 0, {buf, (uint8_t *)buf + bufsize}};
     int ret;
 
     update_now(conn->super.ctx);
@@ -3755,28 +3758,25 @@ int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_pa
     assert_consistency(conn, 1);
 
 Exit:
+    if (s.num_packets != 0) {
+        *dest = conn->super.peer.address;
+        *src = conn->super.host.address;
+    }
     *num_packets = s.num_packets;
     --in_quicly_send_cnt;
     return ret;
 }
 
-quicly_datagram_t *quicly_send_close_invalid_token(quicly_context_t *ctx, struct sockaddr *dest_addr, ptls_iovec_t dest_cid,
-                                                   struct sockaddr *src_addr, ptls_iovec_t src_cid, const char *err_desc)
+size_t quicly_send_close_invalid_token(quicly_context_t *ctx, struct sockaddr *dest_addr, ptls_iovec_t dest_cid,
+                                       struct sockaddr *src_addr, ptls_iovec_t src_cid, const char *err_desc, void *datagram)
 {
     struct st_quicly_cipher_context_t egress = {};
-    quicly_datagram_t *dgram = NULL;
 
     /* setup keys */
     if (setup_initial_encryption(get_aes128gcmsha256(ctx), NULL, &egress, src_cid, 0, NULL) != 0)
-        goto Exit;
+        return SIZE_MAX;
 
-    /* allocate packet, set peer address */
-    if ((dgram = ctx->packet_allocator->alloc_packet(ctx->packet_allocator, QUICLY_MIN_CLIENT_INITIAL_SIZE)) == NULL)
-        goto Exit;
-    set_address(&dgram->dest, dest_addr);
-    set_address(&dgram->src, src_addr);
-
-    uint8_t *dst = dgram->data.base, *length_at;
+    uint8_t *dst = datagram, *length_at;
 
     /* build packet */
     PTLS_BUILD_ASSERT(QUICLY_SEND_PN_SIZE == 2);
@@ -3798,46 +3798,35 @@ quicly_datagram_t *quicly_send_close_invalid_token(quicly_context_t *ctx, struct
 
     /* determine the size of the packet, make adjustments */
     dst += egress.aead->algo->tag_size;
-    assert(dst - dgram->data.base <= QUICLY_MIN_CLIENT_INITIAL_SIZE);
+    assert(dst - (uint8_t *)datagram <= QUICLY_MIN_CLIENT_INITIAL_SIZE);
     assert(dst - length_at - 1 < 64);
     *length_at = dst - length_at - 1;
-    dgram->data.len = dst - dgram->data.base;
+    size_t datagram_len = dst - (uint8_t *)datagram;
 
     /* encrypt packet */
-    ptls_aead_encrypt(egress.aead, payload_from, payload_from, dst - payload_from - egress.aead->algo->tag_size, 0,
-                      dgram->data.base, payload_from - dgram->data.base);
+    ptls_aead_encrypt(egress.aead, payload_from, payload_from, dst - payload_from - egress.aead->algo->tag_size, 0, datagram,
+                      payload_from - (uint8_t *)datagram);
     quicly_default_crypto_engine.finalize_send_packet(&quicly_default_crypto_engine, NULL, egress.header_protection, egress.aead,
-                                                      dgram, 0, payload_from - dgram->data.base, 0);
+                                                      ptls_iovec_init(datagram, datagram_len), 0,
+                                                      payload_from - (uint8_t *)datagram, 0);
 
-Exit:
-    if (egress.aead != NULL)
-        dispose_cipher(&egress);
-    return dgram;
+    dispose_cipher(&egress);
+    return datagram_len;
 }
 
-quicly_datagram_t *quicly_send_stateless_reset(quicly_context_t *ctx, struct sockaddr *dest_addr, struct sockaddr *src_addr,
-                                               const void *src_cid)
+size_t quicly_send_stateless_reset(quicly_context_t *ctx, struct sockaddr *dest_addr, struct sockaddr *src_addr,
+                                   const void *src_cid, void *payload)
 {
-    quicly_datagram_t *dgram;
-
-    /* allocate packet, set peer address */
-    if ((dgram = ctx->packet_allocator->alloc_packet(ctx->packet_allocator, QUICLY_STATELESS_RESET_PACKET_MIN_LEN)) == NULL)
-        return NULL;
-    set_address(&dgram->dest, dest_addr);
-    set_address(&dgram->src, src_addr);
+    uint8_t *base = payload;
 
     /* build stateless reset packet */
-    ctx->tls->random_bytes(dgram->data.base, QUICLY_STATELESS_RESET_PACKET_MIN_LEN - QUICLY_STATELESS_RESET_TOKEN_LEN);
-    dgram->data.base[0] = (dgram->data.base[0] & ~QUICLY_LONG_HEADER_BIT) | QUICLY_QUIC_BIT;
+    ctx->tls->random_bytes(base, QUICLY_STATELESS_RESET_PACKET_MIN_LEN - QUICLY_STATELESS_RESET_TOKEN_LEN);
+    base[0] = (base[0] & ~QUICLY_LONG_HEADER_BIT) | QUICLY_QUIC_BIT;
     if (!ctx->cid_encryptor->generate_stateless_reset_token(
-            ctx->cid_encryptor, dgram->data.base + QUICLY_STATELESS_RESET_PACKET_MIN_LEN - QUICLY_STATELESS_RESET_TOKEN_LEN,
-            src_cid)) {
-        ctx->packet_allocator->free_packet(ctx->packet_allocator, dgram);
-        return NULL;
-    }
-    dgram->data.len = QUICLY_STATELESS_RESET_PACKET_MIN_LEN;
+            ctx->cid_encryptor, base + QUICLY_STATELESS_RESET_PACKET_MIN_LEN - QUICLY_STATELESS_RESET_TOKEN_LEN, src_cid))
+        return SIZE_MAX;
 
-    return dgram;
+    return QUICLY_STATELESS_RESET_PACKET_MIN_LEN;
 }
 
 int quicly_send_resumption_token(quicly_conn_t *conn)

--- a/t/loss.c
+++ b/t/loss.c
@@ -105,11 +105,13 @@ static void init_cond_rand(struct loss_cond_t *cond, unsigned nloss, unsigned nt
 static int transmit_cond(quicly_conn_t *src, quicly_conn_t *dst, size_t *num_sent, size_t *num_received, struct loss_cond_t *cond,
                          int64_t latency)
 {
-    quicly_datagram_t *packets[32];
+    quicly_address_t destaddr, srcaddr;
+    struct iovec packets[32];
+    uint8_t packetsbuf[PTLS_ELEMENTSOF(packets) * quicly_get_context(src)->transport_params.max_udp_payload_size];
     int ret;
 
     *num_sent = PTLS_ELEMENTSOF(packets);
-    if ((ret = quicly_send(src, packets, num_sent)) != 0) {
+    if ((ret = quicly_send(src, &destaddr, &srcaddr, packets, num_sent, packetsbuf, sizeof(packetsbuf))) != 0) {
         fprintf(stderr, "%s: quicly_send: ret=%d\n", __FUNCTION__, ret);
         return ret;
     }
@@ -134,7 +136,6 @@ static int transmit_cond(quicly_conn_t *src, quicly_conn_t *dst, size_t *num_sen
                 ++*num_received;
             }
         }
-        free_packets(packets, *num_sent);
     }
     quic_now += latency;
 
@@ -155,7 +156,9 @@ static void test_even(void)
     quic_now = 0;
 
     { /* transmit first flight */
-        quicly_datagram_t *raw;
+        quicly_address_t destaddr, srcaddr;
+        struct iovec raw;
+        uint8_t rawbuf[quic_ctx.transport_params.max_udp_payload_size];
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
@@ -163,14 +166,13 @@ static void test_even(void)
                              NULL, NULL);
         ok(ret == 0);
         num_packets = 1;
-        ret = quicly_send(client, &raw, &num_packets);
+        ret = quicly_send(client, &destaddr, &srcaddr, &raw, &num_packets, rawbuf, sizeof(rawbuf));
         ok(ret == 0);
         ok(num_packets == 1);
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
         ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
-        free_packets(&raw, 1);
         cond_up.cb(&cond_up);
     }
 
@@ -267,7 +269,9 @@ static void loss_core(void)
     quic_now = 0;
 
     { /* transmit first flight */
-        quicly_datagram_t *raw;
+        quicly_address_t destaddr, srcaddr;
+        struct iovec raw;
+        uint8_t rawbuf[quic_ctx.transport_params.max_udp_payload_size];
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
@@ -275,7 +279,7 @@ static void loss_core(void)
                              NULL, NULL);
         ok(ret == 0);
         num_packets = 1;
-        ret = quicly_send(client, &raw, &num_packets);
+        ret = quicly_send(client, &destaddr, &srcaddr, &raw, &num_packets, rawbuf, sizeof(rawbuf));
         ok(ret == 0);
         ok(num_packets == 1);
         quic_now += 10;
@@ -283,7 +287,6 @@ static void loss_core(void)
         ok(num_packets == 1);
         ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
-        free_packets(&raw, 1);
         quic_now += 10;
     }
 

--- a/t/stream-concurrency.c
+++ b/t/stream-concurrency.c
@@ -33,7 +33,9 @@ void test_stream_concurrency(void)
     int ret;
 
     { /* connect */
-        quicly_datagram_t *raw;
+        quicly_address_t dest, src;
+        struct iovec raw;
+        uint8_t rawbuf[quic_ctx.transport_params.max_udp_payload_size];
         size_t num_packets;
         quicly_decoded_packet_t decoded;
 
@@ -41,14 +43,13 @@ void test_stream_concurrency(void)
                              NULL, NULL);
         ok(ret == 0);
         num_packets = 1;
-        ret = quicly_send(client, &raw, &num_packets);
+        ret = quicly_send(client, &dest, &src, &raw, &num_packets, rawbuf, sizeof(rawbuf));
         ok(ret == 0);
         ok(num_packets == 1);
         ok(decode_packets(&decoded, &raw, 1) == 1);
         ok(num_packets == 1);
         ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
         ok(ret == 0);
-        free_packets(&raw, 1);
         transmit(server, client);
     }
 

--- a/t/test.h
+++ b/t/test.h
@@ -43,8 +43,7 @@ extern size_t on_destroy_callcnt;
 
 const quicly_cid_plaintext_t *new_master_id(void);
 extern quicly_stream_open_t stream_open;
-void free_packets(quicly_datagram_t **packets, size_t cnt);
-size_t decode_packets(quicly_decoded_packet_t *decoded, quicly_datagram_t **raw, size_t cnt);
+size_t decode_packets(quicly_decoded_packet_t *decoded, struct iovec *raw, size_t cnt);
 int buffer_is(ptls_buffer_t *buf, const char *s);
 size_t transmit(quicly_conn_t *src, quicly_conn_t *dst);
 int max_data_is_equal(quicly_conn_t *client, quicly_conn_t *server);


### PR DESCRIPTION
Up until now, we have had `quicly_packet_allocator` that is used for allocating memory for storing a packet image, associated with the source and destination addresses. While conceptually clean, this design has had issues:
* Unnecessary use of alloc - free. Typically, applications call `quicy_send` then immediately submits the UDP packets being built to the kernel. In such case, freedom for releasing things in arbitrary order (what heap allocation provides) is unnecessary and just costly.
* Unfriendliness with GSO. The prerequisite of GSO is that all packets contain the same 4-tuple. As the 4-tuple tuple contained in each packet generated by quicly can be different, __applications are required to consult the 4-tuple of each packet and route them to the correct socket (or underlying network interface)__. Also, it was hard to build all the UDP packet images in a contiguous range of memory. That resulted in the kernel doing gather operation when using GSO.

This PR changes the approach.

It eliminates the alloc_packet callback, and instead requires application to supply the buffer in which UDP packet images should be built, when calling functions like `quicly_send`.

In master, `quicly_send` function looks like:
```c
/**
 * Builds UDP datagrams to be sent for given connection.
 * @param [out] packets         vector of `quicly_datagram_t *`, each of the elements containing the 4-tuple and the datagram
 *                              payload. Each `quicly_datagram_t *` is allocated and freed using the alloc_packet callback provided
 *                              through `quicly_context_t`.
 * @param [in,out] num_packets  Upon entry, the application provides the number of entries that the `packets` vector can contain.
 *                              Upon return, contains the number of packet vectors emitted by `quicly_send`.
 * @return 0 if successful, otherwise an error. When an error is returned, the caller must call `quicly_close` to discard the
 *         connection context.
 */
int quicly_send(quicly_conn_t *conn, quicly_datagram_t **packets, size_t *num_packets);
```

With the proposed change, it becomes like:
```c
/**
 * Builds UDP datagrams to be sent for given connection.
 * @param [out] dest            destination address
 * @param [out] src             source address
 * @param [out] packets         vector of iovecs pointing to the payloads of UDP datagrams. Each iovec represens a single UDP
 *                              datagram.
 * @param [in,out] num_packets  Upon entry, the application provides the number of entries that the `packets` vector can contain.
 *                              Upon return, contains the number of packet vectors emitted by `quicly_send`.
 * @param buf                   buffer used for building UDP datagrams. It is guaranteed that the first datagram would be built from
 *                              the address provided by `buf`, and that succeeding packets (if any) will be contiguously laid out.
 *                              This constraint reduces the number of vectors that need to be passed to the kernel when using GSO.
 * @return 0 if successful, otherwise an error. When an error is returned, the caller must call `quicly_close` to discard the
 *         connection context.
 */
int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *src, struct iovec *packets, size_t *num_packets,
                void *buf, size_t bufsize);
```

Other functions that emit packets (e.g., `quicly_send_version_negotiation`, `quicly_send_retry`) are also modified so that they would receive a buffer to which the UDP payloads are written.