### PR TITLE
Add API for opening peer-initiated streams before receiving a STREAM frame

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -948,11 +948,12 @@ quicly_stream_t *quicly_get_stream(quicly_conn_t *conn, quicly_stream_id_t strea
  */
 int quicly_open_stream(quicly_conn_t *conn, quicly_stream_t **stream, int unidirectional);
 /**
- * This function returns a stream that is already open. Or if the given ID refers a stream that can be opened by the peer but is
- * yet-to-be opened, the functions opens that stream and returns. Otherwise, `*stream` is set to NULL. Note that invocation of this
- * function might open not only the stream that is referred to by the `stream_id`, but other streams too. This function can be used
- * when implementing application protocols that send references to other streams on one stream (e.g., PRIORITY_UPDATE frame of
- * HTTP/3).
+ * This function returns a stream that is already open, or if the given ID refers to a stream that can be opened by the peer but is
+ * yet-to-be opened, the functions opens that stream and returns it. Otherwise, `*stream` is set to NULL.
+ * This function can be used when implementing application protocols that send references to other streams on a stream (e.g.,
+ * PRIORITY_UPDATE frame of HTTP/3), however note that the peer might complain if the endpoint sends a frame that refers to a peer-
+ * initiated stream for which the peer has not yet sent anything.
+ * Invocation of this function might open not only the stream that is referred to by the `stream_id` but also other streams.
  */
 int quicly_get_or_open_stream(quicly_conn_t *conn, uint64_t stream_id, quicly_stream_t **stream);
 /**

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -948,6 +948,14 @@ quicly_stream_t *quicly_get_stream(quicly_conn_t *conn, quicly_stream_id_t strea
  */
 int quicly_open_stream(quicly_conn_t *conn, quicly_stream_t **stream, int unidirectional);
 /**
+ * This function returns a stream that is already open. Or if the given ID refers a stream that can be opened by the peer but is
+ * yet-to-be opened, the functions opens that stream and returns. Otherwise, `*stream` is set to NULL. Note that invocation of this
+ * function might open not only the stream that is referred to by the `stream_id`, but other streams too. This function can be used
+ * when implementing application protocols that send references to other streams on one stream (e.g., PRIORITY_UPDATE frame of
+ * HTTP/3).
+ */
+int quicly_get_or_open_stream(quicly_conn_t *conn, uint64_t stream_id, quicly_stream_t **stream);
+/**
  *
  */
 void quicly_reset_stream(quicly_stream_t *stream, int err);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4296,7 +4296,7 @@ int quicly_close(quicly_conn_t *conn, int err, const char *reason_phrase)
     return ret;
 }
 
-static int get_stream_or_open_if_new(quicly_conn_t *conn, uint64_t stream_id, quicly_stream_t **stream)
+int quicly_get_or_open_stream(quicly_conn_t *conn, uint64_t stream_id, quicly_stream_t **stream)
 {
     int ret = 0;
 
@@ -4363,7 +4363,7 @@ static int handle_stream_frame(quicly_conn_t *conn, struct st_quicly_handle_payl
     if ((ret = quicly_decode_stream_frame(state->frame_type, &state->src, state->end, &frame)) != 0)
         return ret;
     QUICLY_PROBE(QUICTRACE_RECV_STREAM, conn, conn->stash.now, frame.stream_id, frame.offset, frame.data.len, (int)frame.is_fin);
-    if ((ret = get_stream_or_open_if_new(conn, frame.stream_id, &stream)) != 0 || stream == NULL)
+    if ((ret = quicly_get_or_open_stream(conn, frame.stream_id, &stream)) != 0 || stream == NULL)
         return ret;
     return apply_stream_frame(stream, &frame);
 }
@@ -4377,7 +4377,7 @@ static int handle_reset_stream_frame(quicly_conn_t *conn, struct st_quicly_handl
     if ((ret = quicly_decode_reset_stream_frame(&state->src, state->end, &frame)) != 0)
         return ret;
 
-    if ((ret = get_stream_or_open_if_new(conn, frame.stream_id, &stream)) != 0 || stream == NULL)
+    if ((ret = quicly_get_or_open_stream(conn, frame.stream_id, &stream)) != 0 || stream == NULL)
         return ret;
 
     if (!quicly_recvstate_transfer_complete(&stream->recvstate)) {
@@ -4656,7 +4656,7 @@ static int handle_stop_sending_frame(quicly_conn_t *conn, struct st_quicly_handl
     if ((ret = quicly_decode_stop_sending_frame(&state->src, state->end, &frame)) != 0)
         return ret;
 
-    if ((ret = get_stream_or_open_if_new(conn, frame.stream_id, &stream)) != 0 || stream == NULL)
+    if ((ret = quicly_get_or_open_stream(conn, frame.stream_id, &stream)) != 0 || stream == NULL)
         return ret;
 
     if (quicly_sendstate_is_open(&stream->sendstate)) {


### PR DESCRIPTION
Some application protocols might have a way of specifying a stream from another stream before the specified stream is being opened. One prominent case of such case being the PRIORITY_UPDATE frame of the Extensible Priorities.

When receiving information referring to a stream for which the transport does not have state, an application is assumed to check if the reference is valid (i.e. that the peer is permitted to open the referred stream, and that the referred stream is not yet been closed). Then, the application either caches the information for use in the future (if the reference is valid), or sends an error to the client (if the reference is invalid).

The problem of such design is that it is complex.

The alternative is to add an API to quicly that opens the referred stream, exactly the same way as it does when receiving a STREAM frame that refers to that stream for the first time. PRIORITY_UPDATE frame is just another way of "opening" a stream, after all.

As the latter is simpler, we adopt that approach.