### PR TITLE
Makes Reno CC slightly loss tolerant

### DIFF
--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -81,6 +81,10 @@ typedef struct st_quicly_cc_t {
              * Stash of acknowledged bytes, used during congestion avoidance.
              */
             uint32_t stash;
+            /**
+             * Number of losses seen in a recovery episode.
+             */
+            uint32_t num_lost_in_episode;
         } reno;
         /**
          * State information for CUBIC congestion control.

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -31,8 +31,10 @@ static void reno_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
                           int64_t now, uint32_t max_udp_payload_size)
 {
     assert(inflight >= bytes);
-    /* Do not increase congestion window while in recovery. */
-    if (largest_acked < cc->recovery_end)
+    /* Do not increase congestion window while in recovery and if number of
+     * losses in this episode is greater than the threshold. */
+    if (largest_acked < cc->recovery_end &&
+        cc->state.reno.num_lost_in_episode >= QUICLY_RENO_LOSS_THRESHOLD)
         return;
 
     /* Slow start. */


### PR DESCRIPTION
The key idea here is that it is unlikely that a singular loss is a good indicator of congestion. I considered using a percentage of the congestion window as the threshold, but that might be too aggressive. This PR sets the threshold to two, meaning that there have to be at least two losses in a recovery episode for there to be congestion action.

Additionally, the congestion window is increased during the recovery episode as long as the number of losses is below the threshold.

Note that the recovery episode still starts and ends as before: starting at the first loss and ending an RTT later. This means that it is possible for the window to keep increasing until threshold number of losses occur, which could be near the end of the recovery RTT. In the worst case, this causes the window to be slightly larger (Beta x MaxPacketSize) at the end of a congestion event.