### PR TITLE
Do not send too much

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3078,7 +3078,7 @@ static int _do_allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, siz
     } else {
         if (s->num_datagrams >= s->max_datagrams)
             return QUICLY_ERROR_SENDBUF_FULL;
-        if (ack_eliciting && s->send_window == 0)
+        if (ack_eliciting && s->send_window <= 0)
             return QUICLY_ERROR_SENDBUF_FULL;
         if (s->payload_buf.end - s->payload_buf.datagram < conn->egress.max_udp_payload_size)
             return QUICLY_ERROR_SENDBUF_FULL;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2906,8 +2906,8 @@ struct st_quicly_send_context_t {
         uint8_t *end;
     } payload_buf;
     /**
-     * Currently available window for sending (in bytes); the value becomes negative when the sender uses more window than permitted
-     * permitted. That is because the sender operates at packet-level rather than byte-level.
+     * Currently available window for sending (in bytes); the value becomes negative when the sender uses more space than permitted.
+     * That happens because the sender operates at packet-level rather than byte-level.
      */
     ssize_t send_window;
     /**

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2906,7 +2906,8 @@ struct st_quicly_send_context_t {
         uint8_t *end;
     } payload_buf;
     /**
-     * the currently available window for sending (in bytes)
+     * Currently available window for sending (in bytes); the value becomes negative when the sender uses more window than permitted
+     * permitted. That is because the sender operates at packet-level rather than byte-level.
      */
     ssize_t send_window;
     /**
@@ -3078,6 +3079,7 @@ static int _do_allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, siz
     } else {
         if (s->num_datagrams >= s->max_datagrams)
             return QUICLY_ERROR_SENDBUF_FULL;
+        /* note: send_window (ssize_t) can become negative; see doc-comment */
         if (ack_eliciting && s->send_window <= 0)
             return QUICLY_ERROR_SENDBUF_FULL;
         if (s->payload_buf.end - s->payload_buf.datagram < conn->egress.max_udp_payload_size)

--- a/t/lossy.c
+++ b/t/lossy.c
@@ -426,14 +426,14 @@ static void test_downstream(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 4, 13812, 3582, 17579);
+    loss_check_stats(time_spent, 4, 14193, 3610, 17579);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);
         subtest("50%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 1941, 608, 3006);
+    loss_check_stats(time_spent, 0, 2220, 608, 2779);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 4);
@@ -483,7 +483,7 @@ static void test_bidirectional(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 27, 266649.4, 102052, 649336);
+    loss_check_stats(time_spent, 20, 240012.7, 126541, 652328);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);
@@ -491,7 +491,7 @@ static void test_bidirectional(void)
         subtest("50%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 1, 2283.5, 1171, 6424);
+    loss_check_stats(time_spent, 0, 2286.9, 1175, 6424);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 4);
@@ -499,7 +499,7 @@ static void test_bidirectional(void)
         subtest("25%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 331, 284, 635);
+    loss_check_stats(time_spent, 0, 328.7, 237, 530);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 10);
@@ -507,7 +507,7 @@ static void test_bidirectional(void)
         subtest("10%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 151.7, 80, 298);
+    loss_check_stats(time_spent, 0, 150.1, 80, 298);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 20);
@@ -515,7 +515,7 @@ static void test_bidirectional(void)
         subtest("5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 110.4, 80, 230);
+    loss_check_stats(time_spent, 0, 103.5, 80, 192);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 40);
@@ -523,7 +523,7 @@ static void test_bidirectional(void)
         subtest("2.5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 95.6, 80, 190);
+    loss_check_stats(time_spent, 0, 96.7, 80, 80);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 64);
@@ -531,7 +531,7 @@ static void test_bidirectional(void)
         subtest("1.6%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 95.8, 80, 190);
+    loss_check_stats(time_spent, 0, 96.7, 80, 190);
 }
 
 void test_lossy(void)


### PR DESCRIPTION
Up until now, quicly has been sending too much, unless the amount of data that can be sent at given moment is the exact multiple of the MTU size.

In effect, quicly is thought to have been rounding up the send window size by the unit of 10 datagrams (the number of datagram buffers supplied by the caller to to `quicly_send`), because when `st_quicly_send_context_t::send_window` is calculated from CWND size and bytes inflight, the value rarely becomes an exact multiple of MTU.

When PTO expires or when a time threshold loss detection is triggered while the CWND is full, `send_window` is set to an exact multiple of MTU and therefore quicly has behaved correctly.

EDIT. This regression seems to have gone in in #409.