### PR TITLE
fix issues related to loss recovery

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3869,7 +3869,8 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
     if (conn->application != NULL && (s->current.cipher = &conn->application->cipher.egress.key)->header_protection != NULL) {
         s->current.first_byte = conn->application->one_rtt_writable ? QUICLY_QUIC_BIT : QUICLY_PACKET_TYPE_0RTT;
         /* acks */
-        if (conn->application->one_rtt_writable && conn->application->super.unacked_count != 0) {
+        if (conn->application->one_rtt_writable && conn->egress.send_ack_at <= conn->stash.now &&
+            conn->application->super.unacked_count != 0) {
             if ((ret = send_ack(conn, &conn->application->super, s)) != 0)
                 goto Exit;
         }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3869,8 +3869,7 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
     if (conn->application != NULL && (s->current.cipher = &conn->application->cipher.egress.key)->header_protection != NULL) {
         s->current.first_byte = conn->application->one_rtt_writable ? QUICLY_QUIC_BIT : QUICLY_PACKET_TYPE_0RTT;
         /* acks */
-        if (conn->application->one_rtt_writable && conn->egress.send_ack_at <= conn->stash.now &&
-            conn->application->super.unacked_count != 0) {
+        if (conn->application->one_rtt_writable && conn->application->super.unacked_count != 0) {
             if ((ret = send_ack(conn, &conn->application->super, s)) != 0)
                 goto Exit;
         }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1249,7 +1249,7 @@ static int record_receipt(quicly_conn_t *conn, struct st_quicly_pn_space_t *spac
 
     if (ack_now) {
         conn->egress.send_ack_at = conn->stash.now;
-    } else if (conn->egress.send_ack_at == INT64_MAX) {
+    } else if (conn->egress.send_ack_at == INT64_MAX && space->unacked_count != 0) {
         conn->egress.send_ack_at = conn->stash.now + QUICLY_DELAYED_ACK_TIMEOUT;
     }
 

--- a/lib/sentmap.c
+++ b/lib/sentmap.c
@@ -149,7 +149,7 @@ int quicly_sentmap_update(quicly_sentmap_t *map, quicly_sentmap_iter_t *iter, qu
     }
     iter->p->data.packet.frames_in_flight = 0;
 
-    int should_notify = packet.frames_in_flight,
+    int should_notify = event == QUICLY_SENTMAP_EVENT_ACKED || packet.frames_in_flight,
         should_discard = event == QUICLY_SENTMAP_EVENT_ACKED || event == QUICLY_SENTMAP_EVENT_EXPIRED;
 
     /* Advance to next packet, while if necessary, doing either or both of the following:

--- a/t/loss.c
+++ b/t/loss.c
@@ -426,49 +426,49 @@ static void test_downstream(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 3, 20525.7, 7699, 35624);
+    loss_check_stats(time_spent, 3, 20382.7, 7583, 35624);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);
         subtest("50%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 2000, 740, 3341);
+    loss_check_stats(time_spent, 0, 1946, 710, 3134);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 4);
         subtest("25%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 231, 230, 408);
+    loss_check_stats(time_spent, 0, 223, 230, 408);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 10);
         subtest("10%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 128.6, 80, 298);
+    loss_check_stats(time_spent, 0, 123.4, 80, 249);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 20);
         subtest("5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 101.5, 80, 200);
+    loss_check_stats(time_spent, 0, 102.2, 80, 192);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 40);
         subtest("2.5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 89.5, 80, 80);
+    loss_check_stats(time_spent, 0, 88.6, 80, 80);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 64);
         subtest("1.6%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 84.9, 80, 80);
+    loss_check_stats(time_spent, 0, 89.5, 80, 80);
 }
 
 static void test_bidirectional(void)
@@ -483,7 +483,7 @@ static void test_bidirectional(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 63, 553964.1, 648281.5, 1034348);
+    loss_check_stats(time_spent, 66, 575127.1, 651311.5, 988684);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);
@@ -491,7 +491,7 @@ static void test_bidirectional(void)
         subtest("50%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 15096.9, 4371, 50974);
+    loss_check_stats(time_spent, 0, 11942, 3809, 29538);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 4);
@@ -499,7 +499,7 @@ static void test_bidirectional(void)
         subtest("25%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 365.7, 294, 673);
+    loss_check_stats(time_spent, 0, 338.4, 247, 673);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 10);
@@ -507,7 +507,7 @@ static void test_bidirectional(void)
         subtest("10%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 158, 80, 298);
+    loss_check_stats(time_spent, 0, 157.2, 80, 298);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 20);
@@ -515,7 +515,7 @@ static void test_bidirectional(void)
         subtest("5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 126.5, 80, 230);
+    loss_check_stats(time_spent, 0, 110.8, 80, 230);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 40);
@@ -523,7 +523,7 @@ static void test_bidirectional(void)
         subtest("2.5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 103.7, 80, 200);
+    loss_check_stats(time_spent, 0, 90, 80, 159);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 64);
@@ -531,7 +531,7 @@ static void test_bidirectional(void)
         subtest("1.6%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 84.5, 80, 80);
+    loss_check_stats(time_spent, 0, 91.5, 80, 80);
 }
 
 void test_loss(void)

--- a/t/sentmap.c
+++ b/t/sentmap.c
@@ -43,7 +43,7 @@ static size_t num_blocks(quicly_sentmap_t *map)
     return n;
 }
 
-void test_sentmap(void)
+static void test_basic(void)
 {
     quicly_sentmap_t map;
     uint64_t at;
@@ -99,4 +99,100 @@ void test_sentmap(void)
     ok(num_blocks(&map) == 30 / 16 + 1 + 1 + 30 / 16 + 1);
 
     quicly_sentmap_dispose(&map);
+}
+
+
+static void test_late_ack(void)
+{
+    quicly_sentmap_t map;
+    quicly_sentmap_iter_t iter;
+    const quicly_sent_packet_t *sent;
+
+    on_acked_callcnt = 0;
+    on_acked_ackcnt = 0;
+
+    quicly_sentmap_init(&map);
+
+    /* commit pn 1, 2 */
+    quicly_sentmap_prepare(&map, 1, 0, 0);
+    quicly_sentmap_allocate(&map, on_acked);
+    quicly_sentmap_commit(&map, 10);
+    quicly_sentmap_prepare(&map, 2, 0, 0);
+    quicly_sentmap_allocate(&map, on_acked);
+    quicly_sentmap_commit(&map, 20);
+    ok(map.bytes_in_flight == 30);
+
+    /* mark pn 1 as lost */
+    quicly_sentmap_init_iter(&map, &iter);
+    sent = quicly_sentmap_get(&iter);
+    assert(sent->packet_number == 1);
+    ok(quicly_sentmap_update(&map, &iter, QUICLY_SENTMAP_EVENT_LOST, NULL) == 0);
+    ok(on_acked_callcnt == 1);
+    ok(on_acked_ackcnt == 0);
+    ok(map.bytes_in_flight == 20);
+
+    /* mark pn 1, 2 as acked */
+    quicly_sentmap_init_iter(&map, &iter);
+    sent = quicly_sentmap_get(&iter);
+    assert(sent->packet_number == 1);
+    ok(quicly_sentmap_update(&map, &iter, QUICLY_SENTMAP_EVENT_ACKED, NULL) == 0);
+    sent = quicly_sentmap_get(&iter);
+    assert(sent->packet_number == 2);
+    ok(quicly_sentmap_update(&map, &iter, QUICLY_SENTMAP_EVENT_ACKED, NULL) == 0);
+    ok(on_acked_callcnt == 3);
+    ok(on_acked_ackcnt == 2);
+    ok(map.bytes_in_flight == 0);
+
+    quicly_sentmap_dispose(&map);
+}
+
+static void test_pto(void)
+{
+    quicly_sentmap_t map;
+    quicly_sentmap_iter_t iter;
+    const quicly_sent_packet_t *sent;
+
+    on_acked_callcnt = 0;
+    on_acked_ackcnt = 0;
+
+    quicly_sentmap_init(&map);
+
+    /* commit pn 1, 2 */
+    quicly_sentmap_prepare(&map, 1, 0, 0);
+    quicly_sentmap_allocate(&map, on_acked);
+    quicly_sentmap_commit(&map, 10);
+    quicly_sentmap_prepare(&map, 2, 0, 0);
+    quicly_sentmap_allocate(&map, on_acked);
+    quicly_sentmap_commit(&map, 20);
+    ok(map.bytes_in_flight == 30);
+
+    /* mark pn 1 for PTO */
+    quicly_sentmap_init_iter(&map, &iter);
+    sent = quicly_sentmap_get(&iter);
+    assert(sent->packet_number == 1);
+    ok(quicly_sentmap_update(&map, &iter, QUICLY_SENTMAP_EVENT_PTO, NULL) == 0);
+    ok(on_acked_callcnt == 1);
+    ok(on_acked_ackcnt == 0);
+    ok(map.bytes_in_flight == 30);
+
+    /* mark pn 1, 2 as acked */
+    quicly_sentmap_init_iter(&map, &iter);
+    sent = quicly_sentmap_get(&iter);
+    assert(sent->packet_number == 1);
+    ok(quicly_sentmap_update(&map, &iter, QUICLY_SENTMAP_EVENT_ACKED, NULL) == 0);
+    sent = quicly_sentmap_get(&iter);
+    assert(sent->packet_number == 2);
+    ok(quicly_sentmap_update(&map, &iter, QUICLY_SENTMAP_EVENT_ACKED, NULL) == 0);
+    ok(on_acked_callcnt == 3);
+    ok(on_acked_ackcnt == 2);
+    ok(map.bytes_in_flight == 0);
+
+    quicly_sentmap_dispose(&map);
+}
+
+void test_sentmap(void)
+{
+    subtest("basic", test_basic);
+    subtest("late-ack", test_late_ack);
+    subtest("pto", test_pto);
 }

--- a/t/simple.c
+++ b/t/simple.c
@@ -56,7 +56,7 @@ static void test_handshake(void)
     ok(ret == 0);
     ok(num_packets != 0);
 
-    /* receive ServerFinished, send ClientFinished */
+    /* receive server flight upto ServerFinished, send ClientFinished */
     num_decoded = decode_packets(decoded, packets, num_packets);
     for (i = 0; i != num_decoded; ++i) {
         ret = quicly_receive(client, NULL, &fake_address.sa, decoded + i);

--- a/t/simple.c
+++ b/t/simple.c
@@ -106,8 +106,8 @@ static void test_handshake(void)
     ok(quicly_get_state(server) == QUICLY_STATE_CONNECTED);
 
     /* both endpoints have nothing to send */
-    ok(quicly_get_first_timeout(server) >= quic_now + quic_ctx.transport_params.max_idle_timeout);
-    ok(quicly_get_first_timeout(client) >= quic_now + quic_ctx.transport_params.max_idle_timeout);
+    ok(quicly_get_first_timeout(server) == quic_now + quic_ctx.transport_params.max_idle_timeout);
+    ok(quicly_get_first_timeout(client) == quic_now + quic_ctx.transport_params.max_idle_timeout);
 }
 
 static void simple_http(void)

--- a/t/simple.c
+++ b/t/simple.c
@@ -90,8 +90,8 @@ static void test_handshake(void)
         ok(ret == 0);
     }
     ok(quicly_get_state(client) == QUICLY_STATE_CONNECTED);
-    ok(quicly_get_first_timeout(server) > quic_now + quic_ctx.transport_params.max_ack_delay);
-    quic_now = quicly_get_first_timeout(server);
+    ok(quicly_get_first_timeout(client) == quic_now + QUICLY_DELAYED_ACK_TIMEOUT);
+    quic_now = quicly_get_first_timeout(client);
     num_packets = PTLS_ELEMENTSOF(packets);
     ret = quicly_send(client, &dest, &src, packets, &num_packets, packetsbuf, sizeof(packetsbuf));
     ok(ret == 0);

--- a/t/simple.c
+++ b/t/simple.c
@@ -138,6 +138,7 @@ static void simple_http(void)
     quicly_streambuf_egress_shutdown(server_stream);
     ok(quicly_num_streams(server) == 1);
 
+    quic_now += QUICLY_DELAYED_ACK_TIMEOUT;
     transmit(server, client);
 
     ok(client_streambuf->is_detached);


### PR DESCRIPTION
Specifically:
* don't arm the delayed ack timer when receiving an ack-only packet (b8dd944)
* notify late-acks (incl. ACK after PTO) to frame-level callbacks (4cb55b3)

Tests are added to confirm the correct behaviors.