### PR TITLE
consistently use `uint64_t` for stat counters

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -390,6 +390,9 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t sent;                                                                                                             \
     } num_bytes;                                                                                                                   \
+    /**                                                                                                                            \
+     * Total number of each frame being sent / received.                                                                           \
+     */                                                                                                                            \
     struct {                                                                                                                       \
         uint64_t padding, ping, ack, reset_stream, stop_sending, crypto, new_token, stream, max_data, max_stream_data,             \
             max_streams_bidi, max_streams_uni, data_blocked, stream_data_blocked, streams_blocked, new_connection_id,              \
@@ -397,7 +400,7 @@ struct st_quicly_conn_streamgroup_state_t {
             ack_frequency;                                                                                                         \
     } num_frames_sent, num_frames_received;                                                                                        \
     /**                                                                                                                            \
-     * Total number of PTOs during the connections.                                                                                \
+     * Total number of PTOs observed during the connection.                                                                        \
      */                                                                                                                            \
     uint32_t num_ptos
 

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -402,7 +402,7 @@ struct st_quicly_conn_streamgroup_state_t {
     /**                                                                                                                            \
      * Total number of PTOs observed during the connection.                                                                        \
      */                                                                                                                            \
-    uint32_t num_ptos
+    uint64_t num_ptos
 
 typedef struct st_quicly_stats_t {
     /**

--- a/misc/probe2trace.pl
+++ b/misc/probe2trace.pl
@@ -127,7 +127,7 @@ for my $probe (@probes) {
                 for my $container (qw(num_frames_sent num_frames_received)) {
                     push @fields, map{["$container.$_" => '%llu']} qw(padding ping ack reset_stream stop_sending crypto new_token stream max_data max_stream_data max_streams_bidi max_streams_uni data_blocked stream_data_blocked streams_blocked new_connection_id retire_connection_id path_challenge path_response transport_close application_close handshake_done ack_frequency);
                 }
-            push @fields, ["num_ptos" => '%u'];
+            push @fields, ["num_ptos" => '%llu'];
             # generate @fmt, @ap
             push @fmt, map {my $n = $_->[0]; $n =~ tr/./_/; sprintf '"%s":%s', $n, $_->[1]} @fields;
             if ($arch eq 'linux') {


### PR DESCRIPTION
so that we can use the same struct for retaining an aggregate value