### PR TITLE
lib: apply remote.transport_params.max_udp_payload_size once learned

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -257,8 +257,8 @@ struct st_quicly_context_t {
     ptls_context_t *tls;
     /**
      * Maximum size of packets that we are willing to send when path-specific information is unavailable. As a path-specific
-     * * optimization, quicly acting as a server expands this value to `min(local.tp.max_udp_payload_size,
-     * * remote.tp.max_udp_payload_size, max_size_of_incoming_datagrams)` when it receives the Transport Parameters from the client.
+     * optimization, quicly expands this value to remote.tp.max_udp_payload_size when it receives the Transport Parameters
+     * from the peer.
      */
     uint16_t initial_egress_max_udp_payload_size;
     /**


### PR DESCRIPTION
## Overview
According to my understanding of [RFC-9000](https://quicwg.org/base-drafts/rfc9000.html#name-datagram-size), a sender is not required to apply `max_udp_payload_size` once learned, but **may** do so to optimize the performance of the connection.  In my testing `quicly` does not do that.  There is logic in the server code to reduce the payload size after the initial handshake, but that seems incorrect because the document seems to imply that the logic should be the opposite, that the sender should start with an initial small size that is safe, and then increase it according to the peer's transport parameters.  The current logic takes into account the largest received datagram size and the local `max_udp_payload_size `, both of which are not truly valid parameters.  I have removed that logic and simplified it to be just the the peer's value.  I also implemented the same on the client side.

## Test

### Without this patch

```
$ ./h2o-httpclient -k -3 100 -H "user-agen: nalramli/1.0" -b 2944 -c 1472 -x 127.0.0.1:443 https://www.nalramli.com/test.html 1>/dev/null
HTTP/3 200
server: h2o/2.3.0-DEV@612cbbc
content-length: 4000
date: Fri, 21 May 2021 21:23:31 GMT
content-type: text/html
last-modified: Fri, 21 May 2021 21:20:40 GMT
etag: "60a82428-fa0"
accept-ranges: bytes

```

```
$ sudo /usr/sbin/tcpdump -i any udp and port 443
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on any, link-type LINUX_SLL (Linux cooked), capture size 262144 bytes
17:23:31.533570 IP localhost.33400 > localhost.https: UDP, length 1280
17:23:31.535652 IP localhost.https > localhost.33400: UDP, length 1280
17:23:31.535755 IP localhost.https > localhost.33400: UDP, length 607
17:23:31.536295 IP localhost.33400 > localhost.https: UDP, length 1280
17:23:31.536388 IP localhost.33400 > localhost.https: UDP, length 522
17:23:31.536419 IP localhost.33400 > localhost.https: UDP, length 1280
17:23:31.536427 IP localhost.33400 > localhost.https: UDP, length 261
17:23:31.537083 IP localhost.https > localhost.33400: UDP, length 1280
17:23:31.537172 IP localhost.https > localhost.33400: UDP, length 1280
17:23:31.537179 IP localhost.https > localhost.33400: UDP, length 1280
17:23:31.537516 IP localhost.33400 > localhost.https: UDP, length 33
17:23:31.537617 IP localhost.33400 > localhost.https: UDP, length 32
^C
12 packets captured
26 packets received by filter
1 packet dropped by kernel
```

### With this patch

```
$ ./h2o-httpclient -k -3 100 -H "user-agen: nalramli/1.0" -b 2944 -c 1472 -x 127.0.0.1:443 https://www.nalramli.com/test.html 1>/dev/null
HTTP/3 200
server: h2o/2.3.0-DEV@612cbbc
content-length: 4000
date: Fri, 21 May 2021 21:26:05 GMT
content-type: text/html
last-modified: Fri, 21 May 2021 21:20:40 GMT
etag: "60a82428-fa0"
accept-ranges: bytes

```

```
$ sudo /usr/sbin/tcpdump -i any udp and port 443
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on any, link-type LINUX_SLL (Linux cooked), capture size 262144 bytes
17:26:05.221222 IP localhost.47301 > localhost.https: UDP, length 1280
17:26:05.224034 IP localhost.https > localhost.47301: UDP, length 1472
17:26:05.224088 IP localhost.https > localhost.47301: UDP, length 366
17:26:05.224496 IP localhost.47301 > localhost.https: UDP, length 1472
17:26:05.224508 IP localhost.47301 > localhost.https: UDP, length 330
17:26:05.224532 IP localhost.47301 > localhost.https: UDP, length 1472
17:26:05.224959 IP localhost.https > localhost.47301: UDP, length 1472
17:26:05.225010 IP localhost.https > localhost.47301: UDP, length 1472
17:26:05.225014 IP localhost.https > localhost.47301: UDP, length 1260
17:26:05.226135 IP localhost.47301 > localhost.https: UDP, length 32
^C
10 packets captured
22 packets received by filter
1 packet dropped by kernel
```
