### PR TITLE
loss detection per packet number space

### DIFF
--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -119,10 +119,10 @@ typedef struct quicly_loss_t {
      */
     int64_t time_of_last_packet_sent;
     /**
-     * The largest packet number acknowledged in an ack frame (or zero if no packets have been acknowledged; note: quicly never
-     * sends PN=0).
+     * The largest packet number acknowledged in an ack frame for each epoch (or zero if no packets have been acknowledged; note:
+     * quicly never sends PN=0).
      */
-    uint64_t largest_acked_packet;
+    uint64_t largest_acked_packet[QUICLY_NUM_EPOCHS];
     /**
      * Total number of application data bytes sent when the last tail occurred, not including retransmissions.
      */
@@ -156,7 +156,7 @@ static void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
 /**
  * called when an ACK is received
  */
-static void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, int64_t now, int64_t sent_at,
+static void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, size_t epoch, int64_t now, int64_t sent_at,
                                         uint64_t ack_delay_encoded, int ack_eliciting);
 /* This function updates the loss detection timer and indicates to the caller how many packets should be sent.
  * After calling this function, app should:
@@ -164,12 +164,13 @@ static void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly
  *  * if restrict_sending is true, limit sending to min_packets_to_send, otherwise as limited by congestion/flow control
  * and then call quicly_loss_update_alarm and update the alarm
  */
-static int quicly_loss_on_alarm(quicly_loss_t *r, int64_t now, uint32_t max_ack_delay, size_t *min_packets_to_send,
-                                int *restrict_sending, quicly_loss_on_detect_cb on_loss_detected);
+static int quicly_loss_on_alarm(quicly_loss_t *r, int64_t now, uint32_t max_ack_delay, int is_1rtt_only,
+                                size_t *min_packets_to_send, int *restrict_sending, quicly_loss_on_detect_cb on_loss_detected);
 /**
  *
  */
-int quicly_loss_detect_loss(quicly_loss_t *r, int64_t now, uint32_t max_ack_delay, quicly_loss_on_detect_cb on_loss_detected);
+int quicly_loss_detect_loss(quicly_loss_t *r, int64_t now, uint32_t max_ack_delay, int is_1rtt_only,
+                            quicly_loss_on_detect_cb on_loss_detected);
 /**
  * initializes the sentmap iterator, eviting the entries considered too old.
  */
@@ -231,7 +232,7 @@ inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, u
                          .ack_delay_exponent = ack_delay_exponent,
                          .pto_count = 0,
                          .time_of_last_packet_sent = 0,
-                         .largest_acked_packet = 0,
+                         .largest_acked_packet = {0},
                          .total_bytes_sent = 0,
                          .loss_time = INT64_MAX,
                          .alarm_at = INT64_MAX};
@@ -314,7 +315,7 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
 #undef SET_ALARM
 }
 
-inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, int64_t now, int64_t sent_at,
+inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, size_t epoch, int64_t now, int64_t sent_at,
                                         uint64_t ack_delay_encoded, int ack_eliciting)
 {
     /* Reset PTO count if anything is newly acked, and if sender is not speculatively probing at a tail */
@@ -322,9 +323,9 @@ inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly
         r->pto_count = 0;
 
     /* If largest newly acked is not larger than before, skip RTT sample */
-    if (largest_newly_acked == UINT64_MAX || r->largest_acked_packet >= largest_newly_acked)
+    if (largest_newly_acked == UINT64_MAX || r->largest_acked_packet[epoch] >= largest_newly_acked)
         return;
-    r->largest_acked_packet = largest_newly_acked;
+    r->largest_acked_packet[epoch] = largest_newly_acked;
 
     /* If ack does not acknowledge any ack-eliciting packet, skip RTT sample */
     if (!ack_eliciting)
@@ -339,15 +340,15 @@ inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly
     quicly_rtt_update(&r->rtt, (uint32_t)(now - sent_at), ack_delay_millisecs);
 }
 
-inline int quicly_loss_on_alarm(quicly_loss_t *r, int64_t now, uint32_t max_ack_delay, size_t *min_packets_to_send,
-                                int *restrict_sending, quicly_loss_on_detect_cb on_loss_detected)
+inline int quicly_loss_on_alarm(quicly_loss_t *r, int64_t now, uint32_t max_ack_delay, int is_1rtt_only,
+                                size_t *min_packets_to_send, int *restrict_sending, quicly_loss_on_detect_cb on_loss_detected)
 {
     r->alarm_at = INT64_MAX;
     *min_packets_to_send = 1;
     if (r->loss_time != INT64_MAX) {
         /* Time threshold loss detection. Send at least 1 packet, but no restrictions on sending otherwise. */
         *restrict_sending = 0;
-        return quicly_loss_detect_loss(r, now, max_ack_delay, on_loss_detected);
+        return quicly_loss_detect_loss(r, now, max_ack_delay, is_1rtt_only, on_loss_detected);
     }
     /* PTO. Send at least and at most 1 packet during speculative probing and 2 packets otherwise. */
     ++r->pto_count;

--- a/lib/loss.c
+++ b/lib/loss.c
@@ -38,12 +38,12 @@ void quicly_loss_init_sentmap_iter(quicly_loss_t *loss, quicly_sentmap_iter_t *i
     }
 }
 
