### PR TITLE
Fix erroneous assertion that assumed that a loss leads to a retransmission

### DIFF
--- a/lib/sendstate.c
+++ b/lib/sendstate.c
@@ -185,6 +185,6 @@ int quicly_sendstate_lost(quicly_sendstate_t *state, quicly_sendstate_sent_t *ar
     }
 
 Exit:
-    assert(state->acked.ranges[0].end <= state->pending.ranges[0].start);
+    assert(state->pending.num_ranges == 0 || state->acked.ranges[0].end <= state->pending.ranges[0].start);
     return check_amount_of_state(state);
 }


### PR DESCRIPTION
Addresses server crashes like https://travis-ci.org/github/h2o/quicly/builds/682214901.

The crash was in one of our assertions, that incorrectly assumed that whenever a stream frame is being deemed lost, and if that stream is still active, then there would be something to transmit.

This assumption does not hold when a retransmitted frame is deemed lost after the original frames at the tail get late-acked.

In case of the CI failures, we were seeing something like:
```
{"type":"stream-send", "conn":0, "time":1589436152923, "stream-id":-3, "off":0, "len":1073, "is-fin":0}
{"type":"stream-send", "conn":0, "time":1589436152923, "stream-id":-3, "off":1073, "len":164, "is-fin":0}
{"type":"pto", "conn":0, "time":1589436152925, "inflight":1611, "cwnd":14820, "pto-count":1}
{"type":"stream-lost", "conn":0, "time":1589436152925, "stream-id":-3, "off":0, "len":1073}
{"type":"stream-send", "conn":0, "time":1589436152925, "stream-id":-3, "off":0, "len":1073, "is-fin":0}
{"type":"stream-acked", "conn":0, "time":1589436152944, "stream-id":-3, "off":0, "len":1073}
{"type":"stream-acked", "conn":0, "time":1589436152944, "stream-id":-3, "off":1073, "len":164}
{"type":"crypto-handshake", "conn":0, "time":1589436152944, "ret":0}
{"type":"stream-lost", "conn":0, "time":1589436152944, "stream-id":-3, "off":0, "len":1073}
Assertion failed: (state->acked.ranges[0].end <= state->pending.ranges[0].start)
```

As can be seen, range [0,1073) is retransmitted due to PTO, then gets acked. Alongside the ACKs, the server receives ClientFinished, and the handshake PN space is destructed. At this point, all the sentmap entries belonging that space are called out as lost. But because all the ranges of stream -3 (i.e. CRYPTO stream of handshake PN space) has already been acked, the size of `state->pending.ranges` remains zero, and touching `state->pending.ranges[0].start` causes unexpected behavior.

The full trace is available at https://gist.github.com/kazuho/17e07326f4405025c5fbe094ae964362.

The reason we have been seeing this error in 0-rtt-vs-hrr test is because HRR gives the server an RTT estimate before the client spends time on processing the public key. If the client fails to do the public key calculation and respond in a millisecond or two, PTO timer at the server-side fires and retransmission happens.