### PR TITLE
Apps specify versions included in VN, remove excess arguments

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -835,8 +835,8 @@ int quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t *s);
  * * @param versions  zero-terminated list of versions to advertise; use `quicly_supported_versions` for sending the list of
  *                    protocol versions supported by quicly
  */
-size_t quicly_send_version_negotiation(quicly_context_t *ctx, struct sockaddr *dest_addr, ptls_iovec_t dest_cid,
-                                       struct sockaddr *src_addr, ptls_iovec_t src_cid, const uint32_t *versions, void *payload);
+size_t quicly_send_version_negotiation(quicly_context_t *ctx, ptls_iovec_t dest_cid, ptls_iovec_t src_cid, const uint32_t *versions,
+                                       void *payload);
 /**
  *
  */
@@ -873,14 +873,12 @@ int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *s
 /**
  *
  */
-size_t quicly_send_close_invalid_token(quicly_context_t *ctx, uint32_t protocol_version, struct sockaddr *dest_addr,
-                                       ptls_iovec_t dest_cid, struct sockaddr *src_addr, ptls_iovec_t src_cid, const char *err_desc,
-                                       void *payload);
+size_t quicly_send_close_invalid_token(quicly_context_t *ctx, uint32_t protocol_version, ptls_iovec_t dest_cid,
+                                       ptls_iovec_t src_cid, const char *err_desc, void *datagram);
 /**
  *
  */
-size_t quicly_send_stateless_reset(quicly_context_t *ctx, struct sockaddr *dest_addr, struct sockaddr *src_addr,
-                                   const void *src_cid, void *payload);
+size_t quicly_send_stateless_reset(quicly_context_t *ctx, const void *src_cid, void *payload);
 /**
  *
  */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -708,6 +708,10 @@ struct st_quicly_address_token_plaintext_t {
 };
 
 /**
+ * zero-terminated list of protocol versions being supported by quicly
+ */
+extern const uint32_t quicly_supported_versions[];
+/**
  * returns a boolean indicating if given protocol version is supported
  */
 static int quicly_is_supported_version(uint32_t version);
@@ -827,10 +831,12 @@ int quicly_can_send_stream_data(quicly_conn_t *conn, quicly_send_context_t *s);
  */
 int quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t *s);
 /**
- *
+ * Builds a Version Negotiation packet. The generated packet might include a greasing version.
+ * * @param versions  zero-terminated list of versions to advertise; use `quicly_supported_versions` for sending the list of
+ *                    protocol versions supported by quicly
  */
 size_t quicly_send_version_negotiation(quicly_context_t *ctx, struct sockaddr *dest_addr, ptls_iovec_t dest_cid,
-                                       struct sockaddr *src_addr, ptls_iovec_t src_cid, void *payload);
+                                       struct sockaddr *src_addr, ptls_iovec_t src_cid, const uint32_t *versions, void *payload);
 /**
  *
  */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3540,8 +3540,8 @@ Exit:
     return ret;
 }
 
-size_t quicly_send_version_negotiation(quicly_context_t *ctx, struct sockaddr *dest_addr, ptls_iovec_t dest_cid,
-                                       struct sockaddr *src_addr, ptls_iovec_t src_cid, const uint32_t *versions, void *payload)
+size_t quicly_send_version_negotiation(quicly_context_t *ctx, ptls_iovec_t dest_cid, ptls_iovec_t src_cid, const uint32_t *versions,
+                                       void *payload)
 {
     uint8_t *dst = payload;
 
@@ -4143,9 +4143,8 @@ Exit:
     return ret;
 }
 
-size_t quicly_send_close_invalid_token(quicly_context_t *ctx, uint32_t protocol_version, struct sockaddr *dest_addr,
-                                       ptls_iovec_t dest_cid, struct sockaddr *src_addr, ptls_iovec_t src_cid, const char *err_desc,
-                                       void *datagram)
+size_t quicly_send_close_invalid_token(quicly_context_t *ctx, uint32_t protocol_version, ptls_iovec_t dest_cid,
+                                       ptls_iovec_t src_cid, const char *err_desc, void *datagram)
 {
     struct st_quicly_cipher_context_t egress = {};
     const struct st_ptls_salt_t *salt;
@@ -4193,8 +4192,7 @@ size_t quicly_send_close_invalid_token(quicly_context_t *ctx, uint32_t protocol_
     return datagram_len;
 }
 
-size_t quicly_send_stateless_reset(quicly_context_t *ctx, struct sockaddr *dest_addr, struct sockaddr *src_addr,
-                                   const void *src_cid, void *payload)
+size_t quicly_send_stateless_reset(quicly_context_t *ctx, const void *src_cid, void *payload)
 {
     uint8_t *base = payload;
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3541,7 +3541,7 @@ Exit:
 }
 
 size_t quicly_send_version_negotiation(quicly_context_t *ctx, struct sockaddr *dest_addr, ptls_iovec_t dest_cid,
-                                       struct sockaddr *src_addr, ptls_iovec_t src_cid, void *payload)
+                                       struct sockaddr *src_addr, ptls_iovec_t src_cid, const uint32_t *versions, void *payload)
 {
     uint8_t *dst = payload;
 
@@ -3563,8 +3563,14 @@ size_t quicly_send_version_negotiation(quicly_context_t *ctx, struct sockaddr *d
         dst += src_cid.len;
     }
     /* supported_versions */
-    dst = quicly_encode32(dst, QUICLY_PROTOCOL_VERSION_CURRENT);
-    dst = quicly_encode32(dst, QUICLY_PROTOCOL_VERSION_DRAFT27);
+    for (const uint32_t *v = versions; *v != 0; ++v)
+        dst = quicly_encode32(dst, *v);
+    /* add a greasing version. This also covers the case where an empty list is specified by the caller to indicate rejection. */
+    uint32_t grease_version = 0;
+    if (src_cid.len >= sizeof(grease_version))
+        memcpy(&grease_version, src_cid.base, sizeof(grease_version));
+    grease_version = (grease_version & 0xf0f0f0f0) | 0x0a0a0a0a;
+    dst = quicly_encode32(dst, grease_version);
 
     return dst - (uint8_t *)payload;
 }
