### PR TITLE
picocc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ SET(QUICLY_LIBRARY_FILES
     lib/frame.c
     lib/cc-reno.c
     lib/cc-cubic.c
+    lib/cc-pico.c
     lib/defaults.c
     lib/local_cid.c
     lib/loss.c

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -129,6 +129,10 @@ struct st_quicly_cc_type_t {
      */
     const char *name;
     /**
+     * Corresponding default init_cc.
+     */
+    struct st_quicly_init_cc_t *cc_init;
+    /**
      * Called when a packet is newly acknowledged.
      */
     void (*cc_on_acked)(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t largest_acked, uint32_t inflight,

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -39,31 +39,16 @@ extern "C" {
 #define QUICLY_MIN_CWND 2
 #define QUICLY_RENO_BETA 0.7
 
-typedef enum {
-    /**
-     * Reno, with 0.7 beta reduction
-     */
-    CC_RENO_MODIFIED,
-    /**
-     * CUBIC (RFC 8312)
-     */
-    CC_CUBIC,
-    /**
-     *
-     */
-    CC_PICO
-} quicly_cc_type_t;
-
 /**
  * Holds pointers to concrete congestion control implementation functions.
  */
-struct st_quicly_cc_impl_t;
+typedef const struct st_quicly_cc_type_t quicly_cc_type_t;
 
 typedef struct st_quicly_cc_t {
     /**
-     * Congestion controller implementation.
+     * Congestion controller type.
      */
-    const struct st_quicly_cc_impl_t *impl;
+    quicly_cc_type_t *type;
     /**
      * Current congestion window.
      */
@@ -138,11 +123,11 @@ typedef struct st_quicly_cc_t {
     uint32_t num_loss_episodes;
 } quicly_cc_t;
 
-struct st_quicly_cc_impl_t {
+struct st_quicly_cc_type_t {
     /**
-     * Congestion controller type.
+     * name (e.g., "reno")
      */
-    quicly_cc_type_t type;
+    const char *name;
     /**
      * Called when a packet is newly acknowledged.
      */
@@ -165,17 +150,13 @@ struct st_quicly_cc_impl_t {
 };
 
 /**
- * The factory method for the modified Reno congestion controller.
+ * The type objects for each CC. These can be used for testing the type of each `quicly_cc_t`.
  */
-extern struct st_quicly_init_cc_t quicly_cc_reno_init;
+extern quicly_cc_type_t quicly_cc_type_reno, quicly_cc_type_cubic, quicly_cc_type_pico;
 /**
- * The factory method for the Cubic congestion controller.
+ * The factory methods for each CC.
  */
-extern struct st_quicly_init_cc_t quicly_cc_cubic_init;
-/**
- * The factory method for the Pico congestion controller.
- */
-extern struct st_quicly_init_cc_t quicly_cc_pico_init;
+extern struct st_quicly_init_cc_t quicly_cc_reno_init, quicly_cc_cubic_init, quicly_cc_pico_init;
 
 /**
  * Calculates the initial congestion window size given the maximum UDP payload size.

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -44,7 +44,11 @@ typedef enum {
     /**
      * CUBIC (RFC 8312)
      */
-    CC_CUBIC
+    CC_CUBIC,
+    /**
+     *
+     */
+    CC_PICO
 } quicly_cc_type_t;
 
 /**
@@ -81,7 +85,7 @@ typedef struct st_quicly_cc_t {
              * Stash of acknowledged bytes, used during congestion avoidance.
              */
             uint32_t stash;
-        } reno;
+        } reno, pico;
         /**
          * State information for CUBIC congestion control.
          */
@@ -164,6 +168,10 @@ extern struct st_quicly_init_cc_t quicly_cc_reno_init;
  * The factory method for the modified Reno congestion controller.
  */
 extern struct st_quicly_init_cc_t quicly_cc_cubic_init;
+/**
+ * The factory method for the Pico congestion controller.
+ */
+extern struct st_quicly_init_cc_t quicly_cc_pico_init;
 
 /**
  * Calculates the initial congestion window size given the maximum UDP payload size.

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -147,6 +147,10 @@ struct st_quicly_cc_type_t {
      * Called after a packet is sent.
      */
     void (*cc_on_sent)(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, int64_t now);
+    /**
+     * Switches the underlying algorithm of `cc` to that of `cc_switch`, returning a boolean if the operation was successful.
+     */
+    int (*cc_switch)(quicly_cc_t *cc);
 };
 
 /**

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -167,6 +167,11 @@ extern quicly_cc_type_t quicly_cc_type_reno, quicly_cc_type_cubic, quicly_cc_typ
 extern struct st_quicly_init_cc_t quicly_cc_reno_init, quicly_cc_cubic_init, quicly_cc_pico_init;
 
 /**
+ * A null-terminated list of all CC types.
+ */
+extern quicly_cc_type_t *quicly_cc_all_types[];
+
+/**
  * Calculates the initial congestion window size given the maximum UDP payload size.
  */
 uint32_t quicly_cc_calc_initial_cwnd(uint32_t max_packets, uint16_t max_udp_payload_size);

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -165,7 +165,7 @@ struct st_quicly_cc_impl_t {
  */
 extern struct st_quicly_init_cc_t quicly_cc_reno_init;
 /**
- * The factory method for the modified Reno congestion controller.
+ * The factory method for the Cubic congestion controller.
  */
 extern struct st_quicly_init_cc_t quicly_cc_cubic_init;
 /**

--- a/include/quicly/defaults.h
+++ b/include/quicly/defaults.h
@@ -57,6 +57,7 @@ extern quicly_now_t quicly_default_now;
  */
 extern quicly_crypto_engine_t quicly_default_crypto_engine;
 
+#define quicly_default_cc quicly_cc_type_reno
 #define quicly_default_init_cc quicly_cc_reno_init
 
 #ifdef __cplusplus

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -157,6 +157,13 @@ static void cubic_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
     cc->state.cubic.last_sent_time = now;
 }
 
+static int cubic_on_switch(quicly_cc_t *cc)
+{
+    if (cc->type == &quicly_cc_type_cubic)
+        return 1;
+    return 0;
+}
+
 static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
 {
     memset(cc, 0, sizeof(quicly_cc_t));
@@ -165,5 +172,6 @@ static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwn
     cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
 }
 
-quicly_cc_type_t quicly_cc_type_cubic = {"cubic", cubic_on_acked, cubic_on_lost, cubic_on_persistent_congestion, cubic_on_sent};
+quicly_cc_type_t quicly_cc_type_cubic = {"cubic",       cubic_on_acked, cubic_on_lost, cubic_on_persistent_congestion,
+                                         cubic_on_sent, cubic_on_switch};
 quicly_init_cc_t quicly_cc_cubic_init = {cubic_init};

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -172,6 +172,6 @@ static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwn
     cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
 }
 
-quicly_cc_type_t quicly_cc_type_cubic = {"cubic",       cubic_on_acked, cubic_on_lost, cubic_on_persistent_congestion,
-                                         cubic_on_sent, cubic_on_switch};
+quicly_cc_type_t quicly_cc_type_cubic = {
+    "cubic", &quicly_cc_cubic_init, cubic_on_acked, cubic_on_lost, cubic_on_persistent_congestion, cubic_on_sent, cubic_on_switch};
 quicly_init_cc_t quicly_cc_cubic_init = {cubic_init};

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -157,15 +157,13 @@ static void cubic_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
     cc->state.cubic.last_sent_time = now;
 }
 
-static const struct st_quicly_cc_impl_t cubic_impl = {CC_CUBIC, cubic_on_acked, cubic_on_lost, cubic_on_persistent_congestion,
-                                                      cubic_on_sent};
-
 static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
 {
     memset(cc, 0, sizeof(quicly_cc_t));
-    cc->impl = &cubic_impl;
+    cc->type = &quicly_cc_type_cubic;
     cc->cwnd = cc->cwnd_initial = cc->cwnd_maximum = initcwnd;
     cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
 }
 
+quicly_cc_type_t quicly_cc_type_cubic = {"cubic", cubic_on_acked, cubic_on_lost, cubic_on_persistent_congestion, cubic_on_sent};
 quicly_init_cc_t quicly_cc_cubic_init = {cubic_init};

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -70,12 +70,24 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
         cc->cwnd_maximum = cc->cwnd;
 }
 
