### PR TITLE
Incrase number of inflight new token frames after emitting it

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3731,6 +3731,8 @@ static int send_resumption_token(quicly_conn_t *conn, quicly_send_context_t *s)
     if ((ret = allocate_ack_eliciting_frame(conn, s, quicly_new_token_frame_capacity(ptls_iovec_init(tokenbuf.base, tokenbuf.off)),
                                             &sent, on_ack_new_token)) != 0)
         goto Exit;
+    ++conn->egress.new_token.num_inflight;
+    sent->data.new_token.is_inflight = 1;
     sent->data.new_token.generation = conn->egress.new_token.generation;
     s->dst = quicly_encode_new_token_frame(s->dst, ptls_iovec_init(tokenbuf.base, tokenbuf.off));
     conn->egress.pending_flows &= ~QUICLY_PENDING_FLOW_NEW_TOKEN_BIT;


### PR DESCRIPTION
Before this commit, the memory was left unintialized and would make the
logic in `on_ack_new_token` inoperant:
```
==1101999== Conditional jump or move depends on uninitialised value(s)
==1101999==    at 0x36E093: on_ack_new_token (quicly.c:2732)
==1101999==    by 0x37D6E8: quicly_sentmap_update (sentmap.c:162)
==1101999==    by 0x36B198: mark_frames_on_pto (quicly.c:3565)
==1101999==    by 0x35860A: do_send (quicly.c:4174)
==1101999==    by 0x356E0B: quicly_send (quicly.c:4415)
==1101999==    by 0x492CDD: h2o_quic_send (common.c:1149)
==1101999==    by 0x4910F3: on_timeout (common.c:865)
==1101999==    by 0x3A9C90: h2o_evloop_run (evloop.c.h:671)
==1101999==    by 0x629A49: run_loop (main.c:3551)
==1101999==    by 0x6269FF: main (main.c:4498)
```