### PR TITLE
Fix CUBIC CC behavior after quiescence periods

### DIFF
--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -102,6 +102,10 @@ typedef struct st_quicly_cc_t {
              * Timestamp of the latest congestion event.
              */
             int64_t avoidance_start;
+            /**
+             * Timestamp of the most recent send operation.
+             */
+            int64_t last_sent_time;
         } cubic;
     } state;
     /**
@@ -146,6 +150,10 @@ struct st_quicly_cc_impl_t {
      * Called when persistent congestion is observed.
      */
     void (*cc_on_persistent_congestion)(quicly_cc_t *cc, const quicly_loss_t *loss, int64_t now);
+    /**
+     * Called after a packet is sent.
+     */
+    void (*cc_on_sent)(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, int64_t now);
 };
 
 /**

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -142,7 +142,23 @@ static void cubic_on_persistent_congestion(quicly_cc_t *cc, const quicly_loss_t 
     /* TODO */
 }
 
-static const struct st_quicly_cc_impl_t cubic_impl = {CC_CUBIC, cubic_on_acked, cubic_on_lost, cubic_on_persistent_congestion};
+static void cubic_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, int64_t now)
+{
+    /* Prevent extreme cwnd growth following an idle period caused by application limit.
+     * This fixes the W_cubic/W_est calculations by effectively ignoring the idle period
+     * (see https://github.com/torvalds/linux/commit/30927520dbae297182990bb21d08762bcc35ce1d).
+     * Application limit was present if the current packet is the only one in flight. */
+    if (loss->sentmap.bytes_in_flight <= bytes && cc->state.cubic.avoidance_start != 0 && cc->state.cubic.last_sent_time != 0) {
+        int64_t delta = now - cc->state.cubic.last_sent_time;
+        if (delta > 0)
+            cc->state.cubic.avoidance_start += delta;
+    }
+
+    cc->state.cubic.last_sent_time = now;
+}
+
+static const struct st_quicly_cc_impl_t cubic_impl = {CC_CUBIC, cubic_on_acked, cubic_on_lost, cubic_on_persistent_congestion,
+                                                      cubic_on_sent};
 
 void quicly_cc_cubic_init(quicly_cc_t *cc, uint32_t initcwnd)
 {

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -145,9 +145,9 @@ static void cubic_on_persistent_congestion(quicly_cc_t *cc, const quicly_loss_t 
 static void cubic_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, int64_t now)
 {
     /* Prevent extreme cwnd growth following an idle period caused by application limit.
-     * This fixes the W_cubic/W_est calculations by effectively ignoring the idle period
-     * (see https://github.com/torvalds/linux/commit/30927520dbae297182990bb21d08762bcc35ce1d).
-     * Application limit was present if the current packet is the only one in flight. */
+     * This fixes the W_cubic/W_est calculations by effectively subtracting the idle period
+     * The sender is coming out of quiescence if the current packet is the only one in flight. 
+     * (see https://github.com/torvalds/linux/commit/30927520dbae297182990bb21d08762bcc35ce1d). */
     if (loss->sentmap.bytes_in_flight <= bytes && cc->state.cubic.avoidance_start != 0 && cc->state.cubic.last_sent_time != 0) {
         int64_t delta = now - cc->state.cubic.last_sent_time;
         if (delta > 0)

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -80,7 +80,13 @@ static void reno_on_persistent_congestion(quicly_cc_t *cc, const quicly_loss_t *
     /* TODO */
 }
 
-static const struct st_quicly_cc_impl_t reno_impl = {CC_RENO_MODIFIED, reno_on_acked, reno_on_lost, reno_on_persistent_congestion};
+static void reno_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, int64_t now)
+{
+    /* Unused */
+}
+
+static const struct st_quicly_cc_impl_t reno_impl = {CC_RENO_MODIFIED, reno_on_acked, reno_on_lost, reno_on_persistent_congestion,
+                                                     reno_on_sent};
 
 void quicly_cc_reno_init(quicly_cc_t *cc, uint32_t initcwnd)
 {

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2795,6 +2795,7 @@ static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, enu
     if (quicly_sentmap_is_open(&conn->egress.loss.sentmap))
         quicly_sentmap_commit(&conn->egress.loss.sentmap, (uint16_t)packet_bytes_in_flight);
 
+    conn->egress.cc.impl->cc_on_sent(&conn->egress.cc, &conn->egress.loss, (uint32_t)packet_bytes_in_flight, conn->stash.now);
     QUICLY_PROBE(PACKET_COMMIT, conn, conn->stash.now, conn->egress.packet_number, s->dst - s->target.first_byte_at,
                  !s->target.ack_eliciting);
     QUICLY_PROBE(QUICTRACE_SENT, conn, conn->stash.now, conn->egress.packet_number, s->dst - s->target.first_byte_at,


### PR DESCRIPTION
Following up on the initial CUBIC PR, I've implemented a fix similar to the one in the Linux kernel @janaiyengar referenced in https://github.com/h2o/quicly/pull/370#pullrequestreview-449474955.

This PR adds a new CC callback `cc_on_sent` which is called from `commit_send_packet` in quicly.c. CUBIC detects quiescence periods in there using the sentmap's `bytes_in_flight` member and saves the timestamp of `cc_on_sent`'s latest invocation to calculate the delta to add to `avoidance_start`. 

I've noticed that there's a similar `time_of_last_packet_sent` member in `quicly_loss_t`, but that value is never updated after its zero initialization. Since I'm not sure in which of the loss.h callbacks it is supposed to be updated (or if the intention was to add an additional callback), I added a separate `last_sent_time` member to `state.cubic` in `quicly_cc_t` instead of using it. I'd also be fine with updating loss.h and using that, though.