### PR TITLE
Fix an ACK frame interpretation bug in the QLog adapter

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4691,7 +4691,7 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
         /* Ack blocks are organized in the ACK frame and consequently in the ack_block_lengths array from the largest acked down.
          * Processing acks in packet number order requires processing the ack blocks in reverse order. */
         uint64_t pn_block_max = pn_acked + frame.ack_block_lengths[gap_index] - 1;
-        QUICLY_PROBE(ACK_BLOCK_RECV, conn, conn->stash.now, pn_acked, pn_block_max);
+        QUICLY_PROBE(ACK_BLOCK_RECEIVED, conn, conn->stash.now, pn_acked, pn_block_max);
         while (quicly_sentmap_get(&iter)->packet_number < pn_acked)
             quicly_sentmap_skip(&iter);
         do {

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4691,7 +4691,7 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
         /* Ack blocks are organized in the ACK frame and consequently in the ack_block_lengths array from the largest acked down.
          * Processing acks in packet number order requires processing the ack blocks in reverse order. */
         uint64_t pn_block_max = pn_acked + frame.ack_block_lengths[gap_index] - 1;
-        QUICLY_PROBE(QUICTRACE_RECV_ACK, conn, conn->stash.now, pn_acked, pn_block_max);
+        QUICLY_PROBE(ACK_BLOCK_RECV, conn, conn->stash.now, pn_acked, pn_block_max);
         while (quicly_sentmap_get(&iter)->packet_number < pn_acked)
             quicly_sentmap_skip(&iter);
         do {

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4746,7 +4746,7 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
     if ((ret = on_ack_stream_ack_cached(conn)) != 0)
         return ret;
 
-    QUICLY_PROBE(QUICTRACE_RECV_ACK_DELAY, conn, conn->stash.now, frame.ack_delay);
+    QUICLY_PROBE(ACK_DELAY_RECEIVED, conn, conn->stash.now, frame.ack_delay);
 
     /* Update loss detection engine on ack. The function uses ack_delay only when the largest_newly_acked is also the largest acked
      * so far. So, it does not matter if the ack_delay being passed in does not apply to the largest_newly_acked. */

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -74,6 +74,7 @@ def handle_packet_sent(events, idx):
 def handle_ack_send(event):
     return {
         "frame_type": "ack",
+        "acked_ranges": [[event["largest-acked"]]]
     }
 
 def handle_data_blocked_receive(event):

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -35,7 +35,7 @@ def handle_packet_received(events, idx):
 
         # An ACK frame can't be re-composed in an iteration. Continue buffering
         # the ACK blocks until all the blocks are processed.
-        if ev["type"] == "quictrace-recv-ack":
+        if ev["type"] == "ack-block-received":
             acked.append([ev["ack-block-begin"],ev["ack-block-end"]])
             continue
         elif ev["type"] == "quictrace-recv-ack-delay":

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -38,7 +38,7 @@ def handle_packet_received(events, idx):
         if ev["type"] == "ack-block-received":
             acked.append([ev["ack-block-begin"],ev["ack-block-end"]])
             continue
-        elif ev["type"] == "quictrace-recv-ack-delay":
+        elif ev["type"] == "ack-delay-received":
             frames.append(render_ack_frame(acked))
             continue
 

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -72,10 +72,7 @@ def handle_packet_sent(events, idx):
     }]
 
 def handle_ack_send(event):
-    return {
-        "frame_type": "ack",
-        "acked_ranges": [[event["largest-acked"]]]
-    }
+    return render_ack_frame([[event["largest-acked"]]])
 
 def handle_data_blocked_receive(event):
     return {

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -54,6 +54,7 @@ provider quicly {
                           size_t inflight);
     probe cc_congestion(struct st_quicly_conn_t *conn, int64_t at, uint64_t max_lost_pn, size_t inflight, uint32_t cwnd);
 
+    probe ack_block_recv(struct st_quicly_conn_t *conn, int64_t at, uint64_t ack_block_begin, uint64_t ack_block_end);
     probe ack_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t largest_acked, uint64_t ack_delay);
 
     probe ping_send(struct st_quicly_conn_t *conn, int64_t at);
@@ -112,7 +113,6 @@ provider quicly {
     probe quictrace_send_stream(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off,
                                 size_t len, int fin);
     probe quictrace_recv_stream(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t off, size_t len, int fin);
-    probe quictrace_recv_ack(struct st_quicly_conn_t *conn, int64_t at, uint64_t ack_block_begin, uint64_t ack_block_end);
     probe quictrace_recv_ack_delay(struct st_quicly_conn_t *conn, int64_t at, int64_t ack_delay);
     probe quictrace_lost(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
     probe quictrace_cc_ack(struct st_quicly_conn_t *conn, int64_t at, struct quicly_rtt_t *rtt, uint32_t cwnd, size_t inflight);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -54,7 +54,7 @@ provider quicly {
                           size_t inflight);
     probe cc_congestion(struct st_quicly_conn_t *conn, int64_t at, uint64_t max_lost_pn, size_t inflight, uint32_t cwnd);
 
-    probe ack_block_recv(struct st_quicly_conn_t *conn, int64_t at, uint64_t ack_block_begin, uint64_t ack_block_end);
+    probe ack_block_received(struct st_quicly_conn_t *conn, int64_t at, uint64_t ack_block_begin, uint64_t ack_block_end);
     probe ack_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t largest_acked, uint64_t ack_delay);
 
     probe ping_send(struct st_quicly_conn_t *conn, int64_t at);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -55,6 +55,7 @@ provider quicly {
     probe cc_congestion(struct st_quicly_conn_t *conn, int64_t at, uint64_t max_lost_pn, size_t inflight, uint32_t cwnd);
 
     probe ack_block_received(struct st_quicly_conn_t *conn, int64_t at, uint64_t ack_block_begin, uint64_t ack_block_end);
+    probe ack_delay_received(struct st_quicly_conn_t *conn, int64_t at, int64_t ack_delay);
     probe ack_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t largest_acked, uint64_t ack_delay);
 
     probe ping_send(struct st_quicly_conn_t *conn, int64_t at);
@@ -113,7 +114,6 @@ provider quicly {
     probe quictrace_send_stream(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off,
                                 size_t len, int fin);
     probe quictrace_recv_stream(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t off, size_t len, int fin);
-    probe quictrace_recv_ack_delay(struct st_quicly_conn_t *conn, int64_t at, int64_t ack_delay);
     probe quictrace_lost(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
     probe quictrace_cc_ack(struct st_quicly_conn_t *conn, int64_t at, struct quicly_rtt_t *rtt, uint32_t cwnd, size_t inflight);
     probe quictrace_cc_lost(struct st_quicly_conn_t *conn, int64_t at, struct quicly_rtt_t *rtt, uint32_t cwnd, size_t inflight);


### PR DESCRIPTION
The qlog-adapter program incorrectly renders each incoming `quictrace_recv_ack` event as an individual ACK frame. The fix is to buffer acknowledged blocks until the entire ACK frame is processed. I also renamed `quictrace_recv_ack` to `ack_block_received` in order to make the purpose of the probe more clear.

![Screen Shot 2020-12-01 at 5 54 50 PM](https://user-images.githubusercontent.com/8677/100818140-5ffc1d80-33fe-11eb-89a4-f8b2481ec562.png)
