### PR TITLE
Preliminary work to produce QLog compliant traces

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2933,10 +2933,8 @@ static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, enu
         quicly_sentmap_commit(&conn->egress.loss.sentmap, (uint16_t)packet_bytes_in_flight);
 
     conn->egress.cc.impl->cc_on_sent(&conn->egress.cc, &conn->egress.loss, (uint32_t)packet_bytes_in_flight, conn->stash.now);
-    QUICLY_PROBE(PACKET_COMMIT, conn, conn->stash.now, conn->egress.packet_number, s->dst - s->target.first_byte_at,
-                 !s->target.ack_eliciting);
-    QUICLY_PROBE(QUICTRACE_SENT, conn, conn->stash.now, conn->egress.packet_number, s->dst - s->target.first_byte_at,
-                 get_epoch(*s->target.first_byte_at));
+    QUICLY_PROBE(PACKET_SENT, conn, conn->stash.now, conn->egress.packet_number, s->dst - s->target.first_byte_at,
+                 get_epoch(*s->target.first_byte_at), !s->target.ack_eliciting);
 
     ++conn->egress.packet_number;
     ++conn->super.stats.num_packets.sent;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5392,8 +5392,7 @@ int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *
 
     QUICLY_PROBE(ACCEPT, *conn, (*conn)->stash.now,
                  QUICLY_PROBE_HEXDUMP(packet->cid.dest.encrypted.base, packet->cid.dest.encrypted.len), address_token);
-    QUICLY_PROBE(CRYPTO_DECRYPT, *conn, (*conn)->stash.now, pn, payload.base, payload.len);
-    QUICLY_PROBE(QUICTRACE_RECV, *conn, (*conn)->stash.now, pn);
+    QUICLY_PROBE(PACKET_RECEIVED, *conn, (*conn)->stash.now, pn, payload.base, payload.len);
 
     /* handle the input; we ignore is_ack_only, we consult if there's any output from TLS in response to CH anyways */
     (*conn)->super.stats.num_packets.received += 1;
@@ -5586,12 +5585,11 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     if ((ret = decrypt_packet(header_protection, aead.cb, aead.ctx, &(*space)->next_expected_packet_number, packet, &pn,
                               &payload)) != 0) {
         ++conn->super.stats.num_packets.decryption_failed;
-        QUICLY_PROBE(CRYPTO_DECRYPT, conn, conn->stash.now, pn, NULL, 0);
+        QUICLY_PROBE(CRYPTO_DECRYPT_FAILURE, conn, conn->stash.now, pn);
         goto Exit;
     }
 
-    QUICLY_PROBE(CRYPTO_DECRYPT, conn, conn->stash.now, pn, payload.base, payload.len);
-    QUICLY_PROBE(QUICTRACE_RECV, conn, conn->stash.now, pn);
+    QUICLY_PROBE(PACKET_RECEIVED, conn, conn->stash.now, pn, payload.base, payload.len);
 
     /* update states */
     if (conn->super.state == QUICLY_STATE_FIRSTFLIGHT)

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5583,7 +5583,7 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     if ((ret = decrypt_packet(header_protection, aead.cb, aead.ctx, &(*space)->next_expected_packet_number, packet, &pn,
                               &payload)) != 0) {
         ++conn->super.stats.num_packets.decryption_failed;
-        QUICLY_PROBE(CRYPTO_DECRYPT_FAILURE, conn, conn->stash.now, pn);
+        QUICLY_PROBE(PACKET_DROPPED, conn, conn->stash.now, pn);
         goto Exit;
     }
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5583,7 +5583,7 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     if ((ret = decrypt_packet(header_protection, aead.cb, aead.ctx, &(*space)->next_expected_packet_number, packet, &pn,
                               &payload)) != 0) {
         ++conn->super.stats.num_packets.decryption_failed;
-        QUICLY_PROBE(PACKET_DROPPED, conn, conn->stash.now, "payload_decrypt_error", pn);
+        QUICLY_PROBE(PACKET_DECRYPTION_FAILURE, conn, conn->stash.now, pn);
         goto Exit;
     }
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5390,7 +5390,7 @@ int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *
 
     QUICLY_PROBE(ACCEPT, *conn, (*conn)->stash.now,
                  QUICLY_PROBE_HEXDUMP(packet->cid.dest.encrypted.base, packet->cid.dest.encrypted.len), address_token);
-    QUICLY_PROBE(PACKET_RECEIVED, *conn, (*conn)->stash.now, pn, payload.base, payload.len);
+    QUICLY_PROBE(PACKET_RECEIVED, *conn, (*conn)->stash.now, pn, payload.base, payload.len, get_epoch(packet->octets.base[0]));
 
     /* handle the input; we ignore is_ack_only, we consult if there's any output from TLS in response to CH anyways */
     (*conn)->super.stats.num_packets.received += 1;
@@ -5587,7 +5587,7 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
         goto Exit;
     }
 
