### PR TITLE
Fix traffic secret labels according to NSS Key Log Format

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4038,8 +4038,8 @@ static int update_traffic_key_cb(ptls_update_traffic_key_t *self, ptls_t *tls, i
     ptls_aead_context_t **aead_slot;
     int ret;
     static const char *log_labels[2][4] = {
-        {NULL, "QUIC_CLIENT_EARLY_TRAFFIC_SECRET", "QUIC_CLIENT_HANDSHAKE_TRAFFIC_SECRET", "QUIC_CLIENT_TRAFFIC_SECRET_0"},
-        {NULL, NULL, "QUIC_SERVER_HANDSHAKE_TRAFFIC_SECRET", "QUIC_SERVER_TRAFFIC_SECRET_0"}};
+        {NULL, "CLIENT_EARLY_TRAFFIC_SECRET", "CLIENT_HANDSHAKE_TRAFFIC_SECRET", "CLIENT_TRAFFIC_SECRET_0"},
+        {NULL, NULL, "SERVER_HANDSHAKE_TRAFFIC_SECRET", "SERVER_TRAFFIC_SECRET_0"}};
     const char *log_label = log_labels[ptls_is_server(tls) == is_enc][epoch];
 
     QUICLY_PROBE(CRYPTO_UPDATE_SECRET, conn, conn->stash.now, is_enc, epoch, log_label,


### PR DESCRIPTION
Currently, traffic secret labels are prefixed with `QUIC_`, which leads to an error decrypting packets using Wireshark:

```
Wireshark SSL debug log 

Wireshark version: 3.4.3 (v3.4.3-0-g6ae6cd335aa9)
GnuTLS version:    3.6.15
Libgcrypt version: 1.8.7

dissect_tls13_handshake enter frame #1 (first time)
packet_from_server: is from server - FALSE
  conversation = 0x7fa524d699b0, ssl_session = 0x7fa524d6a600, from_server = 0
dissect_ssl3_handshake iteration 1 type 1 offset 0 length 232 bytes
ssl_dissect_hnd_hello_common found CLIENT RANDOM -> state 0x2011

dissect_tls13_handshake enter frame #2 (first time)
packet_from_server: is from server - TRUE
  conversation = 0x7fa524d699b0, ssl_session = 0x7fa524d6a600, from_server = 1
dissect_ssl3_handshake iteration 1 type 2 offset 0 length 119 bytes
ssl_try_set_version found version 0x0304 -> state 0x2011
ssl_dissect_hnd_hello_common found SERVER RANDOM -> state 0x2013
ssl_set_cipher found CIPHER 0x1302 TLS_AES_256_GCM_SHA384 -> state 0x2017
trying to use TLS keylog in /Users/<myuser>/secrets.log
  checking keylog line: QUIC_SERVER_HANDSHAKE_TRAFFIC_SECRET 9592ccee35d05e51eed76b6bec754eb9773e8c32684c13d3d734c4f618326769 e25b34dee53222755092f4923cd1139f5239c70f1d8f94f7933677aa0404d37056753e90c10b2c8298826390063eebb7
    unrecognized line
  checking keylog line: QUIC_CLIENT_HANDSHAKE_TRAFFIC_SECRET 9592ccee35d05e51eed76b6bec754eb9773e8c32684c13d3d734c4f618326769 a3ecf45ffb19208f0d7409c8bb5f81be7c739855fd8d9c6896bd33d09551781b7cbd7e19fbae1d7955d19a7e26f1a244
    unrecognized line
  checking keylog line: QUIC_SERVER_TRAFFIC_SECRET_0 9592ccee35d05e51eed76b6bec754eb9773e8c32684c13d3d734c4f618326769 8e26cfbd3174c8b431e8b3a337972279f26f478ed05c825fae5c11a97e539bc948211a3a778ef5fab2003dcd7ade0c53
    unrecognized line
  checking keylog line: QUIC_CLIENT_TRAFFIC_SECRET_0 9592ccee35d05e51eed76b6bec754eb9773e8c32684c13d3d734c4f618326769 76366d5d5e2c6882a3f0e77942528f700d926ab0c53c72b5c8a9153a167784e49dc5ea1cf84d12f46ce7fc4940498b09
    unrecognized line
tls13_get_quic_secret frame 2 is_quic=1
trying to use TLS keylog in /Users/<myuser>/secrets.log
tls13_get_quic_secret Cannot find QUIC SERVER_HANDSHAKE_TRAFFIC_SECRET of size 48..48, found bad size 0!
tls13_get_quic_secret frame 3 is_quic=1
trying to use TLS keylog in /Users/<myuser>/secrets.log
tls13_get_quic_secret Cannot find QUIC SERVER_HANDSHAKE_TRAFFIC_SECRET of size 48..48, found bad size 0!
tls13_get_quic_secret frame 4 is_quic=1
trying to use TLS keylog in /Users/<myuser>/secrets.log
tls13_get_quic_secret Cannot find QUIC CLIENT_HANDSHAKE_TRAFFIC_SECRET of size 48..48, found bad size 0!
tls13_get_quic_secret frame 4 is_quic=1
trying to use TLS keylog in /Users/<myuser>/secrets.log
tls13_get_quic_secret Cannot find QUIC CLIENT_TRAFFIC_SECRET_0 of size 48..48, found bad size 0!
```

In line with the [NSS Key Log Format](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format), removing the prefix enables the decryption of packets:

```
Wireshark SSL debug log 

Wireshark version: 3.4.3 (v3.4.3-0-g6ae6cd335aa9)
GnuTLS version:    3.6.15
Libgcrypt version: 1.8.7

dissect_tls13_handshake enter frame #1 (first time)
packet_from_server: is from server - FALSE
  conversation = 0x7f936a0129b0, ssl_session = 0x7f936a013600, from_server = 0
dissect_ssl3_handshake iteration 1 type 1 offset 0 length 232 bytes
ssl_dissect_hnd_hello_common found CLIENT RANDOM -> state 0x2011

dissect_tls13_handshake enter frame #2 (first time)
packet_from_server: is from server - TRUE
  conversation = 0x7f936a0129b0, ssl_session = 0x7f936a013600, from_server = 1
dissect_ssl3_handshake iteration 1 type 2 offset 0 length 119 bytes
ssl_try_set_version found version 0x0304 -> state 0x2011
ssl_dissect_hnd_hello_common found SERVER RANDOM -> state 0x2013
ssl_set_cipher found CIPHER 0x1302 TLS_AES_256_GCM_SHA384 -> state 0x2017
trying to use TLS keylog in /Users/<myuser>/secrets.log
  checking keylog line: SERVER_HANDSHAKE_TRAFFIC_SECRET 868a447c60ee8e7c6f30a8f754369b96d1319cd67fa1e6da8965bfe560890fa8 52817832fe2565e2540291865374c4ae8d87c236b9140be4f5bf8a1b0a35f01677949c17bdd7b108c3eba33b8b8ba1ec
    matched server_handshake
  checking keylog line: CLIENT_HANDSHAKE_TRAFFIC_SECRET 868a447c60ee8e7c6f30a8f754369b96d1319cd67fa1e6da8965bfe560890fa8 70cb1ff75b020dfeb0cb768d53403573de8db08dd72d7fec074040ef8995fe512ded4d08964bce8bffc45f31a0db041d
    matched client_handshake
  checking keylog line: SERVER_TRAFFIC_SECRET_0 868a447c60ee8e7c6f30a8f754369b96d1319cd67fa1e6da8965bfe560890fa8 b26d03f06edbf9843fb059e6695892e408297b6b29b8d823ddb299cde1504ad109699ab544e389fd630d014ce6f80779
    matched server_appdata
  checking keylog line: CLIENT_TRAFFIC_SECRET_0 868a447c60ee8e7c6f30a8f754369b96d1319cd67fa1e6da8965bfe560890fa8 50c8daa179b99498c5c35276d9cb768e27ec810baff58f9cc92ac69109c5396bdce90fe978db44925699c1cff7027895
    matched client_appdata
```

Tested and verified with Wireshark 3.4.0 and 3.4.3 on macOS and Linux. I tried to track down the underlaying cause, but was unable to identify recent changes in Wireshark, quicly or quicly implemented QUIC draft-xx explaining the behaviour. However, I am not a TLS guy - Please refer to https://github.com/wireshark/wireshark/commit/2fd42045f5afb556a03d8a1090f3278c77798766 for the initial change in Wireshark referring the `QUIC_` prefix.