### PR TITLE
adjust retransmission behavior during handshake

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4214,7 +4214,8 @@ Exit:
     if (ret == 0 && s->target.first_byte_at != NULL) {
         /* last packet can be small-sized, unless it is the first flight sent from the client */
         enum en_quicly_send_packet_mode_t commit_mode = QUICLY_COMMIT_SEND_PACKET_MODE_SMALL;
-        if (quicly_is_client(conn) && (s->payload_buf.datagram[0] & QUICLY_PACKET_TYPE_BITMASK) == QUICLY_PACKET_TYPE_INITIAL)
+        if ((s->payload_buf.datagram[0] & QUICLY_PACKET_TYPE_BITMASK) == QUICLY_PACKET_TYPE_INITIAL &&
+            (quicly_is_client(conn) || !ack_only))
             commit_mode = QUICLY_COMMIT_SEND_PACKET_MODE_FULL_SIZE;
         commit_send_packet(conn, s, commit_mode);
     }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4085,11 +4085,9 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
 
     /* send handshake flows */
     if ((ret = send_handshake_flow(conn, QUICLY_EPOCH_INITIAL, s, ack_only,
-                                   min_packets_to_send != 0 ||
-                                       (conn->super.remote.address_validation.send_probe && conn->handshake == NULL))) != 0)
+                                   min_packets_to_send != 0 && (!quicly_is_client(conn) || conn->handshake == NULL))) != 0)
         goto Exit;
-    if ((ret = send_handshake_flow(conn, QUICLY_EPOCH_HANDSHAKE, s, ack_only,
-                                   min_packets_to_send != 0 || conn->super.remote.address_validation.send_probe)) != 0)
+    if ((ret = send_handshake_flow(conn, QUICLY_EPOCH_HANDSHAKE, s, ack_only, min_packets_to_send != 0)) != 0)
         goto Exit;
 
     /* send encrypted frames */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4083,7 +4083,10 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
     if (s->send_window == 0)
         ack_only = 1;
 
-    /* send handshake flows */
+    /* send handshake flows; when PTO fires...
+     *  * quicly running as a client sends either a Handshake probe (or data) if the handshake keys are available, or else an
+     *    Initial probe (or data).
+     *  * quicly running as a server sends both Initial and Handshake probes (or data) if the corresponding keys are available. */
     if ((ret = send_handshake_flow(conn, QUICLY_EPOCH_INITIAL, s, ack_only,
                                    min_packets_to_send != 0 && (!quicly_is_client(conn) || conn->handshake == NULL))) != 0)
         goto Exit;

--- a/t/lossy.c
+++ b/t/lossy.c
@@ -405,7 +405,7 @@ static void loss_check_stats(int64_t *time_spent, unsigned max_failures, double 
     ok(num_failures_in_loss_core <= max_failures);
     ok(time_mean >= expected_time_mean * 0.6);
     ok(time_mean <= expected_time_mean * 1.2);
-    ok(time_median >= expected_time_median * 0.8);
+    ok(time_median >= expected_time_median * 0.6);
     ok(time_median <= expected_time_median * 1.2);
     // ok(time_90th >= expected_time_90th * 0.9); 90th is fragile to errors, we track this as an guarantee
     ok(time_90th <= expected_time_90th * 1.2);
@@ -426,49 +426,49 @@ static void test_downstream(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 3, 19927, 4188, 23030);
+    loss_check_stats(time_spent, 4, 13812, 3582, 17579);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);
         subtest("50%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 1294.1, 710, 2988);
+    loss_check_stats(time_spent, 0, 1941, 608, 3006);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 4);
         subtest("25%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 225.6, 230, 408);
+    loss_check_stats(time_spent, 0, 228.7, 230, 408);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 10);
         subtest("10%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 134.6, 80, 298);
+    loss_check_stats(time_spent, 0, 140.2, 80, 298);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 20);
         subtest("5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 102.8, 80, 230);
+    loss_check_stats(time_spent, 0, 99.9, 80, 230);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 40);
         subtest("2.5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 88.2, 80, 80);
+    loss_check_stats(time_spent, 0, 90.8, 80, 80);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 64);
         subtest("1.6%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 91.3, 80, 80);
+    loss_check_stats(time_spent, 0, 91.1, 80, 80);
 }
 
 static void test_bidirectional(void)
@@ -483,7 +483,7 @@ static void test_bidirectional(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 27, 271754, 113887, 688726);
+    loss_check_stats(time_spent, 27, 266649.4, 102052, 649336);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);
@@ -491,7 +491,7 @@ static void test_bidirectional(void)
         subtest("50%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 4913.4, 1815, 7106);
+    loss_check_stats(time_spent, 1, 2283.5, 1171, 6424);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 4);
@@ -499,7 +499,7 @@ static void test_bidirectional(void)
         subtest("25%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 394, 264, 652);
+    loss_check_stats(time_spent, 0, 331, 284, 635);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 10);
@@ -507,7 +507,7 @@ static void test_bidirectional(void)
         subtest("10%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 150.1, 80, 298);
+    loss_check_stats(time_spent, 0, 151.7, 80, 298);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 20);
@@ -515,7 +515,7 @@ static void test_bidirectional(void)
         subtest("5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 107.8, 80, 230);
+    loss_check_stats(time_spent, 0, 110.4, 80, 230);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 40);
@@ -523,7 +523,7 @@ static void test_bidirectional(void)
         subtest("2.5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 90.9, 80, 170);
+    loss_check_stats(time_spent, 0, 95.6, 80, 190);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 64);
@@ -531,7 +531,7 @@ static void test_bidirectional(void)
         subtest("1.6%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 86.9, 80, 80);
+    loss_check_stats(time_spent, 0, 95.8, 80, 190);
 }
 
 void test_lossy(void)


### PR DESCRIPTION
This PR makes the following changes:
* Removes half-broken rounding of packet size when CWND is below MTU (see https://github.com/h2o/quicly/pull/400#discussion_r487458521). With this PR, quicly never limits the size of a newly limit packet below MTU. If there's something to send, quicly will build a full-sized packet if there is at least one byte left in the send window. The rationale is that when the path is so congested that a fraction of MTU makes a difference, the sender should be pacing the packets being sent, rather than sending small packets.
* Pad Initial packets carrying CRYPTO data to full-size. Doing so prevents handshake making progress, when the path MTU is below that "full-size" (closes #408).
* Suppresses excessive emission of ack-eliciting packets that lead to ping-pong when the MTU is below 1200 bytes. See the commit comment of 7b26eab for details (closes #406).