### PR TITLE
Make sure that an ack-eliciting packet is sent when PTO timer fires

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2721,7 +2721,9 @@ static inline uint64_t calc_amplification_limit_allowance(quicly_conn_t *conn)
     uint64_t budget = conn->super.stats.num_bytes.received * conn->super.ctx->pre_validation_amplification_limit;
     if (budget <= conn->super.stats.num_bytes.sent)
         return 0;
-    return budget - conn->super.stats.num_bytes.sent;
+    uint64_t window = budget - conn->super.stats.num_bytes.sent;
+
+    return window >= MIN_SEND_WINDOW ? window : 0;
 }
 
 /* Helper function to compute send window based on:

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3025,6 +3025,9 @@ static int _do_allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, siz
         /* adjust send_window to either 0 byte or MIN*2 bytes, if it is between those two */
         if (s->send_window < MIN_SEND_WINDOW * 2)
             s->send_window = s->send_window < MIN_SEND_WINDOW ? 0 : MIN_SEND_WINDOW * 2;
+        /* appropriate byte counting is applied only if the first frame for a datagram is ack-eliciting; we are too lazy to adjust
+         * things when a packet is turned into ack-eliciting after an ACK frame is written into the packet image. This diversion is
+         * considered acceptable as only the first packet being built would start with a non-ack-eliciting frame (i.e. ACK). */
         if (ack_eliciting && s->send_window < (ssize_t)min_space)
             return QUICLY_ERROR_SENDBUF_FULL;
         if (s->payload_buf.end - s->payload_buf.datagram < conn->egress.max_udp_payload_size)


### PR DESCRIPTION
Currently, when the amplification limit allowance is below 64 bytes (the value of MIN_SEND_WINDOW), the following happens:
* PTO timeout is armed. This is because  `calc_amplification_limit_allowance` invoked by `quicly_get_first_timeout` does not take MIN_SEND_WINDOW into account.
* When PTO timer fires, an ACK-eliciting packet is not sent. This is because `calc_send_window` determines that the size of the send window is less than 64 bytes and therefore only emits ACKs.

Commit 38a15a3 of this PR addresses the problem, by adding the same rounding logic to `calc_amplification_limit_allowance`. The other commits are refactors / editorial improvements.