### PR TITLE
[cli] do not send VN in response to VN

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -755,7 +755,7 @@ static int run_server(int fd, struct sockaddr *sa, socklen_t salen)
                     if (quicly_decode_packet(&ctx, &packet, buf, rret, &off) == SIZE_MAX)
                         break;
                     if (QUICLY_PACKET_IS_LONG_HEADER(packet.octets.base[0])) {
-                        if (!quicly_is_supported_version(packet.version)) {
+                        if (packet.version != 0 && !quicly_is_supported_version(packet.version)) {
                             uint8_t payload[ctx.transport_params.max_udp_payload_size];
                             size_t payload_len = quicly_send_version_negotiation(&ctx, packet.cid.src, packet.cid.dest.encrypted,
                                                                                  quicly_supported_versions, payload);


### PR DESCRIPTION
Thanks to @marten-seemann for pointing out the issue.

The check was missing in cli, even though we have had the correct code in the HTTP/3 implementation of H2O.