### PR TITLE
failure to set DF bit is okay, some platforms do not support it even though their SDK might

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -1406,18 +1406,14 @@ int main(int argc, char **argv)
 #if defined(IP_DONTFRAG)
     {
         int on = 1;
-        if (setsockopt(fd, IPPROTO_IP, IP_DONTFRAG, &on, sizeof(on)) != 0) {
-            perror("setsockopt(IP_DONTFRAG) failed");
-            return 1;
-        }
+        if (setsockopt(fd, IPPROTO_IP, IP_DONTFRAG, &on, sizeof(on)) != 0)
+            perror("Warning: setsockopt(IP_DONTFRAG) failed");
     }
 #elif defined(IP_PMTUDISC_DO)
     {
         int opt = IP_PMTUDISC_DO;
-        if (setsockopt(fd, IPPROTO_IP, IP_MTU_DISCOVER, &opt, sizeof(opt)) != 0) {
-            perror("setsockopt(IP_MTU_DISCOVER) failed");
-            return 1;
-        }
+        if (setsockopt(fd, IPPROTO_IP, IP_MTU_DISCOVER, &opt, sizeof(opt)) != 0)
+            perror("Warning: setsockopt(IP_MTU_DISCOVER) failed");
     }
 #endif
 


### PR DESCRIPTION
With 10.16 being released, macOS SDK now has the definition of IP_DONTFRAG, but it is impossible to set that socket option when running 10.15.

Hence demoting the error to a warning.

See also: https://github.com/h2o/h2o/pull/2489.