### PR TITLE
eliminate `is_active` flag, as it is fragile to bugs

### DIFF
--- a/include/quicly/sendstate.h
+++ b/include/quicly/sendstate.h
@@ -62,7 +62,7 @@ static int quicly_sendstate_is_open(quicly_sendstate_t *state);
 int quicly_sendstate_activate(quicly_sendstate_t *state);
 int quicly_sendstate_shutdown(quicly_sendstate_t *state, uint64_t final_size);
 void quicly_sendstate_reset(quicly_sendstate_t *state);
-int quicly_sendstate_acked(quicly_sendstate_t *state, quicly_sendstate_sent_t *args, int is_active, size_t *bytes_to_shift);
+int quicly_sendstate_acked(quicly_sendstate_t *state, quicly_sendstate_sent_t *args, size_t *bytes_to_shift);
 int quicly_sendstate_lost(quicly_sendstate_t *state, quicly_sendstate_sent_t *args);
 
 /* inline definitions */

--- a/lib/sendstate.c
+++ b/lib/sendstate.c
@@ -113,7 +113,7 @@ static int check_amount_of_state(quicly_sendstate_t *state)
     return 0;
 }
 
-int quicly_sendstate_acked(quicly_sendstate_t *state, quicly_sendstate_sent_t *args, int is_active, size_t *bytes_to_shift)
+int quicly_sendstate_acked(quicly_sendstate_t *state, quicly_sendstate_sent_t *args, size_t *bytes_to_shift)
 {
     uint64_t prev_sent_upto = state->acked.ranges[0].end;
     int ret;
@@ -121,10 +121,8 @@ int quicly_sendstate_acked(quicly_sendstate_t *state, quicly_sendstate_sent_t *a
     /* adjust acked and pending ranges */
     if ((ret = quicly_ranges_add(&state->acked, args->start, args->end)) != 0)
         return ret;
-    if (!is_active) {
-        if ((ret = quicly_ranges_subtract(&state->pending, args->start, args->end)) != 0)
-            return ret;
-    }
+    if ((ret = quicly_ranges_subtract(&state->pending, args->start, args->end)) != 0)
+        return ret;
     assert(state->pending.num_ranges == 0 || state->acked.ranges[0].end <= state->pending.ranges[0].start);
 
     /* calculate number of bytes that can be retired from the send buffer */


### PR DESCRIPTION
The flag is only usable when there is a guarantee that there would not be more than one inflight sentmap carrying the same byte. But that does not stand for the FIN flag, leading to assertion failures.

`quicly_ranges_subtract` is going to be fast unless packet loss is involved (due to end offset being acked being no greater than the beginning offset of pending ranges), therefore this optimization is unnecessary.