+static int pico_on_switch(quicly_cc_t *cc)
+{
+    if (cc->type == &quicly_cc_type_pico) {
+        return 1; /* nothing to do */
+    } else if (cc->type == &quicly_cc_type_reno) {
+        cc->type = &quicly_cc_type_pico;
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
 static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
 {
     quicly_cc_reno_init.cb(&quicly_cc_reno_init, cc, initcwnd, now);
     cc->type = &quicly_cc_type_pico;
 }
 
-quicly_cc_type_t quicly_cc_type_pico = {"pico", pico_on_acked, quicly_cc_reno_on_lost, quicly_cc_reno_on_persistent_congestion,
-                                        quicly_cc_reno_on_sent};
+quicly_cc_type_t quicly_cc_type_pico = {
+    "pico", pico_on_acked, quicly_cc_reno_on_lost, quicly_cc_reno_on_persistent_congestion, quicly_cc_reno_on_sent, pico_on_switch};
 quicly_init_cc_t quicly_cc_pico_init = {pico_init};

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -70,13 +70,12 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
         cc->cwnd_maximum = cc->cwnd;
 }
 
-static const struct st_quicly_cc_impl_t pico_impl = {CC_PICO, pico_on_acked, quicly_cc_reno_on_lost,
-                                                     quicly_cc_reno_on_persistent_congestion, quicly_cc_reno_on_sent};
-
 static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
 {
     quicly_cc_reno_init.cb(&quicly_cc_reno_init, cc, initcwnd, now);
-    cc->impl = &pico_impl;
+    cc->type = &quicly_cc_type_pico;
 }
 
+quicly_cc_type_t quicly_cc_type_pico = {"pico", pico_on_acked, quicly_cc_reno_on_lost, quicly_cc_reno_on_persistent_congestion,
+                                        quicly_cc_reno_on_sent};
 quicly_init_cc_t quicly_cc_pico_init = {pico_init};

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Fastly, Janardhan Iyengar, Kazuho Oku
+ * Copyright (c) 2021 Fastly, Kazuho Oku
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -22,19 +22,18 @@
 #include "quicly/cc.h"
 #include "quicly.h"
 
-#define QUICLY_MIN_CWND 2
-#define QUICLY_PICO_BETA 0.5
 #define QUICLY_PICO_RECOVERY_PERIOD 1000 /* in milliseconds */
 
 static uint32_t calc_bytes_per_mtu_increase(uint32_t cwnd, uint32_t ssthresh, uint32_t rtt, uint32_t mtu)
 {
     /* Increase per byte acked is the sum of 1mtu/cwnd (additive part) and ... */
     double increase_per_byte = (double)mtu / cwnd;
-    /* ... multiplicative part being 1 during slow start, and the RTT-compensated rate for recovery within QUICLY_PICO_RECOVERY_PERIOD during congestion avoidance. */
+    /* ... multiplicative part being 1 during slow start, and the RTT-compensated rate for recovery within
+     * QUICLY_PICO_RECOVERY_PERIOD during congestion avoidance. */
     if (cwnd < ssthresh) {
         increase_per_byte += 1;
     } else {
-        increase_per_byte += (1 / QUICLY_PICO_BETA - 1) / QUICLY_PICO_RECOVERY_PERIOD * rtt;
+        increase_per_byte += (1 / QUICLY_RENO_BETA - 1) / QUICLY_PICO_RECOVERY_PERIOD * rtt;
     }
 
     return (uint32_t)(mtu / increase_per_byte);
@@ -50,65 +49,31 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
     if (largest_acked < cc->recovery_end)
         return;
 
-    cc->state.pico.stash += bytes;
+    cc->state.reno.stash += bytes;
 
     /* Calculate the amount of bytes required to be acked for incrementing CWND by one MTU. */
     uint32_t bytes_per_mtu_increase = calc_bytes_per_mtu_increase(cc->cwnd, cc->ssthresh, loss->rtt.smoothed, max_udp_payload_size);
 
     /* Bail out if we do not yet have enough bytes being acked. */
-    if (cc->state.pico.stash < bytes_per_mtu_increase)
+    if (cc->state.reno.stash < bytes_per_mtu_increase)
         return;
 
     /* Update CWND, reducing stash relative to the amount we've adjusted the CWND */
-    uint32_t count = cc->state.pico.stash / bytes_per_mtu_increase;
+    uint32_t count = cc->state.reno.stash / bytes_per_mtu_increase;
     cc->cwnd += count * max_udp_payload_size;
-    cc->state.pico.stash -= count * bytes_per_mtu_increase;
+    cc->state.reno.stash -= count * bytes_per_mtu_increase;
 
     if (cc->cwnd_maximum < cc->cwnd)
         cc->cwnd_maximum = cc->cwnd;
 }
 
-static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn,
-                         int64_t now, uint32_t max_udp_payload_size)
-{
-    /* Nothing to do if loss is in recovery window. */
-    if (lost_pn < cc->recovery_end)
-        return;
-    cc->recovery_end = next_pn;
-
-    ++cc->num_loss_episodes;
-    if (cc->cwnd_exiting_slow_start == 0)
-        cc->cwnd_exiting_slow_start = cc->cwnd;
-
-    /* Reduce congestion window. */
-    cc->cwnd *= QUICLY_PICO_BETA;
-    if (cc->cwnd < QUICLY_MIN_CWND * max_udp_payload_size)
-        cc->cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
-    cc->ssthresh = cc->cwnd;
-
-    if (cc->cwnd_minimum > cc->cwnd)
-        cc->cwnd_minimum = cc->cwnd;
-}
-
-static void pico_on_persistent_congestion(quicly_cc_t *cc, const quicly_loss_t *loss, int64_t now)
-{
-    /* TODO */
-}
-
-static void pico_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, int64_t now)
-{
-    /* Unused */
-}
-
-static const struct st_quicly_cc_impl_t pico_impl = {CC_PICO, pico_on_acked, pico_on_lost, pico_on_persistent_congestion,
-                                                     pico_on_sent};
+static const struct st_quicly_cc_impl_t pico_impl = {CC_PICO, pico_on_acked, quicly_cc_reno_on_lost,
+                                                     quicly_cc_reno_on_persistent_congestion, quicly_cc_reno_on_sent};
 
 static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
 {
-    memset(cc, 0, sizeof(quicly_cc_t));
+    quicly_cc_reno_init.cb(&quicly_cc_reno_init, cc, initcwnd, now);
     cc->impl = &pico_impl;
-    cc->cwnd = cc->cwnd_initial = cc->cwnd_maximum = initcwnd;
-    cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
 }
 
 quicly_init_cc_t quicly_cc_pico_init = {pico_init};

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2019-2021 Fastly, Janardhan Iyengar, Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "quicly/cc.h"
+#include "quicly.h"
+
+#define QUICLY_MIN_CWND 2
+#define QUICLY_PICO_BETA 0.5
+#define QUICLY_PICO_RECOVERY_PERIOD 1000 /* in milliseconds */
+
+static uint32_t calc_bytes_per_mtu_increase(uint32_t cwnd, uint32_t ssthresh, uint32_t rtt, uint32_t mtu)
+{
+    /* Increase per byte acked is the sum of 1mtu/cwnd (additive part) and ... */
+    double increase_per_byte = (double)mtu / cwnd;
+    /* ... multiplicative part being 1 during slow start, or (1/beta - 1) * RTT during congestion avoidance. */
+    if (cwnd < ssthresh) {
+        increase_per_byte += 1;
+    } else {
+        increase_per_byte += (1 / QUICLY_PICO_BETA - 1) / QUICLY_PICO_RECOVERY_PERIOD * rtt;
+    }
+
+    return (uint32_t)(mtu / increase_per_byte);
+}
+
+/* TODO: Avoid increase if sender was application limited. */
+static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t largest_acked, uint32_t inflight,
+                          int64_t now, uint32_t max_udp_payload_size)
+{
+    assert(inflight >= bytes);
+
+    /* Do not increase congestion window while in recovery. */
+    if (largest_acked < cc->recovery_end)
+        return;
+
+    cc->state.pico.stash += bytes;
+
+    /* Calculate the amount of bytes required to be acked for incrementing CWND by one MTU. */
+    uint32_t bytes_per_mtu_increase = calc_bytes_per_mtu_increase(cc->cwnd, cc->ssthresh, loss->rtt.smoothed, max_udp_payload_size);
+
+    /* Bail out if we do not yet have enough bytes being acked. */
+    if (cc->state.pico.stash < bytes_per_mtu_increase)
+        return;
+
+    /* Update CWND, reducing stash relative to the amount we've adjusted the CWND */
+    uint32_t count = cc->state.pico.stash / bytes_per_mtu_increase;
+    cc->cwnd += count * max_udp_payload_size;
+    cc->state.pico.stash -= count * bytes_per_mtu_increase;
+
+    if (cc->cwnd_maximum < cc->cwnd)
+        cc->cwnd_maximum = cc->cwnd;
+}
+
+static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn,
+                         int64_t now, uint32_t max_udp_payload_size)
+{
+    /* Nothing to do if loss is in recovery window. */
+    if (lost_pn < cc->recovery_end)
+        return;
+    cc->recovery_end = next_pn;
+
+    ++cc->num_loss_episodes;
+    if (cc->cwnd_exiting_slow_start == 0)
+        cc->cwnd_exiting_slow_start = cc->cwnd;
+
+    /* Reduce congestion window. */
+    cc->cwnd *= QUICLY_PICO_BETA;
+    if (cc->cwnd < QUICLY_MIN_CWND * max_udp_payload_size)
+        cc->cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
+    cc->ssthresh = cc->cwnd;
+
+    if (cc->cwnd_minimum > cc->cwnd)
+        cc->cwnd_minimum = cc->cwnd;
+}
+
+static void pico_on_persistent_congestion(quicly_cc_t *cc, const quicly_loss_t *loss, int64_t now)
+{
+    /* TODO */
+}
+
+static void pico_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, int64_t now)
+{
+    /* Unused */
+}
+
+static const struct st_quicly_cc_impl_t pico_impl = {CC_PICO, pico_on_acked, pico_on_lost, pico_on_persistent_congestion,
+                                                     pico_on_sent};
+
+static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
+{
+    memset(cc, 0, sizeof(quicly_cc_t));
+    cc->impl = &pico_impl;
+    cc->cwnd = cc->cwnd_initial = cc->cwnd_maximum = initcwnd;
+    cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
+}
+
+quicly_init_cc_t quicly_cc_pico_init = {pico_init};

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -30,7 +30,7 @@ static uint32_t calc_bytes_per_mtu_increase(uint32_t cwnd, uint32_t ssthresh, ui
 {
     /* Increase per byte acked is the sum of 1mtu/cwnd (additive part) and ... */
     double increase_per_byte = (double)mtu / cwnd;
-    /* ... multiplicative part being 1 during slow start, or (1/beta - 1) * RTT during congestion avoidance. */
+    /* ... multiplicative part being 1 during slow start, and the RTT-compensated rate for recovery within QUICLY_PICO_RECOVERY_PERIOD during congestion avoidance. */
     if (cwnd < ssthresh) {
         increase_per_byte += 1;
     } else {

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -84,10 +84,15 @@ static int pico_on_switch(quicly_cc_t *cc)
 
 static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
 {
-    quicly_cc_reno_init.cb(&quicly_cc_reno_init, cc, initcwnd, now);
+    quicly_cc_type_reno.cc_init->cb(quicly_cc_type_reno.cc_init, cc, initcwnd, now);
     cc->type = &quicly_cc_type_pico;
 }
 
-quicly_cc_type_t quicly_cc_type_pico = {
-    "pico", pico_on_acked, quicly_cc_reno_on_lost, quicly_cc_reno_on_persistent_congestion, quicly_cc_reno_on_sent, pico_on_switch};
+quicly_cc_type_t quicly_cc_type_pico = {"pico",
+                                        &quicly_cc_pico_init,
+                                        pico_on_acked,
+                                        quicly_cc_reno_on_lost,
+                                        quicly_cc_reno_on_persistent_congestion,
+                                        quicly_cc_reno_on_sent,
+                                        pico_on_switch};
 quicly_init_cc_t quicly_cc_pico_init = {pico_init};

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -82,17 +82,16 @@ void quicly_cc_reno_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t
     /* Unused */
 }
 
-static const struct st_quicly_cc_impl_t reno_impl = {CC_RENO_MODIFIED, reno_on_acked, quicly_cc_reno_on_lost,
-                                                     quicly_cc_reno_on_persistent_congestion, quicly_cc_reno_on_sent};
-
 static void reno_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
 {
     memset(cc, 0, sizeof(quicly_cc_t));
-    cc->impl = &reno_impl;
+    cc->type = &quicly_cc_type_reno;
     cc->cwnd = cc->cwnd_initial = cc->cwnd_maximum = initcwnd;
     cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
 }
 
+quicly_cc_type_t quicly_cc_type_reno = {"reno", reno_on_acked, quicly_cc_reno_on_lost, quicly_cc_reno_on_persistent_congestion,
+                                        quicly_cc_reno_on_sent};
 quicly_init_cc_t quicly_cc_reno_init = {reno_init};
 
 uint32_t quicly_cc_calc_initial_cwnd(uint32_t max_packets, uint16_t max_udp_payload_size)

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -82,6 +82,18 @@ void quicly_cc_reno_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t
     /* Unused */
 }
 
+static int reno_on_switch(quicly_cc_t *cc)
+{
+    if (cc->type == &quicly_cc_type_reno) {
+        return 1; /* nothing to do */
+    } else if (cc->type == &quicly_cc_type_pico) {
+        cc->type = &quicly_cc_type_reno;
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
 static void reno_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
 {
     memset(cc, 0, sizeof(quicly_cc_t));
@@ -90,8 +102,8 @@ static void reno_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd
     cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
 }
 
-quicly_cc_type_t quicly_cc_type_reno = {"reno", reno_on_acked, quicly_cc_reno_on_lost, quicly_cc_reno_on_persistent_congestion,
-                                        quicly_cc_reno_on_sent};
+quicly_cc_type_t quicly_cc_type_reno = {
+    "reno", reno_on_acked, quicly_cc_reno_on_lost, quicly_cc_reno_on_persistent_congestion, quicly_cc_reno_on_sent, reno_on_switch};
 quicly_init_cc_t quicly_cc_reno_init = {reno_init};
 
 uint32_t quicly_cc_calc_initial_cwnd(uint32_t max_packets, uint16_t max_udp_payload_size)

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -111,6 +111,8 @@ quicly_cc_type_t quicly_cc_type_reno = {"reno",
                                         reno_on_switch};
 quicly_init_cc_t quicly_cc_reno_init = {reno_init};
 
+quicly_cc_type_t *quicly_cc_all_types[] = {&quicly_cc_type_reno, &quicly_cc_type_cubic, &quicly_cc_type_pico, NULL};
+
 uint32_t quicly_cc_calc_initial_cwnd(uint32_t max_packets, uint16_t max_udp_payload_size)
 {
     static const uint32_t mtu_max = 1472;

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -22,9 +22,6 @@
 #include "quicly/cc.h"
 #include "quicly.h"
 
-#define QUICLY_MIN_CWND 2
-#define QUICLY_RENO_BETA 0.7
-
 /* TODO: Avoid increase if sender was application limited. */
 static void reno_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t largest_acked, uint32_t inflight,
                           int64_t now, uint32_t max_udp_payload_size)
@@ -53,8 +50,8 @@ static void reno_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
         cc->cwnd_maximum = cc->cwnd;
 }
 
-static void reno_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn,
-                         int64_t now, uint32_t max_udp_payload_size)
+void quicly_cc_reno_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn,
+                            int64_t now, uint32_t max_udp_payload_size)
 {
     /* Nothing to do if loss is in recovery window. */
     if (lost_pn < cc->recovery_end)
@@ -75,18 +72,18 @@ static void reno_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
         cc->cwnd_minimum = cc->cwnd;
 }
 
