### PR TITLE
quicly_memcpy: a version that checks for null pointers

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -1101,6 +1101,10 @@ int quicly_build_session_ticket_auth_data(ptls_buffer_t *auth_data, const quicly
  */
 static void quicly_byte_to_hex(char *dst, uint8_t v);
 /**
+ * A version of memcpy that can take a NULL @src to avoid UB
+ */
+static void *quicly_memcpy(void *dst, const void *src, size_t n);
+/**
  *
  */
 socklen_t quicly_get_socklen(struct sockaddr *sa);
@@ -1282,6 +1286,15 @@ inline void quicly_byte_to_hex(char *dst, uint8_t v)
 {
     dst[0] = "0123456789abcdef"[v >> 4];
     dst[1] = "0123456789abcdef"[v & 0xf];
+}
+
+inline void *quicly_memcpy(void *dst, const void *src, size_t n)
+{
+    if (src != NULL)
+        return memcpy(dst, src, n);
+    else if (n != 0)
+        assert(0 && "null pointer passed to memcpy");
+    return dst;
 }
 
 #ifdef __cplusplus

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3136,7 +3136,7 @@ static int _do_allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, siz
         if (s->current.first_byte == QUICLY_PACKET_TYPE_INITIAL) {
             s->dst = quicly_encodev(s->dst, conn->token.len);
             assert(s->dst_end - s->dst > conn->token.len);
-            memcpy(s->dst, conn->token.base, conn->token.len);
+            quicly_memcpy(s->dst, conn->token.base, conn->token.len);
             s->dst += conn->token.len;
         }
         /* payload length is filled laterwards (see commit_send_packet) */


### PR DESCRIPTION
This allows to cleanup an ASAN warning
```
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /build/src/main.c:445:16 in
/build/deps/quicly/lib/quicly.c:3141:28: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:43:28: note: nonnull attribute specified here
```