### PR TITLE
It's for TLS session tickets that we need to validate TP, not the tokens

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -957,7 +957,7 @@ int quicly_decrypt_address_token(ptls_aead_context_t *aead, quicly_address_token
  * Builds authentication data for TLS session ticket. 0-RTT can be accepted only when the auth_data of the original connection and
  * the new connection are identical.
  */
-int quicly_build_session_ticket_auth_data(ptls_buffer_t *auth_data, quicly_context_t *ctx);
+int quicly_build_session_ticket_auth_data(ptls_buffer_t *auth_data, const quicly_context_t *ctx);
 /**
  *
  */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -954,6 +954,11 @@ int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead
 int quicly_decrypt_address_token(ptls_aead_context_t *aead, quicly_address_token_plaintext_t *plaintext, const void *src,
                                  size_t len, size_t prefix_len, const char **err_desc);
 /**
+ * Builds authentication data for TLS session ticket. 0-RTT can be accepted only when the auth_data of the original connection and
+ * the new connection are identical.
+ */
+int quicly_build_session_ticket_auth_data(quicly_conn_t *conn, ptls_buffer_t *auth_data);
+/**
  *
  */
 static void quicly_byte_to_hex(char *dst, uint8_t v);

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -934,8 +934,15 @@ static int quicly_stream_is_self_initiated(quicly_stream_t *stream);
  */
 void quicly_amend_ptls_context(ptls_context_t *ptls);
 /**
- * Encrypts an address token by serializing the plaintext structure and appending an authentication tag.  Bytes between `start_off`
- * and `buf->off` (at the moment of invocation) is considered part of a token covered by AAD.
+ * Encrypts an address token by serializing the plaintext structure and appending an authentication tag.
+ *
+ * @param random_bytes  PRNG
+ * @param aead          the AEAD context to be used for decrypting the token
+ * @param buf           buffer to where the token being built is appended
+ * @param start_off     Specifies the start offset of the token. When `start_off < buf->off`, the bytes in between will be
+ *                      considered as part of the token and will be covered by the AEAD. Applications can use this location to embed
+ *                      the identifier of the AEAD key being used.
+ * @param plaintext     the token to be encrypted
  */
 int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead_context_t *aead, ptls_buffer_t *buf,
                                  size_t start_off, const quicly_address_token_plaintext_t *plaintext);

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -957,7 +957,7 @@ int quicly_decrypt_address_token(ptls_aead_context_t *aead, quicly_address_token
  * Builds authentication data for TLS session ticket. 0-RTT can be accepted only when the auth_data of the original connection and
  * the new connection are identical.
  */
-int quicly_build_session_ticket_auth_data(quicly_conn_t *conn, ptls_buffer_t *auth_data);
+int quicly_build_session_ticket_auth_data(ptls_buffer_t *auth_data, quicly_context_t *ctx);
 /**
  *
  */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -934,29 +934,18 @@ static int quicly_stream_is_self_initiated(quicly_stream_t *stream);
  */
 void quicly_amend_ptls_context(ptls_context_t *ptls);
 /**
- * Encrypts an address token by serializing the plaintext structure and appending an authentication tag.
- *
- * @param random_bytes  PRNG
- * @param aead          the AEAD context to be used for decrypting the token
- * @param tp            Transport parameters. Used for detecting and rejecting resumption tokens associated to an incompatible set
- *                      of transport parameters. This argument is ignored when encrypting a Retry token.
- * @param buf           buffer to where the token being built is appended
- * @param start_off     Specifies the start offset of the token. When `start_off < buf->off`, the bytes in between will be
- *                      considered as part of the token and will be covered by the AEAD. Applications can use this location to embed
- *                      the identifier of the AEAD key being used.
- * @param plaintext     the token to be encrypted
+ * Encrypts an address token by serializing the plaintext structure and appending an authentication tag.  Bytes between `start_off`
+ * and `buf->off` (at the moment of invocation) is considered part of a token covered by AAD.
  */
-int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead_context_t *aead,
-                                 const quicly_transport_parameters_t *tp, ptls_buffer_t *buf, size_t start_off,
-                                 const quicly_address_token_plaintext_t *plaintext);
+int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead_context_t *aead, ptls_buffer_t *buf,
+                                 size_t start_off, const quicly_address_token_plaintext_t *plaintext);
 /**
  * Decrypts an address token.
  * If decryption succeeds, returns zero. If the token is unusable due to decryption failure, returns PTLS_DECODE_ERROR. If the token
  * is unusable and the connection should be reset, returns QUICLY_ERROR_INVALID_TOKEN.
  */
