### PR TITLE
[reno] better handling of high-BDP connections

### DIFF
--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -81,6 +81,10 @@ typedef struct st_quicly_cc_t {
              * Stash of acknowledged bytes, used during congestion avoidance.
              */
             uint32_t stash;
+            /**
+             * When set, increases CWND as aggressive as Cubic during congestion avoidance.
+             */
+            uint32_t highbdp_mode : 1;
         } reno;
         /**
          * State information for CUBIC congestion control.


### PR DESCRIPTION
Adds a flag called `highbdp_mode` that changes the increase ratio.

The increase ratio of ordinary Reno is 1 mtu per round-trip (i.e. CWND being acked).

When in high-BDP mode, the CC uses exponential increase during congestion avoidance phase, where the increase rate is calculated so that it would reach the send rate at which the loss was observed every ~1 second. This is roughly equal to what Cubic does.