### PR TITLE
Signal decryption failure from quicly_accept

### DIFF
--- a/include/quicly/constants.h
+++ b/include/quicly/constants.h
@@ -106,6 +106,7 @@ extern "C" {
 #define QUICLY_ERROR_IS_CLOSING 0xff06 /* indicates that the connection has already entered closing state */
 #define QUICLY_ERROR_STATE_EXHAUSTION 0xff07
 #define QUICLY_ERROR_INVALID_INITIAL_VERSION 0xff08
+#define QUICLY_ERROR_DECRYPTION_FAILED 0xff09
 
 typedef int64_t quicly_stream_id_t;
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5481,8 +5481,10 @@ int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *
         goto Exit;
     next_expected_pn = 0; /* is this correct? do we need to take care of underflow? */
     if ((ret = decrypt_packet(ingress_cipher.header_protection, aead_decrypt_fixed_key, ingress_cipher.aead, &next_expected_pn,
-                              packet, &pn, &payload)) != 0)
+                              packet, &pn, &payload)) != 0) {
+        ret = QUICLY_ERROR_DECRYPTION_FAILED;
         goto Exit;
+    }
 
     /* create connection */
     if ((*conn = create_connection(ctx, packet->version, NULL, src_addr, dest_addr, &packet->cid.src, new_cid, handshake_properties,

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -592,7 +592,7 @@ size_t quicly_decode_packet(quicly_context_t *ctx, quicly_decoded_packet_t *pack
     packet->token = ptls_iovec_init(NULL, 0);
     packet->decrypted.pn = UINT64_MAX;
 
-    /* move the cursor to the sencond byte */
+    /* move the cursor to the second byte */
     src += *off + 1;
 
     if (QUICLY_PACKET_IS_LONG_HEADER(packet->octets.base[0])) {

--- a/t/simple.c
+++ b/t/simple.c
@@ -460,8 +460,8 @@ static void test_reset_during_loss(void)
 
 static uint16_t test_close_error_code;
 
-static void test_closeed_by_remote(quicly_closed_by_remote_t *self, quicly_conn_t *conn, int err, uint64_t frame_type,
-                                   const char *reason, size_t reason_len)
+static void test_closed_by_remote(quicly_closed_by_remote_t *self, quicly_conn_t *conn, int err, uint64_t frame_type,
+                                  const char *reason, size_t reason_len)
 {
     ok(QUICLY_ERROR_IS_QUIC_APPLICATION(err));
     test_close_error_code = QUICLY_ERROR_GET_ERROR_CODE(err);
@@ -472,7 +472,7 @@ static void test_closeed_by_remote(quicly_closed_by_remote_t *self, quicly_conn_
 
 static void test_close(void)
 {
-    quicly_closed_by_remote_t closed_by_remote = {test_closeed_by_remote}, *orig_closed_by_remote = quic_ctx.closed_by_remote;
+    quicly_closed_by_remote_t closed_by_remote = {test_closed_by_remote}, *orig_closed_by_remote = quic_ctx.closed_by_remote;
     quicly_address_t dest, src;
     struct iovec datagram;
     uint8_t datagram_buf[quic_ctx.transport_params.max_udp_payload_size];


### PR DESCRIPTION
Currently there is no explicit way for an application to know if decryption of Initial packet failed in `quicly_accept`.
This PR defines a new error code `QUICLY_ERROR_DECRYPTION_FAILED` and return it from `quicly_accept` upon decryption failure.