-    QUICLY_PROBE(PACKET_RECEIVED, conn, conn->stash.now, pn, payload.base, payload.len);
+    QUICLY_PROBE(PACKET_RECEIVED, conn, conn->stash.now, pn, payload.base, payload.len, get_epoch(packet->octets.base[0]));
 
     /* update states */
     if (conn->super.state == QUICLY_STATE_FIRSTFLIGHT)

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5583,7 +5583,7 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     if ((ret = decrypt_packet(header_protection, aead.cb, aead.ctx, &(*space)->next_expected_packet_number, packet, &pn,
                               &payload)) != 0) {
         ++conn->super.stats.num_packets.decryption_failed;
-        QUICLY_PROBE(PACKET_DROPPED, conn, conn->stash.now, pn);
+        QUICLY_PROBE(PACKET_DROPPED, conn, conn->stash.now, "payload_decrypt_error", pn);
         goto Exit;
     }
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5583,7 +5583,7 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     if ((ret = decrypt_packet(header_protection, aead.cb, aead.ctx, &(*space)->next_expected_packet_number, packet, &pn,
                               &payload)) != 0) {
         ++conn->super.stats.num_packets.decryption_failed;
-        QUICLY_PROBE(PACKET_DECRYPTION_FAILURE, conn, conn->stash.now, pn);
+        QUICLY_PROBE(PACKET_DECRYPTION_FAILED, conn, conn->stash.now, pn);
         goto Exit;
     }
 

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2020 Fastly, Toru Maesaka
 #
@@ -29,7 +29,7 @@ def handle_packet_received(events, idx):
     frames = []
     for i in range(idx+1, len(events)):
         ev = events[i]
-        if ev["type"] == "packet-prepare" or QLOG_EVENT_HANDLERS.has_key(ev["type"]):
+        if ev["type"] == "packet-prepare" or ev["type"] in QLOG_EVENT_HANDLERS:
             break
         handler = FRAME_EVENT_HANDLERS.get(ev["type"])
         if handler:

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -87,6 +87,17 @@ def handle_max_data_send(event):
         "maximum": event["limit"]
     }
 
