### PR TITLE
Implement the "packet_lost" QLog event

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3570,7 +3570,7 @@ static void on_loss_detected(quicly_loss_t *loss, const quicly_sent_packet_t *lo
     conn->egress.cc.impl->cc_on_lost(&conn->egress.cc, &conn->egress.loss, lost_packet->cc_bytes_in_flight,
                                      lost_packet->packet_number, conn->egress.packet_number, conn->stash.now,
                                      conn->egress.max_udp_payload_size);
-    QUICLY_PROBE(PACKET_LOST, conn, conn->stash.now, lost_packet->packet_number);
+    QUICLY_PROBE(PACKET_LOST, conn, conn->stash.now, lost_packet->packet_number, lost_packet->ack_epoch);
     QUICLY_PROBE(CC_CONGESTION, conn, conn->stash.now, lost_packet->packet_number + 1, conn->egress.loss.sentmap.bytes_in_flight,
                  conn->egress.cc.cwnd);
     QUICLY_PROBE(QUICTRACE_CC_LOST, conn, conn->stash.now, &conn->egress.loss.rtt, conn->egress.cc.cwnd,

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3571,7 +3571,6 @@ static void on_loss_detected(quicly_loss_t *loss, const quicly_sent_packet_t *lo
                                      lost_packet->packet_number, conn->egress.packet_number, conn->stash.now,
                                      conn->egress.max_udp_payload_size);
     QUICLY_PROBE(PACKET_LOST, conn, conn->stash.now, lost_packet->packet_number);
-    QUICLY_PROBE(QUICTRACE_LOST, conn, conn->stash.now, lost_packet->packet_number);
     QUICLY_PROBE(CC_CONGESTION, conn, conn->stash.now, lost_packet->packet_number + 1, conn->egress.loss.sentmap.bytes_in_flight,
                  conn->egress.cc.cwnd);
     QUICLY_PROBE(QUICTRACE_CC_LOST, conn, conn->stash.now, &conn->egress.loss.rtt, conn->egress.cc.cwnd,

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -25,6 +25,14 @@ import json
 
 PACKET_LABELS = ["initial", "0rtt", "handshake", "1rtt"]
 
+def handle_packet_lost(events, idx):
+    return [events[idx]["time"], "recovery", "packet_lost", {
+        "packet_type": PACKET_LABELS[events[idx]["packet-type"]],
+        "header": {
+            "packet_number": events[idx]["pn"]
+        }
+    }]
+
 def handle_packet_received(events, idx):
     frames = []
     acked = []
@@ -270,6 +278,7 @@ def render_ack_frame(ranges):
     }
 
 QLOG_EVENT_HANDLERS = {
+    "packet-lost": handle_packet_lost,
     "packet-received": handle_packet_received,
     "packet-sent": handle_packet_sent
 }

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -46,7 +46,7 @@ provider quicly {
     probe packet_received(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, const void *decrypted, size_t decrypted_len, uint8_t packet_type);
     probe packet_prepare(struct st_quicly_conn_t *conn, int64_t at, uint8_t first_octet, const char *dcid);
     probe packet_acked(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, int is_late_ack);
-    probe packet_lost(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
+    probe packet_lost(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, uint8_t packet_type);
     probe packet_decryption_failed(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
 
     probe pto(struct st_quicly_conn_t *conn, int64_t at, size_t inflight, uint32_t cwnd, int8_t pto_count);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -114,7 +114,6 @@ provider quicly {
     probe quictrace_send_stream(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off,
                                 size_t len, int fin);
     probe quictrace_recv_stream(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t off, size_t len, int fin);
-    probe quictrace_lost(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
     probe quictrace_cc_ack(struct st_quicly_conn_t *conn, int64_t at, struct quicly_rtt_t *rtt, uint32_t cwnd, size_t inflight);
     probe quictrace_cc_lost(struct st_quicly_conn_t *conn, int64_t at, struct quicly_rtt_t *rtt, uint32_t cwnd, size_t inflight);
 


### PR DESCRIPTION
Hello. This PR adds QLog's [packet_lost recovery event](https://tools.ietf.org/id/draft-marx-qlog-event-definitions-quic-h3-02.html#name-packet_lost) support to our QLog adapter program. In the process I made couple of tweaks to the BPF probes.

1. Removed `QUICTRACE_LOST` which was identical to `PACKET_LOST`
2. Made the `PACKET_LOST` probe emit the epoch byte as `packet_type`

Rendering the actual `packet_lost` event was trivial thanks to the handler registry architecture.