### PR TITLE
Support switching CCs to/from Cubic

### DIFF
--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -157,19 +157,35 @@ static void cubic_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
     cc->state.cubic.last_sent_time = now;
 }
 
-static int cubic_on_switch(quicly_cc_t *cc)
-{
-    if (cc->type == &quicly_cc_type_cubic)
-        return 1;
-    return 0;
-}
-
-static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
+static void cubic_reset(quicly_cc_t *cc, uint32_t initcwnd)
 {
     memset(cc, 0, sizeof(quicly_cc_t));
     cc->type = &quicly_cc_type_cubic;
     cc->cwnd = cc->cwnd_initial = cc->cwnd_maximum = initcwnd;
     cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
+}
+
+static int cubic_on_switch(quicly_cc_t *cc)
+{
+    if (cc->type == &quicly_cc_type_cubic)
+        return 1;
+
+    if (cc->type == &quicly_cc_type_reno || cc->type == &quicly_cc_type_pico) {
+        /* When in slow start, state can be reused as-is; otherwise, restart. */
+        if (cc->cwnd_exiting_slow_start == 0) {
+            cc->type = &quicly_cc_type_cubic;
+        } else {
+            cubic_reset(cc, cc->cwnd_initial);
+        }
+        return 1;
+    }
+
+    return 0;
+}
+
+static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
+{
+    cubic_reset(cc, initcwnd);
 }
 
 quicly_cc_type_t quicly_cc_type_cubic = {

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -72,14 +72,11 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
 
 static int pico_on_switch(quicly_cc_t *cc)
 {
-    if (cc->type == &quicly_cc_type_pico) {
-        return 1; /* nothing to do */
-    } else if (cc->type == &quicly_cc_type_reno) {
-        cc->type = &quicly_cc_type_pico;
-        return 1;
-    } else {
+    /* switch to reno then rewrite the type */
+    if (!quicly_cc_type_reno.cc_switch(cc))
         return 0;
-    }
+    cc->type = &quicly_cc_type_pico;
+    return 1;
 }
 
 static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)


### PR DESCRIPTION
Works perfectly during slow start. OTOH, when in congestion avoidance, we restart the CC.

I tend to believe that this approach would be sufficient for switching CCs at the beginning of the connection when receiving SNI. 

@janaiyengar thoughts?