+def handle_max_streams_send(event):
+    if event["is-unidirectional"]:
+        stream_type = "unidirectional"
+    else:
+        stream_type = "bidirectional"
+    return {
+        "frame_type": "max_streams",
+        "stream_type": stream_type,
+        "maximum": event["limit"]
+    }
+
 def handle_max_stream_data_receive(event):
     return {
         "frame_type": "max_stream_data",
@@ -185,6 +196,7 @@ FRAME_EVENT_HANDLERS = {
     "handshake-done-send": handle_handshake_done_send,
     "max-data-receive": handle_max_data_receive,
     "max-data-send": handle_max_data_send,
+    "max-streams-send": handle_max_streams_send,
     "max-stream-data-receive": handle_max_stream_data_receive,
     "max-stream-data-send": handle_max_stream_data_send,
     "new-connection-id-receive": handle_new_connection_id_receive,

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -65,6 +65,16 @@ def handle_ack_send(event):
         "frame_type": "ack",
     }
 
+def handle_data_blocked_receive(event):
+    return {
+        "frame_type": "data_blocked"
+    }
+
+def handle_data_blocked_send(event):
+    return {
+        "frame_type": "data_blocked"
+    }
+
 def handle_handshake_done_receive(event):
     return {
         "frame_type": "handshake_done",
@@ -214,6 +224,8 @@ QLOG_EVENT_HANDLERS = {
 
 FRAME_EVENT_HANDLERS = {
     "ack-send": handle_ack_send,
+    "data-blocked-receive": handle_data_blocked_receive,
+    "data-blocked-send": handle_data_blocked_send,
     "handshake-done-receive": handle_handshake_done_receive,
     "handshake-done-send": handle_handshake_done_send,
     "max-data-receive": handle_max_data_receive,

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -164,6 +164,18 @@ def handle_quictrace_recv_ack(event):
         "frame_type": "ack",
     }
 
+def handle_retire_connection_id_receive(event):
+    return {
+        "frame_type": "retire_connection_id",
+        "sequence_number": event["sequence"]
+    }
+
+def handle_retire_connection_id_send(event):
+    return {
+        "frame_type": "retire_connection_id",
+        "sequence_number": event["sequence"]
+    }
+
 def handle_streams_blocked_receive(event):
     if event["is-unidirectional"]:
       stream_type = unidirectional
@@ -253,6 +265,8 @@ FRAME_EVENT_HANDLERS = {
     "new-token-send": handle_new_token_send,
     "ping-receive": handle_ping_receive,
     "quictrace-recv-ack": handle_quictrace_recv_ack,
+    "retire-connection-id-receive": handle_retire_connection_id_receive,
+    "retire-connection-id-send": handle_retire_connection_id_send,
     "streams-blocked-receive": handle_streams_blocked_receive,
     "streams-blocked-send": handle_streams_blocked_send,
     "stream-data-blocked-receive": handle_stream_data_blocked_receive,

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2020 Fastly, Toru Maesaka
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import sys
+import json
+
+PACKET_LABELS = ["initial", "0rtt", "handshake", "1rtt"]
+
+def handle_packet_received(events, idx):
+    source_event = events[idx]
+    qlog_event_data = {
+        "packet_type": PACKET_LABELS[source_event["packet-type"]],
+        "header": {
+            "packet_number": source_event["pn"]
+        },
+        "frames": []
+    }
+    return [source_event["time"], "transport", "packet_received", qlog_event_data]
+
+def handle_packet_sent(events, idx):
+    source_event = events[idx]
+    qlog_event_data = {
+        "packet_type": PACKET_LABELS[source_event["packet-type"]],
+        "header": {
+            "packet_number": source_event["pn"]
+        },
+        "frames": []
+    }
+    return [source_event["time"], "transport", "packet_sent", qlog_event_data]
+
+QLOG_EVENT_HANDLERS = {
+    "packet-received": handle_packet_received,
+    "packet-sent": handle_packet_sent
+}
+
+def usage():
+    print(r"""
+Usage:
+    python qlog-adapter.py inTrace.jsonl
+""".strip())
+
+def load_quicly_events(infile):
+    events = []
+    with open(infile, "r") as fh:
+        for line in fh:
+            events.append(json.loads(line))
+    return events
+
+def main():
+    if len(sys.argv) != 2:
+        usage()
+        sys.exit(1)
+
+    (_, infile) = sys.argv
+    source_events = load_quicly_events(infile)
+    trace = {
+        "vantage_point": {
+            "type": "server"
+        },
+        "event_fields": [
+           "time",
+           "category",
+           "event",
+           "data"
+        ],
+        "events": []
+    }
+    for i, event in enumerate(source_events):
+        handler = QLOG_EVENT_HANDLERS.get(event["type"])
+        if handler:
+            trace["events"].append(handler(source_events, i))
+
+    print(json.dumps({
+        "qlog_version": "draft-02-wip",
+        "title": "h2o/quicly qlog",
+        "traces": [trace]
+    }))
+
+if __name__ == "__main__":
+    main()

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -102,6 +102,22 @@ def handle_stream_receive(event):
         "offset": event["off"]
     }
 
+def handle_transport_close_receive(event):
+    return {
+        "frame_type": "connection_close",
+        "offending_frame_type": event["frame-type"],
+        "error_code": event["error-code"],
+        "reason": event["reason-phrase"]
+    }
+
+def handle_transport_close_send(event):
+    return {
+        "frame_type": "connection_close",
+        "offending_frame_type": event["frame-type"],
+        "error_code": event["error-code"],
+        "reason": event["reason-phrase"]
+    }
+
 QLOG_EVENT_HANDLERS = {
     "packet-received": handle_packet_received,
     "packet-sent": handle_packet_sent
@@ -114,6 +130,8 @@ FRAME_EVENT_HANDLERS = {
     "ping-receive": handle_ping_receive,
     "quictrace-recv-ack": handle_quictrace_recv_ack,
     "stream-receive": handle_stream_receive,
+    "transport-close-receive": handle_transport_close_receive,
+    "transport-close-send": handle_transport_close_send
 }
 
 def usage():

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -176,6 +176,33 @@ def handle_retire_connection_id_send(event):
         "sequence_number": event["sequence"]
     }
 
+def handle_stream_data_blocked_receive(event):
+    return {
+        "frame_type": "stream_data_blocked",
+        "stream_id": event["stream-id"],
+        "limit": event["limit"]
+    }
+
+def handle_stream_data_blocked_send(event):
+    return {
+        "frame_type": "stream_data_blocked",
+        "stream_id": event["stream-id"],
+        "limit": event["limit"]
+    }
+
+def handle_stream_on_receive_reset(event):
+    return {
+        "frame_type": "reset_stream",
+        "stream_id": event["stream-id"],
+        "error_code": event["err"]
+    }
+
+def handle_stream_on_send_stop(event):
+    return {
+        "frame_type": "stop_sending",
+        "stream_id": event["stream-id"]
+    }
+
 def handle_streams_blocked_receive(event):
     if event["is-unidirectional"]:
       stream_type = unidirectional
@@ -196,26 +223,6 @@ def handle_streams_blocked_send(event):
         "frame_type": "streams_blocked",
         "stream_type": stream_type,
         "limit": event["limit"]
-    }
-
-def handle_stream_data_blocked_receive(event):
-    return {
-        "frame_type": "stream_data_blocked",
-        "stream_id": event["stream-id"],
-        "limit": event["limit"]
-    }
-
-def handle_stream_data_blocked_send(event):
-    return {
-        "frame_type": "stream_data_blocked",
-        "stream_id": event["stream-id"],
-        "limit": event["limit"]
-    }
-
-def handle_stream_on_send_stop(event):
-    return {
-        "frame_type": "stop_sending",
-        "stream_id": event["stream-id"]
     }
 
 def handle_stream_receive(event):
@@ -267,10 +274,11 @@ FRAME_EVENT_HANDLERS = {
     "quictrace-recv-ack": handle_quictrace_recv_ack,
     "retire-connection-id-receive": handle_retire_connection_id_receive,
     "retire-connection-id-send": handle_retire_connection_id_send,
-    "streams-blocked-receive": handle_streams_blocked_receive,
-    "streams-blocked-send": handle_streams_blocked_send,
     "stream-data-blocked-receive": handle_stream_data_blocked_receive,
     "stream-data-blocked-send": handle_stream_data_blocked_send,
+    "stream-on-receive-reset": handle_stream_on_receive_reset,
+    "streams-blocked-receive": handle_streams_blocked_receive,
+    "streams-blocked-send": handle_streams_blocked_send,
     "stream-on-send-stop": handle_stream_on_send_stop,
     "stream-receive": handle_stream_receive,
     "transport-close-receive": handle_transport_close_receive,

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -107,14 +107,20 @@ def handle_new_token_send(event):
         "generation": event["generation"]
     }
 
+def handle_ping_receive(event):
+    return {
+        "frame_type": "ping",
+    }
+
 def handle_quictrace_recv_ack(event):
     return {
         "frame_type": "ack",
     }
 
-def handle_ping_receive(event):
+def handle_stream_on_send_stop(event):
     return {
-        "frame_type": "ping",
+        "frame_type": "stop_sending",
+        "stream_id": event["stream-id"]
     }
 
 def handle_stream_receive(event):
@@ -157,6 +163,7 @@ FRAME_EVENT_HANDLERS = {
     "new-token-send": handle_new_token_send,
     "ping-receive": handle_ping_receive,
     "quictrace-recv-ack": handle_quictrace_recv_ack,
+    "stream-on-send-stop": handle_stream_on_send_stop,
     "stream-receive": handle_stream_receive,
     "transport-close-receive": handle_transport_close_receive,
     "transport-close-send": handle_transport_close_send

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -76,7 +76,7 @@ def handle_ping_receive(event):
     }
 
 def handle_stream_receive(event):
-    label = "stream" if event["stream-id"] > 0 else "crypto"
+    label = "stream" if event["stream-id"] >= 0 else "crypto"
     return {
         "frame_type": label,
         "stream_id": event["stream-id"],

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -154,6 +154,28 @@ def handle_quictrace_recv_ack(event):
         "frame_type": "ack",
     }
 
+def handle_streams_blocked_receive(event):
+    if event["is-unidirectional"]:
+      stream_type = unidirectional
+    else:
+      stream_type = bidirectional
+    return {
+        "frame_type": "streams_blocked",
+        "stream_type": stream_type,
+        "limit": event["limit"]
+    }
+
+def handle_streams_blocked_send(event):
+    if event["is-unidirectional"]:
+      stream_type = unidirectional
+    else:
+      stream_type = bidirectional
+    return {
+        "frame_type": "streams_blocked",
+        "stream_type": stream_type,
+        "limit": event["limit"]
+    }
+
 def handle_stream_on_send_stop(event):
     return {
         "frame_type": "stop_sending",
@@ -205,6 +227,8 @@ FRAME_EVENT_HANDLERS = {
     "new-token-send": handle_new_token_send,
     "ping-receive": handle_ping_receive,
     "quictrace-recv-ack": handle_quictrace_recv_ack,
+    "streams-blocked-receive": handle_streams_blocked_receive,
+    "streams-blocked-send": handle_streams_blocked_send,
     "stream-on-send-stop": handle_stream_on_send_stop,
     "stream-receive": handle_stream_receive,
     "transport-close-receive": handle_transport_close_receive,

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -223,9 +223,9 @@ def handle_stream_on_send_stop(event):
 
 def handle_streams_blocked_receive(event):
     if event["is-unidirectional"]:
-      stream_type = unidirectional
+      stream_type = "unidirectional"
     else:
-      stream_type = bidirectional
+      stream_type = "bidirectional"
     return {
         "frame_type": "streams_blocked",
         "stream_type": stream_type,
@@ -234,9 +234,9 @@ def handle_streams_blocked_receive(event):
 
 def handle_streams_blocked_send(event):
     if event["is-unidirectional"]:
-      stream_type = unidirectional
+      stream_type = "unidirectional"
     else:
-      stream_type = bidirectional
+      stream_type = "bidirectional"
     return {
         "frame_type": "streams_blocked",
         "stream_type": stream_type,

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -75,10 +75,11 @@ def handle_ping_receive(event):
         "frame_type": "ping",
     }
 
-
-def handle_recv_crypto_frame(event):
+def handle_stream_receive(event):
+    label = "stream" if event["stream-id"] > 0 else "crypto"
     return {
-        "frame_type": "crypto",
+        "frame_type": label,
+        "stream_id": event["stream-id"],
         "length": event["len"],
         "offset": event["off"]
     }
@@ -92,7 +93,7 @@ FRAME_EVENT_HANDLERS = {
     "ack-send": handle_ack_send,
     "ping-receive": handle_ping_receive,
     "quictrace-recv-ack": handle_quictrace_recv_ack,
-    "recv-crypto-frame": handle_recv_crypto_frame,
+    "stream-receive": handle_stream_receive,
 }
 
 def usage():

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -65,6 +65,24 @@ def handle_ack_send(event):
         "frame_type": "ack",
     }
 
+def handle_new_connection_id_receive(event):
+    return {
+        "frame_type": "new_connection_id",
+        "sequence_number": event["sequence"],
+        "retire_prior_to": event["retire-prior-to"],
+        "connection_id": event["cid"],
+        "stateless_reset_token": event["stateless-reset-token"]
+    }
+
+def handle_new_connection_id_send(event):
+    return {
+        "frame_type": "new_connection_id",
+        "sequence_number": event["sequence"],
+        "retire_prior_to": event["retire-prior-to"],
+        "connection_id": event["cid"],
+        "stateless_reset_token": event["stateless-reset-token"]
+    }
+
 def handle_quictrace_recv_ack(event):
     return {
         "frame_type": "ack",
@@ -91,6 +109,8 @@ QLOG_EVENT_HANDLERS = {
 
 FRAME_EVENT_HANDLERS = {
     "ack-send": handle_ack_send,
+    "new-connection-id-receive": handle_new_connection_id_receive,
+    "new-connection-id-send": handle_new_connection_id_send,
     "ping-receive": handle_ping_receive,
     "quictrace-recv-ack": handle_quictrace_recv_ack,
     "stream-receive": handle_stream_receive,

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -65,6 +65,16 @@ def handle_ack_send(event):
         "frame_type": "ack",
     }
 
+def handle_handshake_done_receive(event):
+    return {
+        "frame_type": "handshake_done",
+    }
+
+def handle_handshake_done_send(event):
+    return {
+        "frame_type": "handshake_done",
+    }
+
 def handle_new_connection_id_receive(event):
     return {
         "frame_type": "new_connection_id",
@@ -139,6 +149,8 @@ QLOG_EVENT_HANDLERS = {
 
 FRAME_EVENT_HANDLERS = {
     "ack-send": handle_ack_send,
+    "handshake-done-receive": handle_handshake_done_receive,
+    "handshake-done-send": handle_handshake_done_send,
     "new-connection-id-receive": handle_new_connection_id_receive,
     "new-connection-id-send": handle_new_connection_id_send,
     "new-token-receive": handle_new_token_receive,

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -186,6 +186,20 @@ def handle_streams_blocked_send(event):
         "limit": event["limit"]
     }
 
+def handle_stream_data_blocked_receive(event):
+    return {
+        "frame_type": "stream_data_blocked",
+        "stream_id": event["stream-id"],
+        "limit": event["limit"]
+    }
+
+def handle_stream_data_blocked_send(event):
+    return {
+        "frame_type": "stream_data_blocked",
+        "stream_id": event["stream-id"],
+        "limit": event["limit"]
+    }
+
 def handle_stream_on_send_stop(event):
     return {
         "frame_type": "stop_sending",
@@ -241,6 +255,8 @@ FRAME_EVENT_HANDLERS = {
     "quictrace-recv-ack": handle_quictrace_recv_ack,
     "streams-blocked-receive": handle_streams_blocked_receive,
     "streams-blocked-send": handle_streams_blocked_send,
+    "stream-data-blocked-receive": handle_stream_data_blocked_receive,
+    "stream-data-blocked-send": handle_stream_data_blocked_send,
     "stream-on-send-stop": handle_stream_on_send_stop,
     "stream-receive": handle_stream_receive,
     "transport-close-receive": handle_transport_close_receive,

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -75,6 +75,32 @@ def handle_handshake_done_send(event):
         "frame_type": "handshake_done",
     }
 
+def handle_max_data_receive(event):
+    return {
+        "frame_type": "max_data",
+        "maximum": event["limit"]
+    }
+
+def handle_max_data_send(event):
+    return {
+        "frame_type": "max_data",
+        "maximum": event["limit"]
+    }
+
+def handle_max_stream_data_receive(event):
+    return {
+        "frame_type": "max_stream_data",
+        "stream_id": event["stream-id"],
+        "maximum": event["limit"]
+    }
+
+def handle_max_stream_data_send(event):
+    return {
+        "frame_type": "max_stream_data",
+        "stream_id": event["stream-id"],
+        "maximum": event["limit"]
+    }
+
 def handle_new_connection_id_receive(event):
     return {
         "frame_type": "new_connection_id",
@@ -157,6 +183,10 @@ FRAME_EVENT_HANDLERS = {
     "ack-send": handle_ack_send,
     "handshake-done-receive": handle_handshake_done_receive,
     "handshake-done-send": handle_handshake_done_send,
+    "max-data-receive": handle_max_data_receive,
+    "max-data-send": handle_max_data_send,
+    "max-stream-data-receive": handle_max_stream_data_receive,
+    "max-stream-data-send": handle_max_stream_data_send,
     "new-connection-id-receive": handle_new_connection_id_receive,
     "new-connection-id-send": handle_new_connection_id_send,
     "new-token-receive": handle_new_token_receive,

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -83,6 +83,20 @@ def handle_new_connection_id_send(event):
         "stateless_reset_token": event["stateless-reset-token"]
     }
 
+def handle_new_token_receive(event):
+    return {
+        "frame_type": "new_token",
+        "token": event["token"],
+        "generation": event["generation"]
+    }
+
+def handle_new_token_send(event):
+    return {
+        "frame_type": "new_token",
+        "token": event["token"],
+        "generation": event["generation"]
+    }
+
 def handle_quictrace_recv_ack(event):
     return {
         "frame_type": "ack",
@@ -127,6 +141,8 @@ FRAME_EVENT_HANDLERS = {
     "ack-send": handle_ack_send,
     "new-connection-id-receive": handle_new_connection_id_receive,
     "new-connection-id-send": handle_new_connection_id_send,
+    "new-token-receive": handle_new_token_receive,
+    "new-token-send": handle_new_token_send,
     "ping-receive": handle_ping_receive,
     "quictrace-recv-ack": handle_quictrace_recv_ack,
     "stream-receive": handle_stream_receive,

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -197,6 +197,24 @@ def handle_stream_on_receive_reset(event):
         "error_code": event["err"]
     }
 
+def handle_stream_receive(event):
+    label = "stream" if event["stream-id"] >= 0 else "crypto"
+    return {
+        "frame_type": label,
+        "stream_id": event["stream-id"],
+        "length": event["len"],
+        "offset": event["off"]
+    }
+
+def handle_stream_send(event):
+    label = "stream" if event["stream-id"] >= 0 else "crypto"
+    return {
+        "frame_type": label,
+        "stream_id": event["stream-id"],
+        "length": event["len"],
+        "offset": event["off"]
+    }
+
 def handle_stream_on_send_stop(event):
     return {
         "frame_type": "stop_sending",
@@ -223,15 +241,6 @@ def handle_streams_blocked_send(event):
         "frame_type": "streams_blocked",
         "stream_type": stream_type,
         "limit": event["limit"]
-    }
-
-def handle_stream_receive(event):
-    label = "stream" if event["stream-id"] >= 0 else "crypto"
-    return {
-        "frame_type": label,
-        "stream_id": event["stream-id"],
-        "length": event["len"],
-        "offset": event["off"]
     }
 
 def handle_transport_close_receive(event):
@@ -277,6 +286,7 @@ FRAME_EVENT_HANDLERS = {
     "stream-data-blocked-receive": handle_stream_data_blocked_receive,
     "stream-data-blocked-send": handle_stream_data_blocked_send,
     "stream-on-receive-reset": handle_stream_on_receive_reset,
+    "stream-send": handle_stream_send,
     "streams-blocked-receive": handle_streams_blocked_receive,
     "streams-blocked-send": handle_streams_blocked_send,
     "stream-on-send-stop": handle_stream_on_send_stop,

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -26,24 +26,22 @@ import json
 PACKET_LABELS = ["initial", "0rtt", "handshake", "1rtt"]
 
 def handle_packet_received(events, idx):
-    source_event = events[idx]
-    qlog_event_data = {
-        "packet_type": PACKET_LABELS[source_event["packet-type"]],
-        "header": {
-            "packet_number": source_event["pn"]
-        },
-        "frames": []
-    }
-
+    frames = []
     for i in range(idx+1, len(events)):
         ev = events[i]
         if ev["type"] == "packet-prepare" or QLOG_EVENT_HANDLERS.has_key(ev["type"]):
             break
         handler = FRAME_EVENT_HANDLERS.get(ev["type"])
         if handler:
-            qlog_event_data["frames"].append(handler(ev))
+            frames.append(handler(ev))
 
-    return [source_event["time"], "transport", "packet_received", qlog_event_data]
+    return [events[idx]["time"], "transport", "packet_received", {
+        "packet_type": PACKET_LABELS[events[idx]["packet-type"]],
+        "header": {
+            "packet_number": events[idx]["pn"]
+        },
+        "frames": frames
+    }]
 
 def handle_packet_sent(events, idx):
     source_event = events[idx]

--- a/parselog.py
+++ b/parselog.py
@@ -18,7 +18,7 @@ def gen_trace(f, cid, sent_trace, ack_trace):
         if event["type"] == "" or event["conn"] != cid: continue
 
         # sent packet
-        if event["type"] == "packet-commit":
+        if event["type"] == "packet-sent":
             if conn_start == 0: conn_start = event["time"]
             outstr = str(event["time"] - conn_start) + " " + \
                 str(event["pn"]) + " " + \

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -35,7 +35,6 @@ provider quicly {
     probe idle_timeout(struct st_quicly_conn_t *conn, int64_t at);
     probe stateless_reset_receive(struct st_quicly_conn_t *conn, int64_t at);
 
-    probe crypto_decrypt_failure(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
     probe crypto_handshake(struct st_quicly_conn_t *conn, int64_t at, int ret);
     probe crypto_update_secret(struct st_quicly_conn_t *conn, int64_t at, int is_enc, uint8_t epoch, const char *label, const char *secret);
     probe crypto_send_key_update(struct st_quicly_conn_t *conn, int64_t at, uint64_t phase, const char *secret);
@@ -48,6 +47,7 @@ provider quicly {
     probe packet_prepare(struct st_quicly_conn_t *conn, int64_t at, uint8_t first_octet, const char *dcid);
     probe packet_acked(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, int is_late_ack);
     probe packet_lost(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
+    probe packet_dropped(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
 
     probe pto(struct st_quicly_conn_t *conn, int64_t at, size_t inflight, uint32_t cwnd, int8_t pto_count);
     probe cc_ack_received(struct st_quicly_conn_t *conn, int64_t at, uint64_t largest_acked, size_t bytes_acked, uint32_t cwnd,

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -44,7 +44,6 @@ provider quicly {
     probe crypto_receive_key_update_prepare(struct st_quicly_conn_t *conn, int64_t at, uint64_t phase, const char *secret);
 
     probe packet_prepare(struct st_quicly_conn_t *conn, int64_t at, uint8_t first_octet, const char *dcid);
-    probe packet_commit(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, size_t len, int ack_only);
     probe packet_acked(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, int is_late_ack);
     probe packet_lost(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
 
@@ -105,7 +104,7 @@ provider quicly {
     probe ack_frequency_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t sequence, uint64_t packet_tolerance,
                                 uint64_t max_ack_delay, int ignore_order);
 
-    probe quictrace_sent(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, size_t len, uint8_t packet_type);
+    probe packet_sent(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, size_t len, uint8_t packet_type, int ack_only);
     probe packet_received(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, const void *decrypted, size_t decrypted_len);
     probe quictrace_send_stream(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off,
                                 size_t len, int fin);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -47,7 +47,7 @@ provider quicly {
     probe packet_prepare(struct st_quicly_conn_t *conn, int64_t at, uint8_t first_octet, const char *dcid);
     probe packet_acked(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, int is_late_ack);
     probe packet_lost(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
-    probe packet_dropped(struct st_quicly_conn_t *conn, int64_t at, const char *reason_phrase, uint64_t pn);
+    probe packet_decryption_failure(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
 
     probe pto(struct st_quicly_conn_t *conn, int64_t at, size_t inflight, uint32_t cwnd, int8_t pto_count);
     probe cc_ack_received(struct st_quicly_conn_t *conn, int64_t at, uint64_t largest_acked, size_t bytes_acked, uint32_t cwnd,

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -43,6 +43,8 @@ provider quicly {
     probe crypto_receive_key_update(struct st_quicly_conn_t *conn, int64_t at, uint64_t phase, const char *secret);
     probe crypto_receive_key_update_prepare(struct st_quicly_conn_t *conn, int64_t at, uint64_t phase, const char *secret);
 
+    probe packet_sent(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, size_t len, uint8_t packet_type, int ack_only);
+    probe packet_received(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, const void *decrypted, size_t decrypted_len);
     probe packet_prepare(struct st_quicly_conn_t *conn, int64_t at, uint8_t first_octet, const char *dcid);
     probe packet_acked(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, int is_late_ack);
     probe packet_lost(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
@@ -104,8 +106,6 @@ provider quicly {
     probe ack_frequency_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t sequence, uint64_t packet_tolerance,
                                 uint64_t max_ack_delay, int ignore_order);
 
-    probe packet_sent(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, size_t len, uint8_t packet_type, int ack_only);
-    probe packet_received(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, const void *decrypted, size_t decrypted_len);
     probe quictrace_send_stream(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off,
                                 size_t len, int fin);
     probe quictrace_recv_stream(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t off, size_t len, int fin);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -47,7 +47,7 @@ provider quicly {
     probe packet_prepare(struct st_quicly_conn_t *conn, int64_t at, uint8_t first_octet, const char *dcid);
     probe packet_acked(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, int is_late_ack);
     probe packet_lost(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
-    probe packet_dropped(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
+    probe packet_dropped(struct st_quicly_conn_t *conn, int64_t at, const char *reason_phrase, uint64_t pn);
 
     probe pto(struct st_quicly_conn_t *conn, int64_t at, size_t inflight, uint32_t cwnd, int8_t pto_count);
     probe cc_ack_received(struct st_quicly_conn_t *conn, int64_t at, uint64_t largest_acked, size_t bytes_acked, uint32_t cwnd,

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -44,7 +44,7 @@ provider quicly {
     probe crypto_receive_key_update_prepare(struct st_quicly_conn_t *conn, int64_t at, uint64_t phase, const char *secret);
 
     probe packet_sent(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, size_t len, uint8_t packet_type, int ack_only);
-    probe packet_received(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, const void *decrypted, size_t decrypted_len);
+    probe packet_received(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, const void *decrypted, size_t decrypted_len, uint8_t packet_type);
     probe packet_prepare(struct st_quicly_conn_t *conn, int64_t at, uint8_t first_octet, const char *dcid);
     probe packet_acked(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, int is_late_ack);
     probe packet_lost(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -35,7 +35,7 @@ provider quicly {
     probe idle_timeout(struct st_quicly_conn_t *conn, int64_t at);
     probe stateless_reset_receive(struct st_quicly_conn_t *conn, int64_t at);
 
-    probe crypto_decrypt(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, const void *decrypted, size_t decrypted_len);
+    probe crypto_decrypt_failure(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
     probe crypto_handshake(struct st_quicly_conn_t *conn, int64_t at, int ret);
     probe crypto_update_secret(struct st_quicly_conn_t *conn, int64_t at, int is_enc, uint8_t epoch, const char *label, const char *secret);
     probe crypto_send_key_update(struct st_quicly_conn_t *conn, int64_t at, uint64_t phase, const char *secret);
@@ -106,7 +106,7 @@ provider quicly {
                                 uint64_t max_ack_delay, int ignore_order);
 
     probe quictrace_sent(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, size_t len, uint8_t packet_type);
-    probe quictrace_recv(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
+    probe packet_received(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, const void *decrypted, size_t decrypted_len);
     probe quictrace_send_stream(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off,
                                 size_t len, int fin);
     probe quictrace_recv_stream(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t off, size_t len, int fin);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -47,7 +47,7 @@ provider quicly {
     probe packet_prepare(struct st_quicly_conn_t *conn, int64_t at, uint8_t first_octet, const char *dcid);
     probe packet_acked(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, int is_late_ack);
     probe packet_lost(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
-    probe packet_decryption_failure(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
+    probe packet_decryption_failed(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
 
     probe pto(struct st_quicly_conn_t *conn, int64_t at, size_t inflight, uint32_t cwnd, int8_t pto_count);
     probe cc_ack_received(struct st_quicly_conn_t *conn, int64_t at, uint64_t largest_acked, size_t bytes_acked, uint32_t cwnd,

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -41,7 +41,7 @@ subtest "hello" => sub {
         my $events = slurp_file("$tempdir/events");
         complex $events, sub {
             $_ =~ /"type":"transport-close-send",.*?"type":"([^\"]*)",.*?"type":"([^\"]*)",.*?"type":"([^\"]*)",.*?"type":"([^\"]*)"/s
-                and $1 eq 'packet-commit' and $2 eq 'quictrace-sent' and $3 eq 'send' and $4 eq 'free';
+                and $1 eq 'packet-sent' and $2 eq 'send' and $3 eq 'free';
         };
     };
     # check if the client receives extra connection IDs
@@ -122,7 +122,7 @@ subtest "0-rtt" => sub {
     ok -e "$tempdir/session", "session saved";
     system "$cli -s $tempdir/session -e $tempdir/events 127.0.0.1 $port > /dev/null 2>&1";
     my $events = slurp_file("$tempdir/events");
-    like $events, qr/"type":"stream-send".*"stream-id":0,(.|\n)*"type":"packet-commit".*"pn":1,/m, "stream 0 on pn 1";
+    like $events, qr/"type":"stream-send".*"stream-id":0,(.|\n)*"type":"packet-sent".*"pn":1,/m, "stream 0 on pn 1";
     like $events, qr/"type":"cc-ack-received".*"largest-acked":1,/m, "pn 1 acked";
 };
 
@@ -175,7 +175,7 @@ subtest "stateless-reset" => sub {
     # check that the stateless reset is logged
     my $events = slurp_file("$tempdir/events");
     like $events, qr/"type":"stateless-reset-receive",/m, 'got stateless reset';
-    unlike +($events =~ /"type":"stateless-reset-receive",.*?\n/ and $'), qr/"type":"packet-commit",/m, 'nothing sent after receiving stateless reset';
+    unlike +($events =~ /"type":"stateless-reset-receive",.*?\n/ and $'), qr/"type":"packet-sent",/m, 'nothing sent after receiving stateless reset';
 };
 
 subtest "no-compatible-version" => sub {
@@ -204,7 +204,7 @@ subtest "no-compatible-version" => sub {
     # check the trace
     my $events = slurp_file("$tempdir/events");
     like $events, qr/"type":"receive",/m, "one receive event";
-    unlike +($events =~ /"type":"receive",.*?\n/ and $'), qr/"type":"packet-commit",/m, "nothing sent after receiving VN";
+    unlike +($events =~ /"type":"receive",.*?\n/ and $'), qr/"type":"packet-sent",/m, "nothing sent after receiving VN";
 };
 
 subtest "idle-timeout" => sub {


### PR DESCRIPTION
Hello. This PR aims to bootstrap a mechanism to compute [QLog](https://github.com/quiclog/internet-drafts) compliant QUIC server traces. Starting small by focusing on just the `packet_received` and `packet_sent` events.