-static void reno_on_persistent_congestion(quicly_cc_t *cc, const quicly_loss_t *loss, int64_t now)
+void quicly_cc_reno_on_persistent_congestion(quicly_cc_t *cc, const quicly_loss_t *loss, int64_t now)
 {
     /* TODO */
 }
 
-static void reno_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, int64_t now)
+void quicly_cc_reno_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, int64_t now)
 {
     /* Unused */
 }
 
-static const struct st_quicly_cc_impl_t reno_impl = {CC_RENO_MODIFIED, reno_on_acked, reno_on_lost, reno_on_persistent_congestion,
-                                                     reno_on_sent};
+static const struct st_quicly_cc_impl_t reno_impl = {CC_RENO_MODIFIED, reno_on_acked, quicly_cc_reno_on_lost,
+                                                     quicly_cc_reno_on_persistent_congestion, quicly_cc_reno_on_sent};
 
 static void reno_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
 {

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -102,8 +102,13 @@ static void reno_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd
     cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
 }
 
-quicly_cc_type_t quicly_cc_type_reno = {
-    "reno", reno_on_acked, quicly_cc_reno_on_lost, quicly_cc_reno_on_persistent_congestion, quicly_cc_reno_on_sent, reno_on_switch};
+quicly_cc_type_t quicly_cc_type_reno = {"reno",
+                                        &quicly_cc_reno_init,
+                                        reno_on_acked,
+                                        quicly_cc_reno_on_lost,
+                                        quicly_cc_reno_on_persistent_congestion,
+                                        quicly_cc_reno_on_sent,
+                                        reno_on_switch};
 quicly_init_cc_t quicly_cc_reno_init = {reno_init};
 
 uint32_t quicly_cc_calc_initial_cwnd(uint32_t max_packets, uint16_t max_udp_payload_size)

