### PR TITLE
add knobs to configure IW

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -273,6 +273,10 @@ struct st_quicly_context_t {
      */
     uint64_t max_crypto_bytes;
     /**
+     * initial CWND in terms of packet numbers
+     */
+    uint32_t initcwnd_packets;
+    /**
      * (client-only) Initial QUIC protocol version used by the client. Setting this to a greased version will enforce version
      * negotiation.
      */

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -168,7 +168,7 @@ extern struct st_quicly_init_cc_t quicly_cc_cubic_init;
 /**
  * Calculates the initial congestion window size given the maximum UDP payload size.
  */
-uint32_t quicly_cc_calc_initial_cwnd(uint16_t max_udp_payload_size);
+uint32_t quicly_cc_calc_initial_cwnd(uint32_t max_packets, uint16_t max_udp_payload_size);
 
 #ifdef __cplusplus
 }

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -98,13 +98,15 @@ static void reno_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd
 
 quicly_init_cc_t quicly_cc_reno_init = {reno_init};
 
-uint32_t quicly_cc_calc_initial_cwnd(uint16_t max_udp_payload_size)
+uint32_t quicly_cc_calc_initial_cwnd(uint32_t max_packets, uint16_t max_udp_payload_size)
 {
-    static const uint32_t max_packets = 10, max_bytes = 14720;
-    uint32_t cwnd = max_packets * max_udp_payload_size;
-    if (cwnd > max_bytes)
-        cwnd = max_bytes;
-    if (cwnd < QUICLY_MIN_CWND * max_udp_payload_size)
-        cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
-    return cwnd;
+    static const uint32_t mtu_max = 1472;
+
+    /* apply filters to the two arguments */
+    if (max_packets < QUICLY_MIN_CWND)
+        max_packets = QUICLY_MIN_CWND;
+    if (max_udp_payload_size > mtu_max)
+        max_udp_payload_size = mtu_max;
+
+    return max_packets * max_udp_payload_size;
 }

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -26,6 +26,7 @@
 #define DEFAULT_MAX_UDP_PAYLOAD_SIZE 1472
 #define DEFAULT_MAX_PACKETS_PER_KEY 16777216
 #define DEFAULT_MAX_CRYPTO_BYTES 65536
+#define DEFAULT_INITCWND_PACKETS 10
 #define DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT 3
 
 /* profile that employs IETF specified values */
@@ -40,6 +41,7 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                                DEFAULT_MAX_UDP_PAYLOAD_SIZE},
                                               DEFAULT_MAX_PACKETS_PER_KEY,
                                               DEFAULT_MAX_CRYPTO_BYTES,
+                                              DEFAULT_INITCWND_PACKETS,
                                               QUICLY_PROTOCOL_VERSION_CURRENT,
                                               DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                               0, /* is_clustered */
@@ -67,6 +69,7 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                      DEFAULT_MAX_UDP_PAYLOAD_SIZE},
                                                     DEFAULT_MAX_PACKETS_PER_KEY,
                                                     DEFAULT_MAX_CRYPTO_BYTES,
+                                                    DEFAULT_INITCWND_PACKETS,
                                                     QUICLY_PROTOCOL_VERSION_CURRENT,
                                                     DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                                     0, /* is_clustered */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2148,8 +2148,9 @@ int quicly_connect(quicly_conn_t **_conn, quicly_context_t *ctx, const char *ser
         }
     }
 
-    if ((conn = create_connection(ctx, ctx->initial_version, server_name, dest_addr, src_addr, NULL, new_cid, handshake_properties,
-                                  quicly_cc_calc_initial_cwnd(ctx->transport_params.max_udp_payload_size))) == NULL) {
+    if ((conn = create_connection(
+             ctx, ctx->initial_version, server_name, dest_addr, src_addr, NULL, new_cid, handshake_properties,
+             quicly_cc_calc_initial_cwnd(ctx->initcwnd_packets, ctx->transport_params.max_udp_payload_size))) == NULL) {
         ret = PTLS_ERROR_NO_MEMORY;
         goto Exit;
     }
@@ -5485,8 +5486,9 @@ int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *
     }
 
     /* create connection */
-    if ((*conn = create_connection(ctx, packet->version, NULL, src_addr, dest_addr, &packet->cid.src, new_cid, handshake_properties,
-                                   quicly_cc_calc_initial_cwnd(ctx->transport_params.max_udp_payload_size))) == NULL) {
+    if ((*conn = create_connection(
+             ctx, packet->version, NULL, src_addr, dest_addr, &packet->cid.src, new_cid, handshake_properties,
+             quicly_cc_calc_initial_cwnd(ctx->initcwnd_packets, ctx->transport_params.max_udp_payload_size))) == NULL) {
         ret = PTLS_ERROR_NO_MEMORY;
         goto Exit;
     }

--- a/src/cli.c
+++ b/src/cli.c
@@ -1057,6 +1057,7 @@ static void usage(const char *cmd)
            "  -U size                   maximum size of UDP datagarm payload\n"
            "  -V                        verify peer using the default certificates\n"
            "  -v                        verbose mode (-vv emits packet dumps as well)\n"
+           "  -w packets                initial congestion window (default: 10)\n"
            "  -x named-group            named group to be used (default: secp256r1)\n"
            "  -X                        max bidirectional stream count (default: 100)\n"
            "  -y cipher-suite           cipher-suite to be used (default: all)\n"
@@ -1103,7 +1104,7 @@ int main(int argc, char **argv)
         address_token_aead.dec = ptls_aead_new(&ptls_openssl_aes128gcm, &ptls_openssl_sha256, 0, secret, "");
     }
 
-    while ((ch = getopt(argc, argv, "a:b:B:c:C:Dd:k:Ee:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvx:X:y:h")) != -1) {
+    while ((ch = getopt(argc, argv, "a:b:B:c:C:Dd:k:Ee:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvw:x:X:y:h")) != -1) {
         switch (ch) {
         case 'a':
             assert(negotiated_protocols.count < PTLS_ELEMENTSOF(negotiated_protocols.list));
@@ -1251,6 +1252,12 @@ int main(int argc, char **argv)
             break;
         case 'v':
             ++verbosity;
+            break;
+        case 'w':
+            if (sscanf(optarg, "%" SCNu32, &ctx.initcwnd_packets) != 1) {
+                fprintf(stderr, "invalid argument passed to `-w`\n");
+                exit(1);
+            }
             break;
         case 'x': {
             size_t i;


### PR DESCRIPTION
This PR adds:
* `quicly_context_t::initcwnd_packets` (default is 10)
* for the cli command, -w option to set initcwnd_packets