### PR TITLE
add probes points corresponding to stream-level callback invocations

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1018,6 +1018,8 @@ static void destroy_stream(quicly_stream_t *stream, int err)
 {
     quicly_conn_t *conn = stream->conn;
 
+    QUICLY_PROBE(STREAM_ON_DESTROY, conn, conn->stash.now, stream, err);
+
     if (stream->callbacks != NULL)
         stream->callbacks->on_destroy(stream, err);
 
@@ -1399,7 +1401,10 @@ static int received_key_update(quicly_conn_t *conn, uint64_t newly_decrypted_key
 
 void quicly_free(quicly_conn_t *conn)
 {
+    lock_now(conn, 0);
+
     QUICLY_PROBE(FREE, conn, conn->stash.now);
+
 #if QUICLY_USE_EMBEDDED_PROBES || QUICLY_USE_DTRACE
     if (QUICLY_CONN_STATS_ENABLED()) {
         quicly_stats_t stats;
@@ -1434,6 +1439,8 @@ void quicly_free(quicly_conn_t *conn)
 
     ptls_buffer_dispose(&conn->crypto.transport_params.buf);
     ptls_free(conn->crypto.tls);
+
+    unlock_now(conn);
 
     free(conn->token.base);
     free(conn);
@@ -1526,7 +1533,9 @@ static int apply_stream_frame(quicly_stream_t *stream, quicly_stream_frame_t *fr
 
     if (apply_len != 0 || quicly_recvstate_transfer_complete(&stream->recvstate)) {
         uint64_t buf_offset = frame->offset + frame->data.len - apply_len - stream->recvstate.data_off;
-        stream->callbacks->on_receive(stream, (size_t)buf_offset, frame->data.base + frame->data.len - apply_len, apply_len);
+        const void *apply_src = frame->data.base + frame->data.len - apply_len;
+        QUICLY_PROBE(STREAM_ON_RECEIVE, stream->conn, stream->conn->stash.now, stream, (size_t)buf_offset, apply_src, apply_len);
+        stream->callbacks->on_receive(stream, (size_t)buf_offset, apply_src, apply_len);
         if (stream->conn->super.state >= QUICLY_STATE_CLOSING)
             return QUICLY_ERROR_IS_CLOSING;
     }
@@ -2332,8 +2341,10 @@ static int on_ack_stream_ack_one(quicly_conn_t *conn, quicly_stream_id_t stream_
     size_t bytes_to_shift;
     if ((ret = quicly_sendstate_acked(&stream->sendstate, sent, is_active, &bytes_to_shift)) != 0)
         return ret;
-    if (bytes_to_shift != 0)
+    if (bytes_to_shift != 0) {
+        QUICLY_PROBE(STREAM_ON_SEND_SHIFT, stream->conn, stream->conn->stash.now, stream, bytes_to_shift);
         stream->callbacks->on_send_shift(stream, bytes_to_shift);
+    }
     if (stream_is_destroyable(stream)) {
         destroy_stream(stream, 0);
     } else if (stream->_send_aux.reset_stream.sender_state == QUICLY_SENDER_STATE_NONE) {
@@ -3171,7 +3182,9 @@ int quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t *s)
     /* write payload */
     assert(capacity != 0);
     len = capacity;
-    stream->callbacks->on_send_emit(stream, (size_t)(off - stream->sendstate.acked.ranges[0].end), s->dst, &len, &wrote_all);
+    size_t emit_off = (size_t)(off - stream->sendstate.acked.ranges[0].end);
+    QUICLY_PROBE(STREAM_ON_SEND_EMIT, stream->conn, stream->conn->stash.now, stream, emit_off, len);
+    stream->callbacks->on_send_emit(stream, emit_off, s->dst, &len, &wrote_all);
     if (stream->conn->super.state >= QUICLY_STATE_CLOSING) {
         return QUICLY_ERROR_IS_CLOSING;
     } else if (stream->_send_aux.reset_stream.sender_state != QUICLY_SENDER_STATE_NONE) {
@@ -4269,7 +4282,9 @@ static int handle_reset_stream_frame(quicly_conn_t *conn, struct st_quicly_handl
         if ((ret = quicly_recvstate_reset(&stream->recvstate, frame.final_size, &bytes_missing)) != 0)
             return ret;
         stream->conn->ingress.max_data.bytes_consumed += bytes_missing;
-        stream->callbacks->on_receive_reset(stream, QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(frame.app_error_code));
+        int err = QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(frame.app_error_code);
+        QUICLY_PROBE(STREAM_ON_RECEIVE_RESET, stream->conn, stream->conn->stash.now, stream, err);
+        stream->callbacks->on_receive_reset(stream, err);
         if (stream->conn->super.state >= QUICLY_STATE_CLOSING)
             return QUICLY_ERROR_IS_CLOSING;
         if (stream_is_destroyable(stream))
@@ -4545,6 +4560,7 @@ static int handle_stop_sending_frame(quicly_conn_t *conn, struct st_quicly_handl
         /* reset the stream, then notify the application */
         int err = QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(frame.app_error_code);
         quicly_reset_stream(stream, err);
+        QUICLY_PROBE(STREAM_ON_SEND_STOP, stream->conn, stream->conn->stash.now, stream, err);
         stream->callbacks->on_send_stop(stream, err);
         if (stream->conn->super.state >= QUICLY_STATE_CLOSING)
             return QUICLY_ERROR_IS_CLOSING;

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -114,6 +114,15 @@ provider quicly {
     probe quictrace_cc_ack(struct st_quicly_conn_t *conn, int64_t at, struct quicly_rtt_t *rtt, uint32_t cwnd, size_t inflight);
     probe quictrace_cc_lost(struct st_quicly_conn_t *conn, int64_t at, struct quicly_rtt_t *rtt, uint32_t cwnd, size_t inflight);
 
+    probe stream_on_destroy(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, int err);
+    probe stream_on_send_shift(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, size_t delta);
+    probe stream_on_send_emit(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, size_t off,
+                              size_t capacity);
+    probe stream_on_send_stop(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, int err);
+    probe stream_on_receive(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, size_t off,
+                            const void *src, size_t len);
+    probe stream_on_receive_reset(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, int err);
+
     probe debug_message(struct st_quicly_conn_t *conn, const char *function, int line, const char *message);
 
     probe conn_stats(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stats_t *stats, size_t size);


### PR DESCRIPTION
These probes help debugging applications, without requiring each application to define it's own set of probes for the callbacks.