-int quicly_decrypt_address_token(ptls_aead_context_t *aead, const quicly_transport_parameters_t *tp,
-                                 quicly_address_token_plaintext_t *plaintext, const void *src, size_t len, size_t prefix_len,
-                                 const char **err_desc);
+int quicly_decrypt_address_token(ptls_aead_context_t *aead, quicly_address_token_plaintext_t *plaintext, const void *src,
+                                 size_t len, size_t prefix_len, const char **err_desc);
 /**
  *
  */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5750,7 +5750,7 @@ Exit:
     return ret;
 }
 
-int quicly_build_session_ticket_auth_data(ptls_buffer_t *auth_data, quicly_context_t *ctx)
+int quicly_build_session_ticket_auth_data(ptls_buffer_t *auth_data, const quicly_context_t *ctx)
 {
     int ret;
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3556,8 +3556,8 @@ size_t quicly_send_retry(quicly_context_t *ctx, ptls_aead_context_t *token_encry
         memcpy(buf.base + buf.off, token_prefix.base, token_prefix.len);
         buf.off += token_prefix.len;
     }
-    if ((ret = quicly_encrypt_address_token(ctx->tls->random_bytes, token_encrypt_ctx, NULL, &buf, buf.off - token_prefix.len,
-                                            &token)) != 0)
+    if ((ret = quicly_encrypt_address_token(ctx->tls->random_bytes, token_encrypt_ctx, &buf, buf.off - token_prefix.len, &token)) !=
+        0)
         goto Exit;
 
     /* append AEAD tag */
@@ -5563,44 +5563,10 @@ void quicly_amend_ptls_context(ptls_context_t *ptls)
     ptls->update_traffic_key = &update_traffic_key;
 }
 
-/* builds AAD, from the plaintext data we'd have on wire and the transport parameter */
-static int build_aad_of_address_token(ptls_buffer_t *aad, const quicly_transport_parameters_t *tp, const void *plaintext_on_wire,
-                                      size_t plaintext_on_wire_len)
+int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead_context_t *aead, ptls_buffer_t *buf,
+                                 size_t start_off, const quicly_address_token_plaintext_t *plaintext)
 {
     int ret;
-
-    ptls_buffer_push_block(aad, -1, { ptls_buffer_pushv(aad, plaintext_on_wire, plaintext_on_wire_len); });
-#define PUSH_TP(id, block)                                                                                                         \
-    do {                                                                                                                           \
-        ptls_buffer_push_quicint(aad, id);                                                                                         \
-        ptls_buffer_push_block(aad, -1, block);                                                                                    \
-    } while (0)
-    PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_ACTIVE_CONNECTION_ID_LIMIT,
-            { ptls_buffer_push_quicint(aad, tp->active_connection_id_limit); });
-    PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_DATA, { ptls_buffer_push_quicint(aad, tp->max_data); });
-    PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL,
-            { ptls_buffer_push_quicint(aad, tp->max_stream_data.bidi_local); });
-    PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE,
-            { ptls_buffer_push_quicint(aad, tp->max_stream_data.bidi_remote); });
-    PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_UNI, { ptls_buffer_push_quicint(aad, tp->max_stream_data.uni); });
-    PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAMS_BIDI, { ptls_buffer_push_quicint(aad, tp->max_streams_bidi); });
-    PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAMS_UNI, { ptls_buffer_push_quicint(aad, tp->max_streams_uni); });
-#undef PUSH_TP
-
-    ret = 0;
-Exit:
-    return ret;
-}
-
-int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead_context_t *aead,
-                                 const quicly_transport_parameters_t *tp, ptls_buffer_t *buf, size_t start_off,
-                                 const quicly_address_token_plaintext_t *plaintext)
-{
-    ptls_iovec_t aad;
-    ptls_buffer_t resumption_aad;
-    int ret;
-
-    ptls_buffer_init(&resumption_aad, "", 0);
 
     /* type and IV */
     if ((ret = ptls_buffer_reserve(buf, 1 + aead->algo->iv_size)) != 0)
@@ -5632,7 +5598,6 @@ int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead
         });
         ptls_buffer_push16(buf, port);
     }
