### PR TITLE
fix assertion failure when last bytes transmitted separately from FIN are retransmitted

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3301,7 +3301,6 @@ int quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t *s)
 
     /* determine if the frame incorporates FIN */
     if (!quicly_sendstate_is_open(&stream->sendstate) && end_off == stream->sendstate.final_size) {
-        assert(end_off + 1 == stream->sendstate.pending.ranges[stream->sendstate.pending.num_ranges - 1].end);
         assert(frame_type_at != NULL);
         is_fin = 1;
         *frame_type_at |= QUICLY_FRAME_TYPE_STREAM_BIT_FIN;


### PR DESCRIPTION
At the moment, there is an assertion that assumes that when the last bytes of a closed stream is (re)transmitted, FIN will be marked for transmission as well.

But that does not hold.

Consider the case where data is transmitted, then the stream gets closed, causing the FIN to get transmitted separately. When receiving nothing from the peer, the data is marked for pending and gets sent. But at that point, FIN is still considered inflight.

This PR removes the assertion.