### PR TITLE
[cli] `-C` option for specifying the CC algorithm

### DIFF
--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -149,10 +149,13 @@ struct st_quicly_cc_impl_t {
 };
 
 /**
- * Initializes the congestion controller.
+ * The factory method for the modified Reno congestion controller.
  */
-void quicly_cc_reno_init(quicly_cc_t *cc, uint32_t initcwnd);
-void quicly_cc_cubic_init(quicly_cc_t *cc, uint32_t initcwnd);
+extern struct st_quicly_init_cc_t quicly_cc_reno_init;
+/**
+ * The factory method for the modified Reno congestion controller.
+ */
+extern struct st_quicly_init_cc_t quicly_cc_cubic_init;
 
 /**
  * Calculates the initial congestion window size given the maximum UDP payload size.

--- a/include/quicly/defaults.h
+++ b/include/quicly/defaults.h
@@ -56,10 +56,8 @@ extern quicly_now_t quicly_default_now;
  *
  */
 extern quicly_crypto_engine_t quicly_default_crypto_engine;
-/**
- *
- */
-extern quicly_init_cc_t quicly_default_init_cc;
+
+#define quicly_default_init_cc quicly_cc_reno_init
 
 #ifdef __cplusplus
 }

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -144,7 +144,7 @@ static void cubic_on_persistent_congestion(quicly_cc_t *cc, const quicly_loss_t 
 
 static const struct st_quicly_cc_impl_t cubic_impl = {CC_CUBIC, cubic_on_acked, cubic_on_lost, cubic_on_persistent_congestion};
 
-static void cubic_init(quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
+static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
 {
     memset(cc, 0, sizeof(quicly_cc_t));
     cc->impl = &cubic_impl;

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -20,9 +20,9 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-
 #include <math.h>
 #include "quicly/cc.h"
+#include "quicly.h"
 
 #define QUICLY_MIN_CWND 2
 
@@ -144,10 +144,12 @@ static void cubic_on_persistent_congestion(quicly_cc_t *cc, const quicly_loss_t 
 
 static const struct st_quicly_cc_impl_t cubic_impl = {CC_CUBIC, cubic_on_acked, cubic_on_lost, cubic_on_persistent_congestion};
 
-void quicly_cc_cubic_init(quicly_cc_t *cc, uint32_t initcwnd)
+static void cubic_init(quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
 {
     memset(cc, 0, sizeof(quicly_cc_t));
     cc->impl = &cubic_impl;
     cc->cwnd = cc->cwnd_initial = cc->cwnd_maximum = initcwnd;
     cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
 }
+
+quicly_init_cc_t quicly_cc_cubic_init = {cubic_init};

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -19,8 +19,8 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-
 #include "quicly/cc.h"
+#include "quicly.h"
 
 #define QUICLY_MIN_CWND 2
 #define QUICLY_RENO_BETA 0.7
@@ -82,13 +82,15 @@ static void reno_on_persistent_congestion(quicly_cc_t *cc, const quicly_loss_t *
 
 static const struct st_quicly_cc_impl_t reno_impl = {CC_RENO_MODIFIED, reno_on_acked, reno_on_lost, reno_on_persistent_congestion};
 
-void quicly_cc_reno_init(quicly_cc_t *cc, uint32_t initcwnd)
+static void reno_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
 {
     memset(cc, 0, sizeof(quicly_cc_t));
     cc->impl = &reno_impl;
     cc->cwnd = cc->cwnd_initial = cc->cwnd_maximum = initcwnd;
     cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
 }
+
+quicly_init_cc_t quicly_cc_reno_init = {reno_init};
 
 uint32_t quicly_cc_calc_initial_cwnd(uint16_t max_udp_payload_size)
 {

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -439,10 +439,3 @@ static void default_finalize_send_packet(quicly_crypto_engine_t *engine, quicly_
 }
 
 quicly_crypto_engine_t quicly_default_crypto_engine = {default_setup_cipher, default_finalize_send_packet};
-
-static void default_init_cc(quicly_init_cc_t *init_cc, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
-{
-    quicly_cc_reno_init(cc, initcwnd);
-}
-
-quicly_init_cc_t quicly_default_init_cc = {default_init_cc};

--- a/src/cli.c
+++ b/src/cli.c
@@ -999,6 +999,8 @@ static void usage(const char *cmd)
            "  -c certificate-file\n"
            "  -k key-file               specifies the credentials to be used for running the\n"
            "                            server. If omitted, the command runs as a client.\n"
+           "  -C <algorithm>            the congestion control algorithm; either \"reno\" (default) or\n"
+           "                            \"cubic\"\n"
            "  -d draft-number           specifies the draft version number to be used (e.g., 29)\n"
            "  -e event-log-file         file to log events\n"
            "  -E                        expand Client Hello (sends multiple client Initials)\n"
@@ -1068,7 +1070,7 @@ int main(int argc, char **argv)
         address_token_aead.dec = ptls_aead_new(&ptls_openssl_aes128gcm, &ptls_openssl_sha256, 0, secret, "");
     }
 
-    while ((ch = getopt(argc, argv, "a:b:B:c:d:k:Ee:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvx:X:y:h")) != -1) {
+    while ((ch = getopt(argc, argv, "a:b:B:c:C:d:k:Ee:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvx:X:y:h")) != -1) {
         switch (ch) {
         case 'a':
             assert(negotiated_protocols.count < PTLS_ELEMENTSOF(negotiated_protocols.list));
@@ -1085,6 +1087,16 @@ int main(int argc, char **argv)
             break;
         case 'c':
             load_certificate_chain(ctx.tls, optarg);
+            break;
+        case 'C':
+            if (strcmp(optarg, "reno") == 0) {
+                ctx.init_cc = &quicly_cc_reno_init;
+            } else if (strcmp(optarg, "cubic") == 0) {
+                ctx.init_cc = &quicly_cc_cubic_init;
+            } else {
+                fprintf(stderr, "unknown congestion controller: %s\n", optarg);
+                exit(1);
+            }
             break;
         case 'G':
 #ifdef __linux__

--- a/src/cli.c
+++ b/src/cli.c
@@ -994,7 +994,7 @@ static void usage(const char *cmd)
            "  -a <alpn>                 ALPN identifier; repeat the option to set multiple\n"
            "                            candidates\n"
            "  -b <buffer-size>          specifies the size of the send / receive buffer in bytes\n"
-           "  -C <cid-key>              CID encryption key (server-only). Randomly generated\n"
+           "  -B <cid-key>              CID encryption key (server-only). Randomly generated\n"
            "                            if omitted.\n"
            "  -c certificate-file\n"
            "  -k key-file               specifies the credentials to be used for running the\n"
@@ -1068,7 +1068,7 @@ int main(int argc, char **argv)
         address_token_aead.dec = ptls_aead_new(&ptls_openssl_aes128gcm, &ptls_openssl_sha256, 0, secret, "");
     }
 
-    while ((ch = getopt(argc, argv, "a:b:C:c:d:k:Ee:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvx:X:y:h")) != -1) {
+    while ((ch = getopt(argc, argv, "a:b:B:c:d:k:Ee:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvx:X:y:h")) != -1) {
         switch (ch) {
         case 'a':
             assert(negotiated_protocols.count < PTLS_ELEMENTSOF(negotiated_protocols.list));
@@ -1080,7 +1080,7 @@ int main(int argc, char **argv)
                 exit(1);
             }
             break;
-        case 'C':
+        case 'B':
             cid_key = optarg;
             break;
         case 'c':

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -153,7 +153,7 @@ subtest "retry-invalid-token" => sub {
 };
 
 subtest "stateless-reset" => sub {
-    my $guard = spawn_server(qw(-C deadbeef));
+    my $guard = spawn_server(qw(-B deadbeef));
     my $pid = fork;
     die "fork failed:$!"
         unless defined $pid;
@@ -167,7 +167,7 @@ subtest "stateless-reset" => sub {
     # parent process, let the client fetch the first response, then kill respawn the server using same CID encryption key
     sleep 1;
     undef $guard;
-    $guard = spawn_server(qw(-C deadbeef));
+    $guard = spawn_server(qw(-B deadbeef));
     # wait for the child to die
     while (waitpid($pid, 0) != $pid) {
     }


### PR DESCRIPTION
In addition, each CC is given its own factory object.

At the moment, when an application wants to use something other than the default CC, it is required to implement its own CC factory object, and then call one of the CC init functions.

As I added `-C` option to the cli command, I started to realize that that is a pain.

Therefore, in this pull request, I've introduced factory objects for each of the CC algorithm that we provide. Applications can now choose between different CC algorithms just be choosing the object to be assigned to `quicly_context_t`.

In the future, we could consider adding properties to the factory object for controlling things like the size of the cwnd or some other algorithm-specific properties.