-    aad = ptls_iovec_init(buf->base + start_off, enc_start - start_off);
     switch (plaintext->type) {
     case QUICLY_ADDRESS_TOKEN_TYPE_RETRY:
         ptls_buffer_push_block(buf, 1,
@@ -5644,9 +5609,6 @@ int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead
         break;
     case QUICLY_ADDRESS_TOKEN_TYPE_RESUMPTION:
         ptls_buffer_push_block(buf, 1, { ptls_buffer_pushv(buf, plaintext->resumption.bytes, plaintext->resumption.len); });
-        if ((ret = build_aad_of_address_token(&resumption_aad, tp, aad.base, aad.len)) != 0)
-            goto Exit;
-        aad = ptls_iovec_init(resumption_aad.base, resumption_aad.off);
         break;
     default:
         assert(!"unexpected token type");
@@ -5657,19 +5619,17 @@ int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead
     /* encrypt, abusing the internal API to supply full IV */
     if ((ret = ptls_buffer_reserve(buf, aead->algo->tag_size)) != 0)
         goto Exit;
-    aead->do_encrypt_init(aead, buf->base + enc_start - aead->algo->iv_size, aad.base, aad.len);
+    aead->do_encrypt_init(aead, buf->base + enc_start - aead->algo->iv_size, buf->base + start_off, enc_start - start_off);
     ptls_aead_encrypt_update(aead, buf->base + enc_start, buf->base + enc_start, buf->off - enc_start);
     ptls_aead_encrypt_final(aead, buf->base + buf->off);
     buf->off += aead->algo->tag_size;
 
 Exit:
-    ptls_buffer_dispose(&resumption_aad);
     return ret;
 }
 
-int quicly_decrypt_address_token(ptls_aead_context_t *aead, const quicly_transport_parameters_t *tp,
-                                 quicly_address_token_plaintext_t *plaintext, const void *_token, size_t len, size_t prefix_len,
-                                 const char **err_desc)
+int quicly_decrypt_address_token(ptls_aead_context_t *aead, quicly_address_token_plaintext_t *plaintext, const void *_token,
+                                 size_t len, size_t prefix_len, const char **err_desc)
 {
     const uint8_t *const token = _token;
     uint8_t ptbuf[QUICLY_MIN_CLIENT_INITIAL_SIZE];
@@ -5701,20 +5661,12 @@ int quicly_decrypt_address_token(ptls_aead_context_t *aead, const quicly_transpo
     }
 
     /* `goto Exit` can only happen below this line, and that is guaranteed by declaring `ret` here */
-    ptls_iovec_t aad = ptls_iovec_init(token, prefix_len + 1 + aead->algo->iv_size);
-    ptls_buffer_t resumption_aad;
-    ptls_buffer_init(&resumption_aad, "", 0);
     int ret;
 
     /* decrypt */
-    if (plaintext->type == QUICLY_ADDRESS_TOKEN_TYPE_RESUMPTION) {
-        if ((ret = build_aad_of_address_token(&resumption_aad, tp, aad.base, aad.len)) != 0)
-            goto Exit;
-        aad = ptls_iovec_init(resumption_aad.base, resumption_aad.off);
-    }
     if ((ptlen = aead->do_decrypt(aead, ptbuf, token + prefix_len + 1 + aead->algo->iv_size,
-                                  len - (prefix_len + 1 + aead->algo->iv_size), token + prefix_len + 1, aad.base, aad.len)) ==
-        SIZE_MAX) {
+                                  len - (prefix_len + 1 + aead->algo->iv_size), token + prefix_len + 1, token,
+                                  prefix_len + 1 + aead->algo->iv_size)) == SIZE_MAX) {
         ret = PTLS_ALERT_DECRYPT_ERROR;
         *err_desc = "token decryption failure";
         goto Exit;
@@ -5788,7 +5740,6 @@ int quicly_decrypt_address_token(ptls_aead_context_t *aead, const quicly_transpo
     ret = 0;
 
 Exit:
-    ptls_buffer_dispose(&resumption_aad);
     if (ret != 0) {
         if (*err_desc == NULL)
             *err_desc = "token decode error";

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5750,6 +5750,40 @@ Exit:
     return ret;
 }
 
+int quicly_build_session_ticket_auth_data(quicly_conn_t *conn, ptls_buffer_t *auth_data)
+{
+    const quicly_transport_parameters_t *tp = &conn->super.ctx->transport_params;
+    int ret;
+
+#define PUSH_TP(id, block)                                                                                                         \
+    do {                                                                                                                           \
+        ptls_buffer_push_quicint(auth_data, id);                                                                                   \
+        ptls_buffer_push_block(auth_data, -1, block);                                                                              \
+    } while (0)
+
+    ptls_buffer_push_block(auth_data, -1, {
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_ACTIVE_CONNECTION_ID_LIMIT,
+                { ptls_buffer_push_quicint(auth_data, tp->active_connection_id_limit); });
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_DATA, { ptls_buffer_push_quicint(auth_data, tp->max_data); });
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL,
+                { ptls_buffer_push_quicint(auth_data, tp->max_stream_data.bidi_local); });
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE,
+                { ptls_buffer_push_quicint(auth_data, tp->max_stream_data.bidi_remote); });
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_UNI,
+                { ptls_buffer_push_quicint(auth_data, tp->max_stream_data.uni); });
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAMS_BIDI,
+                { ptls_buffer_push_quicint(auth_data, tp->max_streams_bidi); });
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAMS_UNI,
+                { ptls_buffer_push_quicint(auth_data, tp->max_streams_uni); });
+    });
+
+#undef PUSH_TP
+
+    ret = 0;
+Exit:
+    return ret;
+}
+
 void quicly_stream_noop_on_destroy(quicly_stream_t *stream, int err)
 {
 }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5750,9 +5750,8 @@ Exit:
     return ret;
 }
 
