### PR TITLE
when running as a client, report version mismatch to the application

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -421,6 +421,7 @@ static const quicly_stream_callbacks_t crypto_stream_callbacks = {quicly_streamb
 
 static int update_traffic_key_cb(ptls_update_traffic_key_t *self, ptls_t *tls, int is_enc, size_t epoch, const void *secret);
 static int initiate_close(quicly_conn_t *conn, int err, uint64_t frame_type, const char *reason_phrase);
+static int handle_close(quicly_conn_t *conn, int err, uint64_t frame_type, ptls_iovec_t reason_phrase);
 static int discard_sentmap_by_epoch(quicly_conn_t *conn, unsigned ack_epochs);
 
 static const quicly_transport_parameters_t default_transport_params = {.max_udp_payload_size = QUICLY_DEFAULT_MAX_UDP_PAYLOAD_SIZE,
@@ -4726,7 +4727,7 @@ static int handle_version_negotiation_packet(quicly_conn_t *conn, quicly_decoded
         }
     }
     if (selected_version == 0)
-        return QUICLY_ERROR_NO_COMPATIBLE_VERSION;
+        return handle_close(conn, QUICLY_ERROR_NO_COMPATIBLE_VERSION, UINT64_MAX, ptls_iovec_init("", 0));
 
     return negotiate_using_version(conn, selected_version);
 }
@@ -4833,7 +4834,7 @@ Found_StatelessReset:
     return 1;
 }
 
-static int handle_close(quicly_conn_t *conn, int err, uint64_t frame_type, ptls_iovec_t reason_phrase)
+int handle_close(quicly_conn_t *conn, int err, uint64_t frame_type, ptls_iovec_t reason_phrase)
 {
     int ret;
 
@@ -4841,7 +4842,8 @@ static int handle_close(quicly_conn_t *conn, int err, uint64_t frame_type, ptls_
         return 0;
 
     /* switch to closing state, notify the app (at this moment the streams are accessible), then destroy the streams */
-    if ((ret = enter_close(conn, 0, err != QUICLY_ERROR_RECEIVED_STATELESS_RESET)) != 0)
+    if ((ret = enter_close(conn, 0,
+                           !(err == QUICLY_ERROR_RECEIVED_STATELESS_RESET || err == QUICLY_ERROR_NO_COMPATIBLE_VERSION))) != 0)
         return ret;
     if (conn->super.ctx->closed_by_remote != NULL)
         conn->super.ctx->closed_by_remote->cb(conn->super.ctx->closed_by_remote, conn, err, frame_type,

--- a/src/cli.c
+++ b/src/cli.c
@@ -394,6 +394,8 @@ static void on_closed_by_remote(quicly_closed_by_remote_t *self, quicly_conn_t *
                 reason);
     } else if (err == QUICLY_ERROR_RECEIVED_STATELESS_RESET) {
         fprintf(stderr, "stateless reset\n");
+    } else if (err == QUICLY_ERROR_NO_COMPATIBLE_VERSION) {
+        fprintf(stderr, "no compatible version\n");
     } else {
         fprintf(stderr, "unexpected close:code=%d\n", err);
     }

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use Digest::MD5 qw(md5_hex);
 use File::Temp qw(tempdir);
+use IO::Socket::INET;
 use JSON;
 use Net::EmptyPort qw(empty_port);
 use POSIX ":sys_wait_h";
@@ -175,6 +176,35 @@ subtest "stateless-reset" => sub {
     my $events = slurp_file("$tempdir/events");
     like $events, qr/"type":"stateless-reset-receive",/m, 'got stateless reset';
     unlike +($events =~ /"type":"stateless-reset-receive",.*?\n/ and $'), qr/"type":"packet-commit",/m, 'nothing sent after receiving stateless reset';
+};
+
+subtest "no-compatible-version" => sub {
+    # spawn a server that sends empty VN
+    my $sock = IO::Socket::INET->new(
+        LocalAddr => "127.0.0.1:$port",
+        Proto     => 'udp',
+    ) or die "failed to listen to port $port:$!";
+    # launch client
+    open my $client, "-|", "$cli -e $tempdir/events 127.0.0.1 $port 2>&1"
+        or die "failed to launch $cli:$!";
+    # server sends a VN packet in response to client's packet
+    while (1) {
+        if (my $peer = $sock->recv(my $input, 1500, 0)) {
+            my $server_cidl = ord substr $input, 5;
+            my $server_cid = substr $input, 6, $server_cidl;
+            my $client_cidl = ord substr $input, 6 + $server_cidl;
+            my $client_cid = substr $input, 7, $client_cidl;
+            $sock->send(sprintf("\x80\0\0\0\0" . '%c%s%c%s' . "\x0a\x0a\x0a\x0a", $client_cidl, $client_cid, $server_cidl, $server_cid), 0, $peer);
+            last;
+        }
+    }
+    # check the output of the client
+    my $result = do {local $/; join "", <$client>};
+    like $result, qr/no compatible version/;
+    # check the trace
+    my $events = slurp_file("$tempdir/events");
+    like $events, qr/"type":"receive",/m, "one receive event";
+    unlike +($events =~ /"type":"receive",.*?\n/ and $'), qr/"type":"packet-commit",/m, "nothing sent after receiving VN";
 };
 
 subtest "idle-timeout" => sub {

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -173,7 +173,8 @@ subtest "stateless-reset" => sub {
     }
     # check that the stateless reset is logged
     my $events = slurp_file("$tempdir/events");
-    like $events, qr/"type":"stateless-reset-receive",/m;
+    like $events, qr/"type":"stateless-reset-receive",/m, 'got stateless reset';
+    unlike +($events =~ /"type":"stateless-reset-receive",.*?\n/ and $'), qr/"type":"packet-commit",/m, 'nothing sent after receiving stateless reset';
 };
 
 subtest "idle-timeout" => sub {


### PR DESCRIPTION
Up until now, quicly running as a client has not been invoking the `closed_by_remote` callback when the connection attempt fails due to a protocol version mismatch. Instead, it had been silently sending a CONNECTION_CLOSE and discarding the connection after draining period.

This PR fixes these issues and adds a test case covering them.

The test includes an assertion that a client aborting the connection attempt to the version mismatch does not send anything, as well as adding the same check for stateless reset case.