@@ -5937,3 +5943,5 @@ void quicly__debug_printf(quicly_conn_t *conn, const char *function, int line, c
     QUICLY_DEBUG_MESSAGE(conn, function, line, buf);
 #endif
 }
+
+const uint32_t quicly_supported_versions[] = {QUICLY_PROTOCOL_VERSION_CURRENT, QUICLY_PROTOCOL_VERSION_DRAFT27, 0};

--- a/src/cli.c
+++ b/src/cli.c
@@ -755,8 +755,9 @@ static int run_server(int fd, struct sockaddr *sa, socklen_t salen)
                     if (QUICLY_PACKET_IS_LONG_HEADER(packet.octets.base[0])) {
                         if (!quicly_is_supported_version(packet.version)) {
                             uint8_t payload[ctx.transport_params.max_udp_payload_size];
-                            size_t payload_len = quicly_send_version_negotiation(&ctx, &remote.sa, packet.cid.src, NULL,
-                                                                                 packet.cid.dest.encrypted, payload);
+                            size_t payload_len =
+                                quicly_send_version_negotiation(&ctx, &remote.sa, packet.cid.src, NULL, packet.cid.dest.encrypted,
+                                                                quicly_supported_versions, payload);
                             assert(payload_len != SIZE_MAX);
                             send_one_packet(fd, &remote.sa, payload, payload_len);
                             break;

--- a/src/cli.c
+++ b/src/cli.c
@@ -755,9 +755,8 @@ static int run_server(int fd, struct sockaddr *sa, socklen_t salen)
                     if (QUICLY_PACKET_IS_LONG_HEADER(packet.octets.base[0])) {
                         if (!quicly_is_supported_version(packet.version)) {
                             uint8_t payload[ctx.transport_params.max_udp_payload_size];
-                            size_t payload_len =
-                                quicly_send_version_negotiation(&ctx, &remote.sa, packet.cid.src, NULL, packet.cid.dest.encrypted,
-                                                                quicly_supported_versions, payload);
+                            size_t payload_len = quicly_send_version_negotiation(&ctx, packet.cid.src, packet.cid.dest.encrypted,
+                                                                                 quicly_supported_versions, payload);
                             assert(payload_len != SIZE_MAX);
                             send_one_packet(fd, &remote.sa, payload, payload_len);
                             break;
@@ -793,9 +792,8 @@ static int run_server(int fd, struct sockaddr *sa, socklen_t salen)
                                 /* Token that looks like retry was unusable, and we require retry. There's no chance of the
                                  * handshake succeeding. Therefore, send close without aquiring state. */
                                 uint8_t payload[ctx.transport_params.max_udp_payload_size];
-                                size_t payload_len =
-                                    quicly_send_close_invalid_token(&ctx, packet.version, &remote.sa, packet.cid.src, NULL,
-                                                                    packet.cid.dest.encrypted, err_desc, payload);
+                                size_t payload_len = quicly_send_close_invalid_token(&ctx, packet.version, packet.cid.src,
+                                                                                     packet.cid.dest.encrypted, err_desc, payload);
                                 assert(payload_len != SIZE_MAX);
                                 send_one_packet(fd, &remote.sa, payload, payload_len);
                             }
@@ -833,8 +831,7 @@ static int run_server(int fd, struct sockaddr *sa, socklen_t salen)
                          * also sending a reset, then the next CID is highly likely to contain a non-authenticating CID, ... */
                         if (packet.cid.dest.plaintext.node_id == 0 && packet.cid.dest.plaintext.thread_id == 0) {
                             uint8_t payload[ctx.transport_params.max_udp_payload_size];
-                            size_t payload_len =
-                                quicly_send_stateless_reset(&ctx, &remote.sa, NULL, packet.cid.dest.encrypted.base, payload);
+                            size_t payload_len = quicly_send_stateless_reset(&ctx, packet.cid.dest.encrypted.base, payload);
                             assert(payload_len != SIZE_MAX);
                             send_one_packet(fd, &remote.sa, payload, payload_len);
                         }


### PR DESCRIPTION
This PR does two things:
* Instead of sending a fixed VN packet, allow apps to supply the versions to be sent
  * For the existing use-case, a list of supported versions is available as `quicly_supported_versions`.
  * An empty list can be specified. It is useful for sending a stateless rejection.
  * A greasing version number will always be included. This is the most trivial way to guarantee that we are advertising at least one version number. The spec allows sending zero versions, but I do not think we would want to do that.
  * We will have a test-case covering the empty-list use-case in h2o.
* Removes unnecessary arguments from stateless "send" functions (`quicly_send_version_negotiation`, `quicly_send_close_invalid_token`, `quicly_send_stateless_reset`). As of #331, these function no longer deal with the 4-tuple, but the 4-tuple were not removed from the prototype.