-int quicly_build_session_ticket_auth_data(quicly_conn_t *conn, ptls_buffer_t *auth_data)
+int quicly_build_session_ticket_auth_data(ptls_buffer_t *auth_data, quicly_context_t *ctx)
 {
-    const quicly_transport_parameters_t *tp = &conn->super.ctx->transport_params;
     int ret;
 
 #define PUSH_TP(id, block)                                                                                                         \
@@ -5763,18 +5762,19 @@ int quicly_build_session_ticket_auth_data(quicly_conn_t *conn, ptls_buffer_t *au
 
     ptls_buffer_push_block(auth_data, -1, {
         PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_ACTIVE_CONNECTION_ID_LIMIT,
-                { ptls_buffer_push_quicint(auth_data, tp->active_connection_id_limit); });
-        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_DATA, { ptls_buffer_push_quicint(auth_data, tp->max_data); });
+                { ptls_buffer_push_quicint(auth_data, ctx->transport_params.active_connection_id_limit); });
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_DATA,
+                { ptls_buffer_push_quicint(auth_data, ctx->transport_params.max_data); });
         PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL,
-                { ptls_buffer_push_quicint(auth_data, tp->max_stream_data.bidi_local); });
+                { ptls_buffer_push_quicint(auth_data, ctx->transport_params.max_stream_data.bidi_local); });
         PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE,
-                { ptls_buffer_push_quicint(auth_data, tp->max_stream_data.bidi_remote); });
+                { ptls_buffer_push_quicint(auth_data, ctx->transport_params.max_stream_data.bidi_remote); });
         PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_UNI,
-                { ptls_buffer_push_quicint(auth_data, tp->max_stream_data.uni); });
+                { ptls_buffer_push_quicint(auth_data, ctx->transport_params.max_stream_data.uni); });
         PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAMS_BIDI,
-                { ptls_buffer_push_quicint(auth_data, tp->max_streams_bidi); });
+                { ptls_buffer_push_quicint(auth_data, ctx->transport_params.max_streams_bidi); });
         PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAMS_UNI,
-                { ptls_buffer_push_quicint(auth_data, tp->max_streams_uni); });
+                { ptls_buffer_push_quicint(auth_data, ctx->transport_params.max_streams_uni); });
     });
 
 #undef PUSH_TP

--- a/src/cli.c
+++ b/src/cli.c
@@ -394,8 +394,7 @@ static quicly_closed_by_remote_t closed_by_remote = {&on_closed_by_remote};
 static int on_generate_resumption_token(quicly_generate_resumption_token_t *self, quicly_conn_t *conn, ptls_buffer_t *buf,
                                         quicly_address_token_plaintext_t *token)
 {
-    return quicly_encrypt_address_token(tlsctx.random_bytes, address_token_aead.enc, &quicly_get_context(conn)->transport_params,
-                                        buf, buf->off, token);
+    return quicly_encrypt_address_token(tlsctx.random_bytes, address_token_aead.enc, buf, buf->off, token);
 }
 
 static quicly_generate_resumption_token_t generate_resumption_token = {&on_generate_resumption_token};
