### PR TITLE
Preserve sentmap integrity when the `acked` callback returns an error

### DIFF
--- a/lib/sentmap.c
+++ b/lib/sentmap.c
@@ -159,13 +159,15 @@ int quicly_sentmap_update(quicly_sentmap_t *map, quicly_sentmap_iter_t *iter, qu
         --map->num_packets;
     }
     for (next_entry(iter); iter->p->acked != quicly_sentmap__type_packet; next_entry(iter)) {
-        if (should_notify && (ret = iter->p->acked(map, &packet, event == QUICLY_SENTMAP_EVENT_ACKED, iter->p)) != 0)
-            goto Exit;
+        if (should_notify) {
+            int ack_failure = iter->p->acked(map, &packet, event == QUICLY_SENTMAP_EVENT_ACKED, iter->p);
+            if (ack_failure && ret == 0)
+                ret = ack_failure;
+        }
         if (should_discard)
             discard_entry(map, iter);
     }
 
-Exit:
     return ret;
 }
 

--- a/t/sentmap.c
+++ b/t/sentmap.c
@@ -24,6 +24,10 @@
 
 static int on_acked_callcnt, on_acked_ackcnt;
 
+static int on_acked_fail(quicly_sentmap_t *map, const quicly_sent_packet_t *packet, int acked, quicly_sent_t *sent)
+{
+    return 1;
+}
 static int on_acked(quicly_sentmap_t *map, const quicly_sent_packet_t *packet, int acked, quicly_sent_t *sent)
 {
     ++on_acked_callcnt;
@@ -42,6 +46,26 @@ static size_t num_blocks(quicly_sentmap_t *map)
 
     return n;
 }
+
+static void test_ack_failure(void)
+{
+    quicly_sentmap_t map;
+    uint64_t at;
+    size_t i;
+    quicly_sentmap_iter_t iter;
+
+    quicly_sentmap_init(&map);
+
+    quicly_sentmap_prepare(&map, 1, 0, QUICLY_EPOCH_INITIAL);
+    quicly_sentmap_allocate(&map, on_acked_fail);
+    quicly_sentmap_commit(&map, 1);
+
+    quicly_sentmap_init_iter(&map, &iter);
+    quicly_sentmap_update(&map, &iter, QUICLY_SENTMAP_EVENT_EXPIRED);
+
+    quicly_sentmap_init_iter(&map, &iter);
+}
+
 
 static void test_basic(void)
 {
@@ -194,4 +218,5 @@ void test_sentmap(void)
     subtest("basic", test_basic);
     subtest("late-ack", test_late_ack);
     subtest("pto", test_pto);
+    subtest("ack-failure", test_ack_failure);
 }


### PR DESCRIPTION
Before this PR, we could exit `quicly_sentmap_update` with the packet
entry removed, but with frames left.
This change makes sure that the sentmap data remains usable after an
error