### PR TITLE
make sure that an ack-eliciting packet is sent when a loss is detected

### DIFF
--- a/t/lossy.c
+++ b/t/lossy.c
@@ -426,7 +426,7 @@ static void test_downstream(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 2, 16545, 4188, 23030);
+    loss_check_stats(time_spent, 3, 19927, 4188, 23030);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);
@@ -483,7 +483,7 @@ static void test_bidirectional(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 23, 242967, 91619, 645628);
+    loss_check_stats(time_spent, 27, 271754, 113887, 688726);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);
@@ -523,7 +523,7 @@ static void test_bidirectional(void)
         subtest("2.5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 90.9, 80, 80);
+    loss_check_stats(time_spent, 0, 90.9, 80, 170);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 64);


### PR DESCRIPTION
Up until now, we have been enforcing this for the PTO timeout, but not for time-based loss detection.

This is necessary to avoid PTO timer left in the past (that leads to the consistency assertion failure), when the PTO period is smaller than loss detection period and if the need to retransmit the contents of the lost packet has evaporated (due to e.g., the stream being reset).