### PR TITLE
switch to delayed-ack-01

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -223,7 +223,8 @@ typedef struct st_quicly_transport_parameters_t {
      */
     uint16_t max_ack_delay;
     /**
-     * quicly ignores the value set for quicly_context_t::transport_parameters. Set to UINT64_MAX when not specified by remote peer.
+     * Delayed-ack extension. UINT64_MAX indicates that the extension is disabled or that the peer does not support it. Any local
+     * value other than UINT64_MAX indicates that the use of the extension should be negotiated.
      */
     uint64_t min_ack_delay_usec;
     /**
@@ -930,7 +931,7 @@ int quicly_encode_transport_parameter_list(ptls_buffer_t *buf, const quicly_tran
  */
 int quicly_decode_transport_parameter_list(quicly_transport_parameters_t *params, quicly_cid_t *original_dcid,
                                            quicly_cid_t *initial_scid, quicly_cid_t *retry_scid, void *stateless_reset_token,
-                                           const uint8_t *src, const uint8_t *end);
+                                           const uint8_t *src, const uint8_t *end, int recognize_delayed_ack);
 /**
  * Initiates a new connection.
  * @param new_cid the CID to be used for the connection. path_id is ignored.

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -749,9 +749,7 @@ inline uint8_t *quicly_encode_ack_frequency_frame(uint8_t *dst, uint64_t sequenc
     dst = quicly_encodev(dst, sequence);
     dst = quicly_encodev(dst, packet_tolerance);
     dst = quicly_encodev(dst, max_ack_delay);
-#if 0 // not in -00
     *dst++ = !!ignore_order;
-#endif
     return dst;
 }
 
@@ -765,9 +763,6 @@ inline int quicly_decode_ack_frequency_frame(const uint8_t **src, const uint8_t 
         goto Error;
     if (*src == end)
         goto Error;
-#if 1 // not in -00
-    frame->ignore_order = 0;
-#else
     switch (*(*src)++) {
     case 0:
         frame->ignore_order = 0;
@@ -778,7 +773,6 @@ inline int quicly_decode_ack_frequency_frame(const uint8_t **src, const uint8_t 
     default:
         goto Error;
     }
-#endif
     return 0;
 Error:
     return QUICLY_TRANSPORT_ERROR_FRAME_ENCODING;

--- a/src/cli.c
+++ b/src/cli.c
@@ -891,7 +891,7 @@ static void load_session(void)
             src = end;
         });
         ptls_decode_open_block(src, end, 2, {
-            if ((ret = quicly_decode_transport_parameter_list(&resumed_transport_params, NULL, NULL, NULL, NULL, src, end)) != 0)
+            if ((ret = quicly_decode_transport_parameter_list(&resumed_transport_params, NULL, NULL, NULL, NULL, src, end, 0)) != 0)
                 goto Exit;
             src = end;
         });

--- a/t/test.c
+++ b/t/test.c
@@ -282,8 +282,8 @@ static void test_transport_parameters(void)
                                           0x07, 0x04, 0x80, 0x10, 0x00, 0x00, 0x04, 0x04, 0x81, 0x00, 0x00, 0x00,
                                           0x01, 0x04, 0x80, 0x00, 0x75, 0x30, 0x08, 0x01, 0x0a, 0x0a, 0x01, 0x0a};
     memset(&decoded, 0x55, sizeof(decoded));
-    ok(quicly_decode_transport_parameter_list(&decoded, NULL, NULL, NULL, NULL, valid_bytes, valid_bytes + sizeof(valid_bytes)) ==
-       0);
+    ok(quicly_decode_transport_parameter_list(&decoded, NULL, NULL, NULL, NULL, valid_bytes, valid_bytes + sizeof(valid_bytes),
+                                              1) == 0);
     ok(decoded.max_stream_data.bidi_local = 0x100000);
     ok(decoded.max_stream_data.bidi_remote = 0x100000);
     ok(decoded.max_stream_data.uni = 0x100000);
@@ -297,7 +297,7 @@ static void test_transport_parameters(void)
 
     static const uint8_t dup_bytes[] = {0x05, 0x04, 0x80, 0x10, 0x00, 0x00, 0x05, 0x04, 0x80, 0x10, 0x00, 0x00};
     memset(&decoded, 0x55, sizeof(decoded));
-    ok(quicly_decode_transport_parameter_list(&decoded, NULL, NULL, NULL, NULL, dup_bytes, dup_bytes + sizeof(dup_bytes)) ==
+    ok(quicly_decode_transport_parameter_list(&decoded, NULL, NULL, NULL, NULL, dup_bytes, dup_bytes + sizeof(dup_bytes), 1) ==
        QUICLY_TRANSPORT_ERROR_TRANSPORT_PARAMETER);
 }
 


### PR DESCRIPTION
Other implementations are likely going to roll out -01. Before that, we need to switch to that too, otherwise we'd lose interop.