-int quicly_loss_detect_loss(quicly_loss_t *loss, int64_t now, uint32_t max_ack_delay, quicly_loss_on_detect_cb on_loss_detected)
+int quicly_loss_detect_loss(quicly_loss_t *loss, int64_t now, uint32_t max_ack_delay, int is_1rtt_only,
+                            quicly_loss_on_detect_cb on_loss_detected)
 {
     /* This function ensures that the value returned in loss_time is when the next application timer should be set for loss
      * detection. if no timer is required, loss_time is set to INT64_MAX. */
 
-    const uint64_t largest_acked = loss->largest_acked_packet;
     const uint32_t delay_until_lost = ((loss->rtt.latest > loss->rtt.smoothed ? loss->rtt.latest : loss->rtt.smoothed) * 9 + 7) / 8;
     quicly_sentmap_iter_t iter;
     const quicly_sent_packet_t *sent;
@@ -55,20 +55,36 @@ int quicly_loss_detect_loss(quicly_loss_t *loss, int64_t now, uint32_t max_ack_d
 
     /* Mark packets as lost if they are smaller than the largest_acked and outside either time-threshold or packet-threshold
      * windows. Once marked as lost, cc_bytes_in_flight becomes zero. */
-    while ((sent = quicly_sentmap_get(&iter))->packet_number < largest_acked &&
-           (sent->sent_at <= now - delay_until_lost ||                                      /* time threshold */
-            sent->packet_number + QUICLY_LOSS_DEFAULT_PACKET_THRESHOLD <= largest_acked)) { /* packet threshold */
-        if (sent->cc_bytes_in_flight != 0) {
-            on_loss_detected(loss, sent, sent->packet_number + QUICLY_LOSS_DEFAULT_PACKET_THRESHOLD > largest_acked);
-            if ((ret = quicly_sentmap_update(&loss->sentmap, &iter, QUICLY_SENTMAP_EVENT_LOST)) != 0)
-                return ret;
+    while (1) {
+        sent = quicly_sentmap_get(&iter);
+        uint64_t largest_acked = loss->largest_acked_packet[sent->ack_epoch];
+        if (sent->packet_number < largest_acked &&
+            (sent->sent_at <= now - delay_until_lost ||                                      /* time threshold */
+             sent->packet_number + QUICLY_LOSS_DEFAULT_PACKET_THRESHOLD <= largest_acked)) { /* packet threshold */
+            if (sent->cc_bytes_in_flight != 0) {
+                on_loss_detected(loss, sent, sent->packet_number + QUICLY_LOSS_DEFAULT_PACKET_THRESHOLD > largest_acked);
+                if ((ret = quicly_sentmap_update(&loss->sentmap, &iter, QUICLY_SENTMAP_EVENT_LOST)) != 0)
+                    return ret;
+            } else {
+                quicly_sentmap_skip(&iter);
+            }
         } else {
+            /* When only one PN space is active, it is possible to stop looking for packets that have to be considered lost and
+             * continue on to calculating the loss time. Otherwise, iterate through the entire sentmap. */
+            if (is_1rtt_only)
+                goto SetTimeThresholdAlarm;
+            if (sent->packet_number == UINT64_MAX)
+                break;
             quicly_sentmap_skip(&iter);
         }
     }
 
+    quicly_loss_init_sentmap_iter(loss, &iter, now, max_ack_delay, 0);
+    sent = quicly_sentmap_get(&iter);
+
     /* schedule time-threshold alarm if there is a packet outstanding that is smaller than largest_acked */
-    while (sent->packet_number < largest_acked && sent->sent_at != INT64_MAX) {
+SetTimeThresholdAlarm:
+    while (sent->packet_number < loss->largest_acked_packet[sent->ack_epoch] && sent->sent_at != INT64_MAX) {
         if (sent->cc_bytes_in_flight != 0) {
             assert(now < sent->sent_at + delay_until_lost);
             loss->loss_time = sent->sent_at + delay_until_lost;

--- a/t/lossy.c
+++ b/t/lossy.c
@@ -483,7 +483,7 @@ static void test_bidirectional(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 63, 553964.1, 648281.5, 1034348);
+    loss_check_stats(time_spent, 70, 612639, 678402, 1006159);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);


### PR DESCRIPTION
So far, we've used unified packet number space and a unified loss detector, rather than having loss detection logic for each packet number space.

That works mostly fine, but there is at least one exception.

When a client spends a certain amount of time (longer than RTT) to verify the certificate chain provided by the server, that client might ACK the Handshake packets, but not respond to the 1-RTT packets that the server sends.

In such case, quicly repeatedly sends probe packets, each of them containing Handshake (PING) and 1-RTT data. The client repeatedly acks the Handshake packet, but does not respond to the 1-RTT packet.

This triggers a loss event for the 1-RTT packet, when the PN of the most-recently acked Handshake packet becomes at least 3 greater than the first 1-RTT packet being sent. The negative side-effect of this loss event is that quicly exits slow start.

This PR fixes the issue by retaining largest-acked packet number for each packet number space.

__Builds on top of #366.__ For review, it is best to see the [diff against #366](https://github.com/h2o/quicly/compare/kazuho/loss-unit-tests...kazuho/slow-cert-verify).