### PR TITLE
Somewhat probabilistic approach for loss recovery tests

### DIFF
--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -354,7 +354,13 @@ static int64_t default_now(quicly_now_t *self)
 {
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    return (int64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000;
+    int64_t tv_now = (int64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000;
+
+    /* make sure that the time does not get rewind */
+    static __thread int64_t now;
+    if (now < tv_now)
+        now = tv_now;
+    return now;
 }
 
 quicly_now_t quicly_default_now = {default_now};

--- a/lib/local_cid.c
+++ b/lib/local_cid.c
@@ -81,13 +81,16 @@ void quicly_local_cid_init_set(quicly_local_cid_set_t *set, quicly_cid_encryptor
         ._size = 1,
     };
 
-    /* initialize cids[0] */
-    if (encryptor != NULL) {
+    /* if provided, set master id */
+    if (new_cid != NULL) {
         assert(new_cid->path_id == 0);
         set->plaintext = *new_cid;
+    }
+
+    /* initialize cids[0] */
+    if (encryptor != NULL) {
+        assert(new_cid != NULL && "master CID must be specified when a non-zero length CID is to be used");
         generate_cid(set, 0);
-    } else {
-        /* we have a zero-length CID at cids[0] */
     }
     set->cids[0].state =
         QUICLY_LOCAL_CID_STATE_DELIVERED; /* no need to use NCID frames, the use delivers this CID to the remote peer */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -434,14 +434,7 @@ static void lock_now(quicly_conn_t *conn, int is_reentrant)
 {
     if (conn->stash.now == 0) {
         assert(conn->stash.lock_count == 0);
-        /* update _now, but never let it go back */
         conn->stash.now = conn->super.ctx->now->cb(conn->super.ctx->now);
-        static __thread int64_t prev_now;
-        if (conn->stash.now < prev_now) {
-            conn->stash.now = prev_now;
-        } else {
-            prev_now = conn->stash.now;
-        }
     } else {
         assert(is_reentrant && "caller must be reentrant");
         assert(conn->stash.lock_count != 0);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -53,6 +53,11 @@ provider quicly {
                           size_t inflight);
     probe cc_congestion(struct st_quicly_conn_t *conn, int64_t at, uint64_t max_lost_pn, size_t inflight, uint32_t cwnd);
 
+    probe ack_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t largest_acked, uint64_t ack_delay);
+
+    probe ping_send(struct st_quicly_conn_t *conn, int64_t at);
+    probe ping_receive(struct st_quicly_conn_t *conn, int64_t at);
+
     probe transport_close_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t error_code, uint64_t frame_type,
                                const char *reason_phrase);
     probe transport_close_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t error_code, uint64_t frame_type,

--- a/t/loss.c
+++ b/t/loss.c
@@ -388,25 +388,25 @@ static int cmp_int64(const void *_x, const void *_y)
     return 0;
 }
 
-static void loss_check_stats(int64_t *time_spent, unsigned max_failures, double expected_time_avg, double expected_time_mean,
+static void loss_check_stats(int64_t *time_spent, unsigned max_failures, double expected_time_mean, double expected_time_median,
                              double expected_time_90th)
 {
     int64_t sum = 0;
     for (size_t i = 0; i < 100; ++i)
         sum += time_spent[i];
 
-    double time_avg = sum / 100.;
+    double time_mean = sum / 100.;
 
     qsort(time_spent, 100, sizeof(time_spent[0]), cmp_int64);
-    double time_mean = (time_spent[49] + time_spent[50]) / 2.;
+    double time_median = (time_spent[49] + time_spent[50]) / 2.;
     double time_90th = (double)time_spent[89];
 
-    printf("fail: %u, times: avg: %.1f, mean: %.1f, 90th: %.1f\n", num_failures_in_loss_core, time_avg, time_mean, time_90th);
+    printf("fail: %u, times: avg: %.1f, mean: %.1f, 90th: %.1f\n", num_failures_in_loss_core, time_mean, time_median, time_90th);
     ok(num_failures_in_loss_core <= max_failures);
-    ok(time_avg >= expected_time_avg * 0.8);
-    ok(time_avg <= expected_time_avg * 1.2);
     ok(time_mean >= expected_time_mean * 0.8);
     ok(time_mean <= expected_time_mean * 1.2);
+    ok(time_median >= expected_time_median * 0.8);
+    ok(time_median <= expected_time_median * 1.2);
     //ok(time_90th >= expected_time_90th * 0.9); 90th is fragile to errors, we track this as an guarantee
     ok(time_90th <= expected_time_90th * 1.2);
 

--- a/t/loss.c
+++ b/t/loss.c
@@ -380,7 +380,7 @@ static void test_downstream(void)
         init_cond_rand(&loss_cond_down, 3, 4);
         subtest("75%", loss_core);
     }
-    ok(num_failures_in_loss_core <= 2);
+    ok(num_failures_in_loss_core <= 3);
 
     num_failures_in_loss_core = 0;
     for (i = 0; i != 100; ++i) {
@@ -443,7 +443,7 @@ static void test_bidirectional(void)
         init_cond_rand(&loss_cond_up, 1, 2);
         subtest("50%", loss_core);
     }
-    ok(num_failures_in_loss_core <= 3);
+    ok(num_failures_in_loss_core <= 4);
 
     num_failures_in_loss_core = 0;
     for (i = 0; i != 100; ++i) {

--- a/t/loss.c
+++ b/t/loss.c
@@ -435,7 +435,7 @@ static void test_bidirectional(void)
         init_cond_rand(&loss_cond_up, 3, 4);
         subtest("75%", loss_core);
     }
-    ok(num_failures_in_loss_core <= 81);
+    ok(num_failures_in_loss_core <= 82);
 
     num_failures_in_loss_core = 0;
     for (i = 0; i != 100; ++i) {

--- a/t/loss.c
+++ b/t/loss.c
@@ -401,7 +401,7 @@ static void loss_check_stats(int64_t *time_spent, unsigned max_failures, double 
     double time_median = (time_spent[49] + time_spent[50]) / 2.;
     double time_90th = (double)time_spent[89];
 
-    printf("fail: %u, times: avg: %.1f, mean: %.1f, 90th: %.1f\n", num_failures_in_loss_core, time_mean, time_median, time_90th);
+    printf("fail: %u, times: mean: %.1f, median: %.1f, 90th: %.1f\n", num_failures_in_loss_core, time_mean, time_median, time_90th);
     ok(num_failures_in_loss_core <= max_failures);
     ok(time_mean >= expected_time_mean * 0.8);
     ok(time_mean <= expected_time_mean * 1.2);

--- a/t/loss.c
+++ b/t/loss.c
@@ -300,6 +300,15 @@ static void loss_core(void)
     ptls_buffer_t transmit_log;
     ptls_buffer_init(&transmit_log, "", 0);
 
+    {
+        char buf[64];
+        sprintf(buf, "odcid: ");
+        const quicly_cid_t *odcid = quicly_get_offered_cid(server);
+        ptls_hexdump(buf + strlen(buf), odcid->cid, odcid->len);
+        strcat(buf, "\n");
+        ptls_buffer_pushv(&transmit_log, buf, strlen(buf));
+    }
+
     quicly_stream_t *client_stream = NULL, *server_stream = NULL;
     test_streambuf_t *client_streambuf = NULL, *server_streambuf = NULL;
     const char *req = "GET / HTTP/1.0\r\n\r\n", *resp = "HTTP/1.0 200 OK\r\n\r\nhello world";

--- a/t/loss.c
+++ b/t/loss.c
@@ -443,7 +443,7 @@ static void test_bidirectional(void)
         init_cond_rand(&loss_cond_up, 1, 2);
         subtest("50%", loss_core);
     }
-    ok(num_failures_in_loss_core <= 2);
+    ok(num_failures_in_loss_core <= 3);
 
     num_failures_in_loss_core = 0;
     for (i = 0; i != 100; ++i) {


### PR DESCRIPTION
Until now, our loss tests have been checking that all attempts succeed in certain amount of time.

However, that is not a very good way of testing. That is because the performance of the worst case is not something that matters, especially when losses happen at random (we have always used a deterministic PRNG so that loss patterns would be repeatable every time we run the test suite, but anyways).

This PR changes the approach to checking the probability of transactions failing within a fixed number of attempts (100), for each loss ratio. The hope is that as we improve our loss recovery code, we can tighten those expectations. If we introduce a regression, we'd be in better place of catching them.