### PR TITLE
Rename "limit" fields to "maximum" in the USDT probe definition

### DIFF
--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -97,13 +97,13 @@ def handle_handshake_done_send(event):
 def handle_max_data_receive(event):
     return {
         "frame_type": "max_data",
-        "maximum": event["limit"]
+        "maximum": event["maximum"]
     }
 
 def handle_max_data_send(event):
     return {
         "frame_type": "max_data",
-        "maximum": event["limit"]
+        "maximum": event["maximum"]
     }
 
 def handle_max_streams_send(event):
@@ -114,21 +114,21 @@ def handle_max_streams_send(event):
     return {
         "frame_type": "max_streams",
         "stream_type": stream_type,
-        "maximum": event["limit"]
+        "maximum": event["maximum"]
     }
 
 def handle_max_stream_data_receive(event):
     return {
         "frame_type": "max_stream_data",
         "stream_id": event["stream-id"],
-        "maximum": event["limit"]
+        "maximum": event["maximum"]
     }
 
 def handle_max_stream_data_send(event):
     return {
         "frame_type": "max_stream_data",
         "stream_id": event["stream-id"],
-        "maximum": event["limit"]
+        "maximum": event["maximum"]
     }
 
 def handle_new_connection_id_receive(event):
@@ -184,14 +184,14 @@ def handle_stream_data_blocked_receive(event):
     return {
         "frame_type": "stream_data_blocked",
         "stream_id": event["stream-id"],
-        "limit": event["limit"]
+        "maximum": event["maximum"]
     }
 
 def handle_stream_data_blocked_send(event):
     return {
         "frame_type": "stream_data_blocked",
         "stream_id": event["stream-id"],
-        "limit": event["limit"]
+        "maximum": event["maximum"]
     }
 
 def handle_stream_on_receive_reset(event):
@@ -233,7 +233,7 @@ def handle_streams_blocked_receive(event):
     return {
         "frame_type": "streams_blocked",
         "stream_type": stream_type,
-        "limit": event["limit"]
+        "maximum": event["maximum"]
     }
 
 def handle_streams_blocked_send(event):
@@ -244,7 +244,7 @@ def handle_streams_blocked_send(event):
     return {
         "frame_type": "streams_blocked",
         "stream_type": stream_type,
-        "limit": event["limit"]
+        "maximum": event["maximum"]
     }
 
 def handle_transport_close_receive(event):

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -74,14 +74,14 @@ provider quicly {
     probe stream_acked(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t off, size_t len);
     probe stream_lost(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t off, size_t len);
 
-    probe max_data_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t limit);
-    probe max_data_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t limit);
+    probe max_data_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t maximum);
+    probe max_data_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t maximum);
 
-    probe max_streams_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t limit, int is_unidirectional);
-    probe max_streams_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t limit, int is_unidirectional);
+    probe max_streams_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t maximum, int is_unidirectional);
+    probe max_streams_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t maximum, int is_unidirectional);
 
-    probe max_stream_data_send(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t limit);
-    probe max_stream_data_receive(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t limit);
+    probe max_stream_data_send(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t maximum);
+    probe max_stream_data_receive(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t maximum);
 
     probe new_token_send(struct st_quicly_conn_t *conn, int64_t at, uint8_t *token, size_t token_len, uint64_t generation);
     probe new_token_acked(struct st_quicly_conn_t *conn, int64_t at, uint64_t generation);
@@ -90,8 +90,8 @@ provider quicly {
     probe handshake_done_send(struct st_quicly_conn_t *conn, int64_t at);
     probe handshake_done_receive(struct st_quicly_conn_t *conn, int64_t at);
 
-    probe streams_blocked_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t limit, int is_unidirectional);
-    probe streams_blocked_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t limit, int is_unidirectional);
+    probe streams_blocked_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t maximum, int is_unidirectional);
+    probe streams_blocked_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t maximum, int is_unidirectional);
 
     probe new_connection_id_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t sequence, uint64_t retire_prior_to, const char *cid, const char *stateless_reset_token);
     probe new_connection_id_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t sequence, uint64_t retire_prior_to, const char *cid, const char *stateless_reset_token);
@@ -102,8 +102,8 @@ provider quicly {
     probe data_blocked_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t off);
     probe data_blocked_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t off);
 
-    probe stream_data_blocked_send(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t limit);
-    probe stream_data_blocked_receive(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t limit);
+    probe stream_data_blocked_send(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t maximum);
+    probe stream_data_blocked_receive(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t maximum);
 
     probe datagram_send(struct st_quicly_conn_t *conn, int64_t at, const void *payload, size_t payload_len);
     probe datagram_receive(struct st_quicly_conn_t *conn, int64_t at, const void *payload, size_t payload_len);


### PR DESCRIPTION
This PR renames the `limit` fields to `maximum` in the USDT probe definition. The nice thing about this change is gaining consistency with QUIC and QLog. Related work: https://github.com/quiclog/internet-drafts/pull/125