### PR TITLE
use full-sized datagrams when sending PATH_CHALLENGE / PATH_RESPONSE

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2933,7 +2933,14 @@ struct st_quicly_send_context_t {
          * contains multiple QUIC packet.
          */
         uint8_t *first_byte_at;
+        /**
+         * if the target QUIC packet contains an ack-eliciting frame
+         */
         uint8_t ack_eliciting : 1;
+        /**
+         * if the target datagram sholud be padded to full size
+         */
+        uint8_t full_size : 1;
     } target;
     /**
      * output buffer into which list of datagrams is written
@@ -2979,13 +2986,7 @@ struct st_quicly_send_context_t {
     uint8_t *dst_payload_from;
 };
 
-enum en_quicly_send_packet_mode_t {
-    QUICLY_COMMIT_SEND_PACKET_MODE_FULL_SIZE,
-    QUICLY_COMMIT_SEND_PACKET_MODE_SMALL,
-    QUICLY_COMMIT_SEND_PACKET_MODE_COALESCED,
-};
-
-static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, enum en_quicly_send_packet_mode_t mode)
+static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, int coalesced)
 {
     size_t datagram_size, packet_bytes_in_flight;
 
@@ -2997,7 +2998,7 @@ static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, enu
     while (s->dst - s->dst_payload_from < QUICLY_MAX_PN_SIZE - QUICLY_SEND_PN_SIZE)
         *s->dst++ = QUICLY_FRAME_TYPE_PADDING;
 
-    if (mode == QUICLY_COMMIT_SEND_PACKET_MODE_FULL_SIZE) {
+    if (!coalesced && s->target.full_size) {
         assert(s->num_datagrams == 0 || s->datagrams[s->num_datagrams - 1].iov_len == conn->egress.max_udp_payload_size);
         const size_t max_size = conn->egress.max_udp_payload_size - QUICLY_AEAD_TAG_SIZE;
         assert(s->dst - s->payload_buf.datagram <= max_size);
@@ -3031,7 +3032,7 @@ static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, enu
                                                    s->target.cipher->aead, ptls_iovec_init(s->payload_buf.datagram, datagram_size),
                                                    s->target.first_byte_at - s->payload_buf.datagram,
                                                    s->dst_payload_from - s->payload_buf.datagram, conn->egress.packet_number,
-                                                   mode == QUICLY_COMMIT_SEND_PACKET_MODE_COALESCED);
+                                                   coalesced);
 
     /* update CC, commit sentmap */
     if (s->target.ack_eliciting) {
@@ -3050,7 +3051,7 @@ static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, enu
     ++conn->egress.packet_number;
     ++conn->super.stats.num_packets.sent;
 
-    if (mode != QUICLY_COMMIT_SEND_PACKET_MODE_COALESCED) {
+    if (!coalesced) {
         conn->super.stats.num_bytes.sent += datagram_size;
         s->datagrams[s->num_datagrams++] = (struct iovec){.iov_base = s->payload_buf.datagram, .iov_len = datagram_size};
         s->payload_buf.datagram += datagram_size;
@@ -3120,8 +3121,7 @@ static int _do_allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, siz
                 coalescible = 0;
         }
         /* close out packet under construction */
-        if ((ret = commit_send_packet(
-                 conn, s, coalescible ? QUICLY_COMMIT_SEND_PACKET_MODE_COALESCED : QUICLY_COMMIT_SEND_PACKET_MODE_FULL_SIZE)) != 0)
+        if ((ret = commit_send_packet(conn, s, coalescible)) != 0)
             return ret;
     } else {
         coalescible = 0;
@@ -3140,6 +3140,7 @@ static int _do_allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, siz
         if (s->payload_buf.end - s->payload_buf.datagram < conn->egress.max_udp_payload_size)
             return QUICLY_ERROR_SENDBUF_FULL;
         s->target.cipher = s->current.cipher;
+        s->target.full_size = 0;
         s->dst = s->payload_buf.datagram;
         s->dst_end = s->dst + conn->egress.max_udp_payload_size;
     }
@@ -3260,7 +3261,8 @@ Emit: /* emit an ACK frame */
             assert(s->target.first_byte_at != s->payload_buf.datagram);
             *s->dst++ = QUICLY_FRAME_TYPE_PADDING;
         }
-        if ((ret = commit_send_packet(conn, s, QUICLY_COMMIT_SEND_PACKET_MODE_FULL_SIZE)) != 0)
+        s->target.full_size = 1;
+        if ((ret = commit_send_packet(conn, s, 0)) != 0)
             return ret;
         goto Emit;
     }
@@ -4381,11 +4383,10 @@ Exit:
         ret = 0;
     if (ret == 0 && s->target.first_byte_at != NULL) {
         /* last packet can be small-sized, unless it is the first flight sent from the client */
-        enum en_quicly_send_packet_mode_t commit_mode = QUICLY_COMMIT_SEND_PACKET_MODE_SMALL;
         if ((s->payload_buf.datagram[0] & QUICLY_PACKET_TYPE_BITMASK) == QUICLY_PACKET_TYPE_INITIAL &&
             (quicly_is_client(conn) || !ack_only))
-            commit_mode = QUICLY_COMMIT_SEND_PACKET_MODE_FULL_SIZE;
-        commit_send_packet(conn, s, commit_mode);
+            s->target.full_size = 1;
+        commit_send_packet(conn, s, 0);
     }
     if (ret == 0) {
         if (conn->application == NULL || conn->application->super.unacked_count == 0)
@@ -4449,7 +4450,7 @@ int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *s
                 if ((ret = send_connection_close(conn, epoch, &s)) != 0)
                     goto Exit;
             }
-            if ((ret = commit_send_packet(conn, &s, QUICLY_COMMIT_SEND_PACKET_MODE_SMALL)) != 0)
+            if ((ret = commit_send_packet(conn, &s, 0)) != 0)
                 goto Exit;
         }
         /* wait at least 1ms */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4310,6 +4310,7 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
                         free(c);
                     } while (conn->egress.path_challenge.head != NULL);
                     conn->egress.path_challenge.tail_ref = &conn->egress.path_challenge.head;
+                    s->target.full_size = 1; /* datagrams carrying PATH_CHALLENGE / PATH_RESPONSE have to be full-sized */
                 }
                 /* send max_streams frames */
                 if ((ret = send_max_streams(conn, 1, s)) != 0)


### PR DESCRIPTION
This is the requirement that when in very late during the standardization process; see https://github.com/quicwg/base-drafts/pull/4241.

The PR accommodates the requirement by adding a flag to indicate if the _datagram_ being built has to be fully padded.

Previously, we've been determining if a datagram has be fully padded by consulting the type of the first packet in the datagram when `commit_packet` is called. But now that frames contained in the QUIC packets trigger the requirement (to pad), we need a flag.

Note: as stated in the document, receivers of these frames cannot enforce the padding requirement. Hence the change is only on the sender side.