### PR TITLE
add appdata annotations to quicly-probes.d

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5558,8 +5558,8 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     lock_now(conn, 0);
 
     QUICLY_PROBE(RECEIVE, conn, conn->stash.now,
-                 QUICLY_PROBE_HEXDUMP(packet->cid.dest.encrypted.base, packet->cid.dest.encrypted.len), packet->octects.base[0],
-                 packet->octets.base, packet->octets.len);
+                 QUICLY_PROBE_HEXDUMP(packet->cid.dest.encrypted.base, packet->cid.dest.encrypted.len), packet->octets.base,
+                 packet->octets.len);
 
     if (is_stateless_reset(conn, packet)) {
         ret = handle_stateless_reset(conn);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5558,8 +5558,8 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     lock_now(conn, 0);
 
     QUICLY_PROBE(RECEIVE, conn, conn->stash.now,
-                 QUICLY_PROBE_HEXDUMP(packet->cid.dest.encrypted.base, packet->cid.dest.encrypted.len), packet->octets.base,
-                 packet->octets.len);
+                 QUICLY_PROBE_HEXDUMP(packet->cid.dest.encrypted.base, packet->cid.dest.encrypted.len), packet->octects.base[0],
+                 packet->octets.base, packet->octets.len);
 
     if (is_stateless_reset(conn, packet)) {
         ret = handle_stateless_reset(conn);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -22,13 +22,8 @@
 
 /* @appdata
 {
-    "receive": ["bytes"],
     "packet_received": ["decrypted"],
     "stream_on_receive": ["src"],
-    "new_token_send": ["token"],
-    "new_token_receive": ["token"],
-    "new_connection_id_send": ["stateless_reset_token"],
-    "new_connection_id_receive": ["stateless_reset_token"],
     "datagram_send": ["payload"],
     "datagram_receive": ["payload"],
     "crypto_update_secret": ["secret"],

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -48,7 +48,7 @@ provider quicly {
                  struct st_quicly_address_token_plaintext_t *address_token);
     probe free(struct st_quicly_conn_t *conn, int64_t at);
     probe send(struct st_quicly_conn_t *conn, int64_t at, int state, const char *dcid);
-    probe receive(struct st_quicly_conn_t *conn, int64_t at, const char *dcid, uint8_t first_octet, const void *bytes, size_t bytes_len);
+    probe receive(struct st_quicly_conn_t *conn, int64_t at, const char *dcid, const void *bytes, size_t bytes_len);
     probe version_switch(struct st_quicly_conn_t *conn, int64_t at, uint32_t new_version);
     probe idle_timeout(struct st_quicly_conn_t *conn, int64_t at);
     probe stateless_reset_receive(struct st_quicly_conn_t *conn, int64_t at);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -48,7 +48,7 @@ provider quicly {
                  struct st_quicly_address_token_plaintext_t *address_token);
     probe free(struct st_quicly_conn_t *conn, int64_t at);
     probe send(struct st_quicly_conn_t *conn, int64_t at, int state, const char *dcid);
-    probe receive(struct st_quicly_conn_t *conn, int64_t at, const char *dcid, const void *bytes, size_t bytes_len);
+    probe receive(struct st_quicly_conn_t *conn, int64_t at, const char *dcid, uint8_t first_octet, const void *bytes, size_t bytes_len);
     probe version_switch(struct st_quicly_conn_t *conn, int64_t at, uint32_t new_version);
     probe idle_timeout(struct st_quicly_conn_t *conn, int64_t at);
     probe stateless_reset_receive(struct st_quicly_conn_t *conn, int64_t at);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -20,6 +20,24 @@
  * IN THE SOFTWARE.
  */
 
+/* @appdata
+{
+    "receive": ["bytes"],
+    "packet_received": ["decrypted"],
+    "stream_on_receive": ["src"],
+    "new_token_send": ["token"],
+    "new_token_receive": ["token"],
+    "new_connection_id_send": ["stateless_reset_token"],
+    "new_connection_id_receive": ["stateless_reset_token"],
+    "datagram_send": ["payload"],
+    "datagram_receive": ["payload"],
+    "crypto_update_secret": ["secret"],
+    "crypto_send_key_update": ["secret"],
+    "crypto_receive_key_update": ["secret"],
+    "crypto_receive_key_update_prepare": ["secret"]
+}
+*/
+
 /**
  * Providers of quicly. Name of the arguments are important - they are used as the names of JSON fields when the dtrace script is
  * generated.


### PR DESCRIPTION
This PR is a dependency for https://github.com/h2o/h2o/pull/2604 and it requires that branch to test like this:

```shell
h2o/h2o$ make -f misc/regen.mk src/h2olog/generated_raw_tracer.cc QUICLY_PROBES_D=../quicly/quicly-probes.d
```

This PR also makes `quicly:receive` to have an additional field `first_octet`. h2olog has a special handling for `first_octet`  in `gen_raw_tracer.py` so far to show it as the first octet of `void* bytes`, but It is difficult to maintain the specification that is contradictory to appdata. The `first_octet` special handling is being removed in https://github.com/h2o/h2o/pull/2604/commits/0fab700a90166f0fc22ac1033671c79d4a127956 (https://github.com/h2o/h2o/pull/2604). 