--- a/quicly.xcodeproj/project.pbxproj
+++ b/quicly.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		082195082683498900E3EFCF /* cc-pico.c in Sources */ = {isa = PBXBuildFile; fileRef = 082195072683498900E3EFCF /* cc-pico.c */; };
+		082195092683498900E3EFCF /* cc-pico.c in Sources */ = {isa = PBXBuildFile; fileRef = 082195072683498900E3EFCF /* cc-pico.c */; };
+		0821950A2683498900E3EFCF /* cc-pico.c in Sources */ = {isa = PBXBuildFile; fileRef = 082195072683498900E3EFCF /* cc-pico.c */; };
 		E904233D24AED0410072C5B7 /* loss.c in Sources */ = {isa = PBXBuildFile; fileRef = E904233C24AED0410072C5B7 /* loss.c */; };
 		E904233E24AED0410072C5B7 /* loss.c in Sources */ = {isa = PBXBuildFile; fileRef = E904233C24AED0410072C5B7 /* loss.c */; };
 		E904233F24AED0410072C5B7 /* loss.c in Sources */ = {isa = PBXBuildFile; fileRef = E904233C24AED0410072C5B7 /* loss.c */; };
@@ -141,6 +144,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		082195072683498900E3EFCF /* cc-pico.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "cc-pico.c"; sourceTree = "<group>"; };
 		E904233C24AED0410072C5B7 /* loss.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = loss.c; sourceTree = "<group>"; };
 		E904234024AEFB980072C5B7 /* loss.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = loss.c; sourceTree = "<group>"; };
 		E9056C071F56965300E2B96C /* linklist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = linklist.h; sourceTree = "<group>"; };
@@ -324,6 +328,7 @@
 			isa = PBXGroup;
 			children = (
 				E9DF012324E4BAC20002EEC7 /* cc-cubic.c */,
