### PR TITLE
avoid memcpy UB, by skipping the operation to add token altogether

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3135,9 +3135,11 @@ static int _do_allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, siz
         /* token */
         if (s->current.first_byte == QUICLY_PACKET_TYPE_INITIAL) {
             s->dst = quicly_encodev(s->dst, conn->token.len);
-            assert(s->dst_end - s->dst > conn->token.len);
-            memcpy(s->dst, conn->token.base, conn->token.len);
-            s->dst += conn->token.len;
+            if (conn->token.len != 0) {
+                assert(s->dst_end - s->dst > conn->token.len);
+                memcpy(s->dst, conn->token.base, conn->token.len);
+                s->dst += conn->token.len;
+            }
         }
         /* payload length is filled laterwards (see commit_send_packet) */
         *s->dst++ = 0;


### PR DESCRIPTION
alternative to #457