### PR TITLE
Prevent potential NULL dereference

### DIFF
--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -414,7 +414,7 @@ Exit:
             ptls_aead_free(*aead_ctx);
             *aead_ctx = NULL;
         }
-        if (*hp_ctx != NULL) {
+        if (hp_ctx != NULL && *hp_ctx != NULL) {
             ptls_cipher_free(*hp_ctx);
             *hp_ctx = NULL;
         }


### PR DESCRIPTION
`hp_ctx` is not guaranteed to be non-NULL.

Fixes Coverity CID 1501098