### PR TITLE
relax stream state limits

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1020,11 +1020,15 @@ static void init_stream_properties(quicly_stream_t *stream, uint32_t initial_max
 
     /* Set the number of max ranges to be capable of handling following case:
      * * every one of the two packets being sent are lost
-     * * average size of a STREAM frame found in a packet is >= ~512 bytes
+     * * average size of a STREAM frame found in a packet is >= ~512 bytes, or small STREAM frame is sent for every other stream
+     *   being opened (e.g., sending QPACK encoder/decoder stream frame for each HTTP/3 request)
      * See also: the doc-comment on `_recv_aux.max_ranges`.
      */
-    if ((stream->_recv_aux.max_ranges = initial_max_stream_data_local / 1024) < 63)
-        stream->_recv_aux.max_ranges = 63;
+    uint32_t fragments_minmax = (uint32_t)(stream->conn->super.ctx->transport_params.max_streams_uni + stream->conn->super.ctx->transport_params.max_streams_bidi);
+    if (fragments_minmax < 63)
+        fragments_minmax = 63;
+    if ((stream->_recv_aux.max_ranges = initial_max_stream_data_local / 1024) < fragments_minmax)
+        stream->_recv_aux.max_ranges = fragments_minmax;
 }
 
 static void dispose_stream_properties(quicly_stream_t *stream)

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1024,7 +1024,8 @@ static void init_stream_properties(quicly_stream_t *stream, uint32_t initial_max
      *   being opened (e.g., sending QPACK encoder/decoder stream frame for each HTTP/3 request)
      * See also: the doc-comment on `_recv_aux.max_ranges`.
      */
-    uint32_t fragments_minmax = (uint32_t)(stream->conn->super.ctx->transport_params.max_streams_uni + stream->conn->super.ctx->transport_params.max_streams_bidi);
+    uint32_t fragments_minmax = (uint32_t)(stream->conn->super.ctx->transport_params.max_streams_uni +
+                                           stream->conn->super.ctx->transport_params.max_streams_bidi);
     if (fragments_minmax < 63)
         fragments_minmax = 63;
     if ((stream->_recv_aux.max_ranges = initial_max_stream_data_local / 1024) < fragments_minmax)


### PR DESCRIPTION
The root cause of #463 seems to be the send-side state reaching their limits.

It is suspected that, when a client sends many HTTP/3 requests carried by separate QUIC packets and server sends QPACK encoder / decoder stream frames for each of the request, and those packets are lost at highly random manner (possibly at the end of slow start), the number of loss-confirmed gaps that server observes for either of the QPACK stream occasionally reaches the cap which is calculated as: `max(16, bytes_inflight / 1024)`.

Note that the formula is half of what you find in the source code, because at the moment loss is confirmed, one gap appears in the acked map and another in the pending map.