### PR TITLE
quicly_receive: do not try to cleanly shutdown connections on fatal errors

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5866,6 +5866,8 @@ Exit:
             conn->egress.loss.alarm_at = conn->stash.now;
         assert_consistency(conn, 0);
         break;
+    case PTLS_ERROR_NO_MEMORY:
+    case QUICLY_ERROR_STATE_EXHAUSTION:
     case QUICLY_ERROR_PACKET_IGNORED:
         break;
     default: /* close connection */


### PR DESCRIPTION


On fatal errors, it's possible that the sentmap has been left in an
unusable state (see https://github.com/h2o/quicly/pull/462)

When these happen, let the application deal with the fatal error.