### PR TITLE
Send (STREAM_)DATA_BLOCKED frames, as well as recording how many

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -390,6 +390,12 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t sent;                                                                                                             \
     } num_bytes;                                                                                                                   \
+    struct {                                                                                                                       \
+        uint64_t padding, ping, ack, reset_stream, stop_sending, crypto, new_token, stream, max_data, max_stream_data,             \
+            max_streams_bidi, max_streams_uni, data_blocked, stream_data_blocked, streams_blocked, new_connection_id,              \
+            retire_connection_id, path_challenge, path_response, transport_close, application_close, handshake_done,               \
+            ack_frequency;                                                                                                         \
+    } num_frames_sent, num_frames_received;                                                                                        \
     /**                                                                                                                            \
      * Total number of PTOs during the connections.                                                                                \
      */                                                                                                                            \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -602,6 +602,10 @@ struct st_quicly_stream_t {
          */
         quicly_maxsender_t max_stream_data_sender;
         /**
+         * send state of STREAM_DATA_BLOCKED frames corresponding to the current max_stream_data value
+         */
+        quicly_sender_state_t blocked;
+        /**
          * linklist of pending streams
          */
         struct {
@@ -827,10 +831,17 @@ uint64_t quicly_get_next_expected_packet_number(quicly_conn_t *conn);
  */
 int quicly_is_flow_capped(quicly_conn_t *conn);
 /**
+ * Returns if stream data can be sent.
+ * When the connection is blocked by the connection-level flow control (see `quicly_is_flow_capped`), `at_stream_level` should be
+ * set to false to see if any retransmissions are to be done. Otherwise, `at_steram_level` should be set to true to test the stream-
+ * level flow control.
+ */
+int quicly_stream_can_send(quicly_stream_t *stream, int at_stream_level);
+/**
  * checks if quicly_send_stream can be invoked
  * @return a boolean indicating if quicly_send_stream can be called immediately
  */
-int quicly_can_send_stream_data(quicly_conn_t *conn, quicly_send_context_t *s);
+int quicly_can_send_data(quicly_conn_t *conn, quicly_send_context_t *s);
 /**
  * Sends data of given stream.  Called by stream scheduler.  Only streams that can send some data or EOS should be specified.  It is
  * the responsibilty of the stream scheduler to maintain a list of such streams.

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -827,9 +827,9 @@ int64_t quicly_get_first_timeout(quicly_conn_t *conn);
  */
 uint64_t quicly_get_next_expected_packet_number(quicly_conn_t *conn);
 /**
- * returns if the connection is currently capped by connection-level flow control.
+ * returns if the connection is currently blocked by connection-level flow control.
  */
-int quicly_is_flow_capped(quicly_conn_t *conn);
+int quicly_is_blocked(quicly_conn_t *conn);
 /**
  * Returns if stream data can be sent.
  * When the connection is blocked by the connection-level flow control (see `quicly_is_flow_capped`), `at_stream_level` should be

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -69,6 +69,7 @@ extern "C" {
 #define QUICLY_MAX_STREAMS_FRAME_CAPACITY (1 + 8)
 #define QUICLY_PING_FRAME_CAPACITY 1
 #define QUICLY_RST_FRAME_CAPACITY (1 + 8 + 8 + 8)
+#define QUICLY_DATA_BLOCKED_FRAME_CAPACITY (1 + 8)
 #define QUICLY_STREAMS_BLOCKED_FRAME_CAPACITY (1 + 8)
 #define QUICLY_STOP_SENDING_FRAME_CAPACITY (1 + 8 + 8)
 #define QUICLY_ACK_MAX_GAPS 256
@@ -171,6 +172,8 @@ typedef struct st_quicly_path_challenge_frame_t {
 } quicly_path_challenge_frame_t;
 
 static int quicly_decode_path_challenge_frame(const uint8_t **src, const uint8_t *end, quicly_path_challenge_frame_t *frame);
+
+static uint8_t *quicly_encode_data_blocked_frame(uint8_t *dst, uint64_t offset);
 
 typedef struct st_quicly_data_blocked_frame_t {
     uint64_t offset;
@@ -552,6 +555,13 @@ inline int quicly_decode_path_challenge_frame(const uint8_t **src, const uint8_t
     return 0;
 Error:
     return QUICLY_TRANSPORT_ERROR_FRAME_ENCODING;
+}
+
+inline uint8_t *quicly_encode_data_blocked_frame(uint8_t *dst, uint64_t offset)
+{
+    *dst++ = QUICLY_FRAME_TYPE_DATA_BLOCKED;
+    dst = quicly_encodev(dst, offset);
+    return dst;
 }
 
 inline int quicly_decode_data_blocked_frame(const uint8_t **src, const uint8_t *end, quicly_data_blocked_frame_t *frame)

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -70,6 +70,7 @@ extern "C" {
 #define QUICLY_PING_FRAME_CAPACITY 1
 #define QUICLY_RST_FRAME_CAPACITY (1 + 8 + 8 + 8)
 #define QUICLY_DATA_BLOCKED_FRAME_CAPACITY (1 + 8)
+#define QUICLY_STREAM_DATA_BLOCKED_FRAME_CAPACITY (1 + 8 + 8)
 #define QUICLY_STREAMS_BLOCKED_FRAME_CAPACITY (1 + 8)
 #define QUICLY_STOP_SENDING_FRAME_CAPACITY (1 + 8 + 8)
 #define QUICLY_ACK_MAX_GAPS 256
@@ -180,6 +181,8 @@ typedef struct st_quicly_data_blocked_frame_t {
 } quicly_data_blocked_frame_t;
 
 static int quicly_decode_data_blocked_frame(const uint8_t **src, const uint8_t *end, quicly_data_blocked_frame_t *frame);
+
+static uint8_t *quicly_encode_stream_data_blocked_frame(uint8_t *dst, quicly_stream_id_t stream_id, uint64_t offset);
 
 typedef struct st_quicly_stream_data_blocked_frame_t {
     quicly_stream_id_t stream_id;
@@ -569,6 +572,14 @@ inline int quicly_decode_data_blocked_frame(const uint8_t **src, const uint8_t *
     if ((frame->offset = quicly_decodev(src, end)) == UINT64_MAX)
         return QUICLY_TRANSPORT_ERROR_FRAME_ENCODING;
     return 0;
+}
+
+inline uint8_t *quicly_encode_stream_data_blocked_frame(uint8_t *dst, quicly_stream_id_t stream_id, uint64_t offset)
+{
+    *dst++ = QUICLY_FRAME_TYPE_STREAM_DATA_BLOCKED;
+    dst = quicly_encodev(dst, stream_id);
+    dst = quicly_encodev(dst, offset);
+    return dst;
 }
 
 inline int quicly_decode_stream_data_blocked_frame(const uint8_t **src, const uint8_t *end,

--- a/include/quicly/sendstate.h
+++ b/include/quicly/sendstate.h
@@ -59,12 +59,6 @@ void quicly_sendstate_init_closed(quicly_sendstate_t *state);
 void quicly_sendstate_dispose(quicly_sendstate_t *state);
 static int quicly_sendstate_transfer_complete(quicly_sendstate_t *state);
 static int quicly_sendstate_is_open(quicly_sendstate_t *state);
-/**
- * Returns if some data or EOS can be sent for the stream.  When `max_stream_data` is non-NULL, stream-level flow control is tested.
- * When `max_stream_data` is NULL, retruns if something can be sent when the connection is capped by the connection-level flow
- * control.
- */
-int quicly_sendstate_can_send(quicly_sendstate_t *state, const uint64_t *max_stream_data);
 int quicly_sendstate_activate(quicly_sendstate_t *state);
 int quicly_sendstate_shutdown(quicly_sendstate_t *state, uint64_t final_size);
 void quicly_sendstate_reset(quicly_sendstate_t *state);

--- a/include/quicly/sentmap.h
+++ b/include/quicly/sentmap.h
@@ -117,6 +117,10 @@ struct st_quicly_sent_t {
             uint64_t offset;
         } data_blocked;
         struct {
+            quicly_stream_id_t stream_id;
+            uint64_t offset;
+        } stream_data_blocked;
+        struct {
             int uni;
             quicly_maxsender_sent_t args;
         } streams_blocked;

--- a/include/quicly/sentmap.h
+++ b/include/quicly/sentmap.h
@@ -114,6 +114,9 @@ struct st_quicly_sent_t {
             quicly_maxsender_sent_t args;
         } max_streams;
         struct {
+            uint64_t offset;
+        } data_blocked;
+        struct {
             int uni;
             quicly_maxsender_sent_t args;
         } streams_blocked;

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -273,11 +273,11 @@ static int default_stream_scheduler_can_send(quicly_stream_scheduler_t *self, qu
     return quicly_linklist_is_linked(&sched->active);
 }
 
-static void link_stream(struct st_quicly_default_scheduler_state_t *sched, quicly_stream_t *stream, int conn_is_flow_capped)
+static void link_stream(struct st_quicly_default_scheduler_state_t *sched, quicly_stream_t *stream, int conn_is_blocked)
 {
     if (!quicly_linklist_is_linked(&stream->_send_aux.pending_link.default_scheduler)) {
         quicly_linklist_t *slot = &sched->active;
-        if (conn_is_flow_capped && !quicly_stream_can_send(stream, 0))
+        if (conn_is_blocked && !quicly_stream_can_send(stream, 0))
             slot = &sched->blocked;
         quicly_linklist_insert(slot->prev, &stream->_send_aux.pending_link.default_scheduler);
     }
@@ -289,9 +289,9 @@ static void link_stream(struct st_quicly_default_scheduler_state_t *sched, quicl
 static int default_stream_scheduler_do_send(quicly_stream_scheduler_t *self, quicly_conn_t *conn, quicly_send_context_t *s)
 {
     struct st_quicly_default_scheduler_state_t *sched = &((struct _st_quicly_conn_public_t *)conn)->_default_scheduler;
-    int conn_is_flow_capped = quicly_is_flow_capped(conn), ret = 0;
+    int conn_is_blocked = quicly_is_blocked(conn), ret = 0;
 
-    if (!conn_is_flow_capped)
+    if (!conn_is_blocked)
         quicly_linklist_insert_list(&sched->active, &sched->blocked);
 
     while (quicly_can_send_data((quicly_conn_t *)conn, s) && quicly_linklist_is_linked(&sched->active)) {
@@ -300,7 +300,7 @@ static int default_stream_scheduler_do_send(quicly_stream_scheduler_t *self, qui
             (void *)((char *)sched->active.next - offsetof(quicly_stream_t, _send_aux.pending_link.default_scheduler));
         quicly_linklist_unlink(&stream->_send_aux.pending_link.default_scheduler);
         /* relink the stream to the blocked list if necessary */
-        if (conn_is_flow_capped && !quicly_stream_can_send(stream, 0)) {
+        if (conn_is_blocked && !quicly_stream_can_send(stream, 0)) {
             quicly_linklist_insert(sched->blocked.prev, &stream->_send_aux.pending_link.default_scheduler);
             continue;
         }
@@ -310,14 +310,14 @@ static int default_stream_scheduler_do_send(quicly_stream_scheduler_t *self, qui
              * adjustments to the scheduler after popping a stream */
             if (ret == QUICLY_ERROR_SENDBUF_FULL) {
                 assert(quicly_stream_can_send(stream, 1));
-                link_stream(sched, stream, conn_is_flow_capped);
+                link_stream(sched, stream, conn_is_blocked);
             }
             break;
         }
         /* reschedule */
-        conn_is_flow_capped = quicly_is_flow_capped(conn);
+        conn_is_blocked = quicly_is_blocked(conn);
         if (quicly_stream_can_send(stream, 1))
-            link_stream(sched, stream, conn_is_flow_capped);
+            link_stream(sched, stream, conn_is_blocked);
     }
 
     return ret;
@@ -332,7 +332,7 @@ static int default_stream_scheduler_update_state(quicly_stream_scheduler_t *self
 
     if (quicly_stream_can_send(stream, 1)) {
         /* activate if not */
-        link_stream(sched, stream, quicly_is_flow_capped(stream->conn));
+        link_stream(sched, stream, quicly_is_blocked(stream->conn));
     } else {
         /* disactivate if active */
         if (quicly_linklist_is_linked(&stream->_send_aux.pending_link.default_scheduler))

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3258,8 +3258,8 @@ static int send_stream_control_frames(quicly_conn_t *conn, quicly_send_context_t
     int ret = 0;
 
     while (s->num_datagrams != s->max_datagrams && quicly_linklist_is_linked(&conn->egress.pending_streams.control)) {
-        quicly_stream_t *stream = (void *)((char *)conn->egress.pending_streams.control.next -
-                                           offsetof(quicly_stream_t, _send_aux.pending_link.control));
+        quicly_stream_t *stream =
+            (void *)((char *)conn->egress.pending_streams.control.next - offsetof(quicly_stream_t, _send_aux.pending_link.control));
         if ((ret = send_control_frames_of_stream(stream, s)) != 0)
             goto Exit;
         quicly_linklist_unlink(&stream->_send_aux.pending_link.control);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3268,7 +3268,7 @@ Exit:
     return ret;
 }
 
-int quicly_is_flow_capped(quicly_conn_t *conn)
+int quicly_is_blocked(quicly_conn_t *conn)
 {
     if (conn->egress.max_data.sent < conn->egress.max_data.permitted)
         return 0;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3247,6 +3247,7 @@ static int send_control_frames_of_stream(quicly_stream_t *stream, quicly_send_co
         s->dst = quicly_encode_stream_data_blocked_frame(s->dst, stream->stream_id, offset);
         stream->_send_aux.blocked = QUICLY_SENDER_STATE_UNACKED;
         ++stream->conn->super.stats.num_frames_sent.stream_data_blocked;
+        QUICLY_PROBE(STREAM_DATA_BLOCKED_SEND, stream->conn, stream->conn->stash.now, stream->stream_id, offset);
     }
 
     return 0;
@@ -3640,6 +3641,7 @@ static int send_data_blocked(quicly_conn_t *conn, quicly_send_context_t *s)
     conn->egress.data_blocked = QUICLY_SENDER_STATE_UNACKED;
 
     ++conn->super.stats.num_frames_sent.data_blocked;
+    QUICLY_PROBE(DATA_BLOCKED_SEND, conn, conn->stash.now, offset);
 
     ret = 0;
 Exit:

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5192,7 +5192,7 @@ static int handle_payload(quicly_conn_t *conn, size_t epoch, const uint8_t *_src
         handle_##n##_frame,                                                                                                        \
         (i << QUICLY_EPOCH_INITIAL) | (z << QUICLY_EPOCH_0RTT) | (h << QUICLY_EPOCH_HANDSHAKE) | (o << QUICLY_EPOCH_1RTT),         \
         ae,                                                                                                                        \
-        offsetof(quicly_conn_t, super.stats.num_frames_received.n) \
+        offsetof(quicly_conn_t, super.stats.num_frames_received.n)                                                                 \
     }
         /*   +----------------------+-------------------+---------------+
          *   |                      |  permitted epochs |               |

--- a/lib/sendstate.c
+++ b/lib/sendstate.c
@@ -49,24 +49,6 @@ void quicly_sendstate_dispose(quicly_sendstate_t *state)
     state->size_inflight = 0;
 }
 
-int quicly_sendstate_can_send(quicly_sendstate_t *state, const uint64_t *max_stream_data)
-{
-    if (state->pending.num_ranges != 0) {
-        /* the flow is capped either by MAX_STREAM_DATA or (in case we are hitting connection-level flow control) by the number of
-         * bytes we've already sent */
-        uint64_t blocked_at = max_stream_data != NULL ? *max_stream_data : state->size_inflight;
-        if (state->pending.ranges[0].start < blocked_at)
-            return 1;
-        /* we can always send EOS, if that is the only thing to be sent */
-        if (state->pending.ranges[0].start >= state->final_size) {
-            assert(state->pending.ranges[0].start == state->final_size);
-            return 1;
-        }
-    }
-
-    return 0;
-}
-
 int quicly_sendstate_activate(quicly_sendstate_t *state)
 {
     uint64_t end_off = state->final_size;

--- a/misc/probe2trace.pl
+++ b/misc/probe2trace.pl
@@ -118,23 +118,22 @@ for my $probe (@probes) {
                 push @ap, map{"arg${i}->$_"} qw(minimum smoothed latest);
             }
         } elsif ($type eq 'struct st_quicly_stats_t *') {
-            push @fmt, map {qq("rtt_$_":\%u)} qw(minimum smoothed latest);
-            push @fmt, map {qq("cc_$_":\%u)} qw(impl->type cwnd ssthresh cwnd_initial cwnd_exiting_slow_start cwnd_minimum cwnd_maximum num_loss_episodes);
-            push @fmt, map {qq("num_packets_$_":\%llu)} qw(sent ack_received lost lost_time_threshold late_acked received decryption_failed);
-            push @fmt, map {qq("num_bytes_$_":\%llu)} qw(sent received);
-            push @fmt, qq("num_ptos":\%u);
+            # build an array of [field-names => type-specifiers]
+            my @fields;
+            push @fields, map {["rtt.$_" => '%u']} qw(minimum smoothed variance);
+            push @fields, map {["cc.$_" => '%u']} qw(impl->type cwnd ssthresh cwnd_initial cwnd_exiting_slow_start cwnd_minimum cwnd_maximum num_loss_episodes);
+            push @fields, map {["num_packets.$_" => '%llu']} qw(sent ack_received lost lost_time_threshold late_acked received decryption_failed);
+            push @fields, map {["num_bytes.$_" => '%llu']} qw(sent received);
+                for my $container (qw(num_frames_sent num_frames_received)) {
+                    push @fields, map{["$container.$_" => '%llu']} qw(padding ping ack reset_stream stop_sending crypto new_token stream max_data max_stream_data max_streams_bidi max_streams_uni data_blocked stream_data_blocked streams_blocked new_connection_id retire_connection_id path_challenge path_response transport_close application_close handshake_done ack_frequency);
+                }
+            push @fields, ["num_ptos" => '%u'];
+            # generate @fmt, @ap
+            push @fmt, map {my $n = $_->[0]; $n =~ tr/./_/; sprintf '"%s":%s', $n, $_->[1]} @fields;
             if ($arch eq 'linux') {
-                push @ap, map{"((struct st_quicly_stats_t *)arg$i)->rtt.$_"} qw(minimum smoothed variance);
-                push @ap, map{"((struct st_quicly_stats_t *)arg$i)->cc.$_"} qw(impl->type cwnd ssthresh cwnd_initial cwnd_exiting_slow_start cwnd_minimum cwnd_maximum num_loss_episodes);
-                push @ap, map{"((struct st_quicly_stats_t *)arg$i)->num_packets.$_"} qw(sent ack_received lost lost_time_threshold late_acked received decryption_failed);
-                push @ap, map{"((struct st_quicly_stats_t *)arg$i)->num_bytes.$_"} qw(sent received);
-                push @ap, "((struct st_quicly_stats_t *)arg$i)->num_ptos";
+                push @ap, map{"((struct st_quicly_stats_t *)arg$i)->" . $_->[0]} @fields;
             } else {
-                push @ap, map{"arg${i}->rtt.$_"} qw(minimum smoothed variance);
-                push @ap, map{"arg${i}->cc.$_"} qw(impl->type cwnd ssthresh cwnd_initial cwnd_exiting_slow_start cwnd_minimum cwnd_maximum num_loss_episodes);
-                push @ap, map{"(unsigned long long)arg${i}->num_packets.$_"} qw(sent ack_received lost lost_time_threshold late_acked received decryption_failed);
-                push @ap, map{"(unsigned long long)arg${i}->num_bytes.$_"} qw(sent received);
-                push @ap, "arg${i}->num_ptos";
+                push @ap, map{"arg${i}->" . $_->[0]} @fields;
             }
         } else {
             $name = 'time'

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -96,8 +96,10 @@ provider quicly {
     probe retire_connection_id_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t sequence);
     probe retire_connection_id_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t sequence);
 
+    probe data_blocked_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t off);
     probe data_blocked_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t off);
 
+    probe stream_data_blocked_send(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t limit);
     probe stream_data_blocked_receive(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t limit);
 
     probe ack_frequency_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t sequence, uint64_t packet_tolerance,


### PR DESCRIPTION
The primary motivation behind this PR is to have a viewpoint on when and how frequently a QUIC endpoint is blocked by flow control.

The approach adopted by this PR is to start sending DATA_BLOCKED and STREAM_DATA_BLOCKED frames, as well as recording the number of those frames being sent. The latter would provide us the necessary information.

Specifically, the following changes are introduced:

* wire-level:
  * send DATA_BLOCKED
  * send STREAM_DATA_BLOCKED
* stats-level:
  * record the number of each frames being sent (not just the BLOCKED frames, but all the frame types)
  * record the number of each frames being received (ditto)
* API-level:
  * changes the API used by the stream scheduler:
    * `quicly_sendstate_can_send` is now `quicly_stream_can_send`. This change is necessary to initiate the emission of a `STREAM_DATA_BLOCKED` frame when the stream is blocked by the stream-level flow control.
    * To avoid confusion with the rename right above, `quicly_can_send_stream_data` is renamed as `quicly_can_send_data`.
    * Separately, `quicly_is_flow_capped` is renamed as `quicly_is_blocked`. This function indicates if the connection is blocked by the connection-level flow control. Now, we consistently used "blocked" as the term, instead of occasionally using "flow-capped."