+				082195072683498900E3EFCF /* cc-pico.c */,
 				E98041C522383C62008B9745 /* cc-reno.c */,
 				E9736527246FD3AC0039AA49 /* remote_cid.c */,
 				E98042352244A5D7008B9745 /* defaults.c */,
@@ -698,6 +703,7 @@
 				E98042362244A5D7008B9745 /* defaults.c in Sources */,
 				E904233D24AED0410072C5B7 /* loss.c in Sources */,
 				E9F6A42E1F41375B0083F0B2 /* sendstate.c in Sources */,
+				082195082683498900E3EFCF /* cc-pico.c in Sources */,
 				E99F8C261F4E9EBF00C26B3D /* frame.c in Sources */,
 				E98448421EA490A500390927 /* quicly.c in Sources */,
 				E9DF012424E4BAC20002EEC7 /* cc-cubic.c in Sources */,
@@ -721,6 +727,7 @@
 				E984483B1EA48DD300390927 /* openssl.c in Sources */,
 				E973652E246FD3B40039AA49 /* remote_cid.c in Sources */,
 				E904233E24AED0410072C5B7 /* loss.c in Sources */,
+				082195092683498900E3EFCF /* cc-pico.c in Sources */,
 				E941428D23B0B839002D3CE0 /* frame.c in Sources */,
 				E941429123B0B86D002D3CE0 /* recvstate.c in Sources */,
 				E9B43E12246943D300824E51 /* fusion.c in Sources */,
