### PR TITLE
Add new API to return plaintext local CID

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -786,6 +786,10 @@ static const quicly_cid_t *quicly_get_original_dcid(quicly_conn_t *conn);
  */
 static const quicly_cid_t *quicly_get_remote_cid(quicly_conn_t *conn);
 /**
+ * Returns the plaintext source of CIDs provided by this host
+ */
+static const quicly_cid_plaintext_t *quicly_get_local_plaintext_cid(quicly_conn_t *conn);
+/**
  *
  */
 static const quicly_transport_parameters_t *quicly_get_remote_transport_parameters(quicly_conn_t *conn);
@@ -1177,9 +1181,7 @@ inline const quicly_cid_t *quicly_get_remote_cid(quicly_conn_t *conn)
     struct _st_quicly_conn_public_t *c = (struct _st_quicly_conn_public_t *)conn;
     return &c->remote.cid_set.cids[0].cid;
 }
-/**
- * Returns the plaintext source of CIDs provided by this host
- */
+
 inline const quicly_cid_plaintext_t *quicly_get_local_plaintext_cid(quicly_conn_t *conn)
 {
     struct _st_quicly_conn_public_t *c = (struct _st_quicly_conn_public_t *)conn;

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -1177,6 +1177,14 @@ inline const quicly_cid_t *quicly_get_remote_cid(quicly_conn_t *conn)
     struct _st_quicly_conn_public_t *c = (struct _st_quicly_conn_public_t *)conn;
     return &c->remote.cid_set.cids[0].cid;
 }
+/**
+ * Returns the plaintext source of CIDs provided by this host
+ */
+inline const quicly_cid_plaintext_t *quicly_get_local_plaintext_cid(quicly_conn_t *conn)
+{
+    struct _st_quicly_conn_public_t *c = (struct _st_quicly_conn_public_t *)conn;
+    return &c->local.cid_set.plaintext;
+}
 
 inline const quicly_transport_parameters_t *quicly_get_remote_transport_parameters(quicly_conn_t *conn)
 {


### PR DESCRIPTION
This commit adds a new API quicly_get_local_plaintext_cid which
returns the plaintext local CID associated with a connection, so
that an application can examine it (e.g. log it).