@@ -773,8 +772,8 @@ static int run_server(int fd, struct sockaddr *sa, socklen_t salen)
                         quicly_address_token_plaintext_t *token = NULL, token_buf;
                         if (packet.token.len != 0) {
                             const char *err_desc = NULL;
-                            int ret = quicly_decrypt_address_token(address_token_aead.dec, &ctx.transport_params, &token_buf,
-                                                                   packet.token.base, packet.token.len, 0, &err_desc);
+                            int ret = quicly_decrypt_address_token(address_token_aead.dec, &token_buf, packet.token.base,
+                                                                   packet.token.len, 0, &err_desc);
                             if (ret == 0 && validate_token(&sa, packet.cid.src, packet.cid.dest.encrypted, &token_buf, &err_desc)) {
                                 token = &token_buf;
                             } else if (enforce_retry && (ret == QUICLY_TRANSPORT_ERROR_INVALID_TOKEN ||

--- a/t/test.c
+++ b/t/test.c
@@ -402,11 +402,11 @@ static void test_address_token_codec(void)
     input.appdata.len = strlen((char *)input.appdata.bytes);
     ptls_buffer_init(&buf, "", 0);
 
-    ok(quicly_encrypt_address_token(ptls_openssl_random_bytes, enc, NULL, &buf, 0, &input) == 0);
+    ok(quicly_encrypt_address_token(ptls_openssl_random_bytes, enc, &buf, 0, &input) == 0);
 
     /* check that the output is ok */
     ptls_openssl_random_bytes(&output, sizeof(output));
-    ok(quicly_decrypt_address_token(dec, NULL, &output, buf.base, buf.off, 0, &err_desc) == 0);
+    ok(quicly_decrypt_address_token(dec, &output, buf.base, buf.off, 0, &err_desc) == 0);
     ok(input.type == output.type);
     ok(input.issued_at == output.issued_at);
     ok(input.remote.sa.sa_family == output.remote.sa.sa_family);
@@ -422,13 +422,13 @@ static void test_address_token_codec(void)
     /* failure to decrypt a Retry token is a hard error */
     ptls_openssl_random_bytes(&output, sizeof(output));
     buf.base[buf.off - 1] ^= 0x80;
-    ok(quicly_decrypt_address_token(dec, NULL, &output, buf.base, buf.off, 0, &err_desc) == QUICLY_TRANSPORT_ERROR_INVALID_TOKEN);
+    ok(quicly_decrypt_address_token(dec, &output, buf.base, buf.off, 0, &err_desc) == QUICLY_TRANSPORT_ERROR_INVALID_TOKEN);
     buf.base[buf.off - 1] ^= 0x80;
 
     /* failure to decrypt a token that is not a Retry is a soft error */
     ptls_openssl_random_bytes(&output, sizeof(output));
     buf.base[0] ^= 0x80;
-    ok(quicly_decrypt_address_token(dec, NULL, &output, buf.base, buf.off, 0, &err_desc) == PTLS_ALERT_DECODE_ERROR);
+    ok(quicly_decrypt_address_token(dec, &output, buf.base, buf.off, 0, &err_desc) == PTLS_ALERT_DECODE_ERROR);
     buf.base[0] ^= 0x80;
 
     ptls_buffer_dispose(&buf);


### PR DESCRIPTION
As being discussed in the I-Ds, when accepting 0-RTT it is necessary to confirm that certain TPs have not changed. As the acceptance (or rejection) of 0-RTT depends on the processing of session tickets, those TPs should be associated to the session tickets.

However, as part of #350, we incorrectly started associating those TPs to NEW_TOKEN tokens.

This PR reverts that, introduces a helper function to be used by applications for proper checking.

Design considerations: QUIC uses TLS as a submodule, sometimes specifying how TLS should be used. Association of TPs to 0-RTT is one such case. From API design standpoint, we try to not hide the TLS context being used by QUIC. Rather, we try to provide helper functions for adjusting how the behavior; see `quicly_amend_ptls_context`. Following this tradition, we add a new helper function called `quicly_build_session_ticket_auth_data` which is to be used for binding TPs to session tickets. For actual usage, see https://github.com/h2o/h2o/pull/2354.