@@ -771,6 +778,7 @@
 				E99B75E91F5D259400CF503E /* stream-concurrency.c in Sources */,
 				E920D22E1F4981E500799777 /* sentmap.c in Sources */,
 				E9CC44261EC1963100DC7D3E /* picotest.c in Sources */,
+				0821950A2683498900E3EFCF /* cc-pico.c in Sources */,
 				E95E953D22904A4C00215ACD /* picotls-probes.d in Sources */,
 				E9CC441C1EC195DF00DC7D3E /* picotls.c in Sources */,
 				E904233F24AED0410072C5B7 /* loss.c in Sources */,

--- a/src/cli.c
+++ b/src/cli.c
@@ -1110,18 +1110,19 @@ int main(int argc, char **argv)
         case 'c':
             cert_file = optarg;
             break;
-        case 'C':
-            if (strcmp(optarg, "reno") == 0) {
-                ctx.init_cc = &quicly_cc_reno_init;
-            } else if (strcmp(optarg, "cubic") == 0) {
-                ctx.init_cc = &quicly_cc_cubic_init;
-            } else if (strcmp(optarg, "pico") == 0) {
-                ctx.init_cc = &quicly_cc_pico_init;
+        case 'C': {
+            static const quicly_cc_type_t *supported[] = {&quicly_cc_type_reno, &quicly_cc_type_cubic, &quicly_cc_type_pico, NULL};
+            quicly_cc_type_t **found;
+            for (found = supported; *found != NULL; found++)
+                if (strcmp((*found)->name, optarg) == 0)
+                    break;
+            if (*found != NULL) {
+                ctx.init_cc = (*found)->cc_init;
             } else {
                 fprintf(stderr, "unknown congestion controller: %s\n", optarg);
                 exit(1);
             }
-            break;
+        } break;
         case 'G':
 #ifdef __linux__
             send_packets = send_packets_gso;

--- a/src/cli.c
+++ b/src/cli.c
@@ -1111,13 +1111,12 @@ int main(int argc, char **argv)
             cert_file = optarg;
             break;
         case 'C': {
-            static const quicly_cc_type_t *supported[] = {&quicly_cc_type_reno, &quicly_cc_type_cubic, &quicly_cc_type_pico, NULL};
-            quicly_cc_type_t **found;
-            for (found = supported; *found != NULL; found++)
-                if (strcmp((*found)->name, optarg) == 0)
+            quicly_cc_type_t **cc;
+            for (cc = quicly_cc_all_types; *cc != NULL; ++cc)
+                if (strcmp((*cc)->name, optarg) == 0)
                     break;
-            if (*found != NULL) {
-                ctx.init_cc = (*found)->cc_init;
+            if (*cc != NULL) {
+                ctx.init_cc = (*cc)->cc_init;
             } else {
                 fprintf(stderr, "unknown congestion controller: %s\n", optarg);
                 exit(1);

--- a/src/cli.c
+++ b/src/cli.c
@@ -1015,7 +1015,7 @@ static void usage(const char *cmd)
            "  -k key-file               specifies the credentials to be used for running the\n"
            "                            server. If omitted, the command runs as a client.\n"
            "  -C <algorithm>            the congestion control algorithm; either \"reno\"\n"
-           "                            (default) or \"cubic\"\n"
+           "                            (default), \"cubic\", or \"pico\"\n"
            "  -d draft-number           specifies the draft version number to be used (e.g.,\n"
            "                            29)\n"
            "  -e event-log-file         file to log events\n"
@@ -1115,6 +1115,8 @@ int main(int argc, char **argv)
                 ctx.init_cc = &quicly_cc_reno_init;
             } else if (strcmp(optarg, "cubic") == 0) {
                 ctx.init_cc = &quicly_cc_cubic_init;
+            } else if (strcmp(optarg, "pico") == 0) {
+                ctx.init_cc = &quicly_cc_pico_init;
             } else {
                 fprintf(stderr, "unknown congestion controller: %s\n", optarg);
                 exit(1);


### PR DESCRIPTION
This is a tiny CC which is a conceptual purification of #469.

The algorithm is dead simple: increase per every byte being acked is calculated as `1mtu/cwnd + (is_slow_start ? 1 : (1/beta -1) * rtt)`. Beta is 0.5.

The only mode that we have is the `is_slow_start` flag, that only changes the multiplicative coefficient. There's nothing like choosing a better value from two.

Regarding the formula, `1mtu/cwnd` is the increase ratio of traditional Reno during congestion avoidance phase. `(1/beta - 1) * rtt` is the exponential increase used during the congestion avoidance phase in the highbdp reno variant; for details, see #469.

The key observations regarding this CC are:
* For convergence, use an increase policy that has an additive component and an multiplicative component, as suggested by the [Chiu & Jain paper in 1989](https://www.cse.wustl.edu/~jain/papers/ftp/cong_av.pdf) (see proposition 1 on p.9).
* During congestion avoidance, when the recovery period of traditional Reno (that is proportional to flow_rate * RTT<sup>2</sup>) is small, we do slightly better than traditional Reno, because in addition to doing the addtive increase, the "base" being the multiplicative part shoots up by 2x within 0.4~1 second.
* During congestion avoidance, when the recovery period of traditional Reno is large, we do much better than traditional Reno, because thanks to the multiplicative part, we shoot up to the original rate within 1 second, provided that the RTT is below 1 second.
* During slow start, the CWND is increased by 2x + 1 per round-trip, as the paper says that we should have an additive component. Though we can remove it if we want to do what Reno / Cubic has done.

Compared to our Reno that uses beta 0.7, this CC is superior in sense that:
* When the recovery period is small, it is not as aggressive as our Reno. The problem with our Reno is that it is overaggressive compared to ordinary Reno or linux's implementation of Cubic that essentially falls back to Reno when the recovery period is small (am I correct, @janaiyenger?).
* When the recovery period is big, it is more agressive than our Reno due to the same reasons as high-bdp Reno (#469).

Compared to high-bdp Reno (#469), this CC is superior in sense that:
* It follows the recommendation by the paper.
* There's no logic like picking the more aggressive increase value among the two during congestion avoidance.