### PR TITLE
add a hook to implement reference counting of quicly_context_t

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -156,6 +156,11 @@ QUICLY_CALLBACK_TYPE(int, generate_resumption_token, quicly_conn_t *conn, ptls_b
  */
 QUICLY_CALLBACK_TYPE(void, init_cc, quicly_cc_t *cc, uint32_t initcwnd, int64_t now);
 /**
+ * reference counting.
+ * delta must be either 1 or -1.
+ */
+QUICLY_CALLBACK_TYPE(void, update_open_count, ssize_t delta);
+/**
  * crypto offload API
  */
 typedef struct st_quicly_crypto_engine_t {
@@ -333,6 +338,10 @@ struct st_quicly_context_t {
      * initializes a congestion controller for given connection.
      */
     quicly_init_cc_t *init_cc;
+    /**
+     * optional refcount callback
+     */
+    quicly_update_open_count_t *update_open_count;
 };
 
 /**

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1480,6 +1480,12 @@ static int received_key_update(quicly_conn_t *conn, uint64_t newly_decrypted_key
     }
 }
 
+static inline void update_open_count(quicly_context_t *ctx, ssize_t delta)
+{
+    if (ctx->update_open_count != NULL)
+        ctx->update_open_count->cb(ctx->update_open_count, delta);
+}
+
 void quicly_free(quicly_conn_t *conn)
 {
     lock_now(conn, 0);
@@ -1493,6 +1499,7 @@ void quicly_free(quicly_conn_t *conn)
         QUICLY_PROBE(CONN_STATS, conn, conn->stash.now, &stats, sizeof(stats));
     }
 #endif
+    update_open_count(conn->super.ctx, -1);
 
     destroy_all_streams(conn, 0, 1);
 
@@ -2045,6 +2052,8 @@ static quicly_conn_t *create_connection(quicly_context_t *ctx, uint32_t protocol
     conn->stash.on_ack_stream.active_acked_cache.stream_id = INT64_MIN;
 
     *ptls_get_data_ptr(tls) = conn;
+
+    update_open_count(conn->super.ctx, 1);
 
     return conn;
 }


### PR DESCRIPTION
We need to make quicly_contet_t to have a reference counting hook in order to use picotls's `update_open_count` from the application layer.

cf. https://github.com/h2o/picotls/commit/dc5dd1b7adb0072d59ab87e49204edc5e5d3494f
