### PR TITLE
Implement quicly_stats_t.num_bytes.lost, quicly_stats_t.num_bytes.stream_data_sent, quicly_stats_t.num_bytes.stream_data_resent

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -440,11 +440,11 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t lost;                                                                                                             \
         /**                                                                                                                        \
-         * Total STREAM_DATA bytes sent                                                                                            \
+         * Total amount of stream-level payload being sent                                                                         \
          */                                                                                                                        \
         uint64_t stream_data_sent;                                                                                                 \
         /**                                                                                                                        \
-         * Total STREAM_DATA bytes resent                                                                                          \
+         * Total amount of stream-level payload being resent                                                                       \
          */                                                                                                                        \
         uint64_t stream_data_resent;                                                                                               \
     } num_bytes;                                                                                                                   \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -440,13 +440,13 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t lost;                                                                                                             \
         /**                                                                                                                        \
-         * Bytes lost but pending to be resent, at UDP datagram-level.                                                             \
+         * Total STREAM_DATA bytes sent                                                                                            \
          */                                                                                                                        \
-        uint64_t lost_pending;                                                                                                     \
+        uint64_t stream_data_sent;                                                                                                 \
         /**                                                                                                                        \
-         * Total bytes resent, at UDP datagram-level.                                                                              \
+         * Total STREAM_DATA bytes resent                                                                                          \
          */                                                                                                                        \
-        uint64_t resent;                                                                                                           \
+        uint64_t stream_data_resent;                                                                                               \
     } num_bytes;                                                                                                                   \
     /**                                                                                                                            \
      * Total number of each frame being sent / received.                                                                           \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -435,6 +435,18 @@ struct st_quicly_conn_streamgroup_state_t {
          * Total bytes sent, at UDP datagram-level.                                                                                \
          */                                                                                                                        \
         uint64_t sent;                                                                                                             \
+        /**                                                                                                                        \
+         * Total bytes sent but lost, at UDP datagram-level.                                                                       \
+         */                                                                                                                        \
+        uint64_t lost;                                                                                                             \
+        /**                                                                                                                        \
+         * Bytes lost but pending to be resent, at UDP datagram-level.                                                             \
+         */                                                                                                                        \
+        uint64_t lost_pending;                                                                                                     \
+        /**                                                                                                                        \
+         * Total bytes resent, at UDP datagram-level.                                                                              \
+         */                                                                                                                        \
+        uint64_t resent;                                                                                                           \
     } num_bytes;                                                                                                                   \
     /**                                                                                                                            \
      * Total number of each frame being sent / received.                                                                           \

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -104,8 +104,6 @@ KHASH_MAP_INIT_INT64(quicly_stream_t, quicly_stream_t *)
         quicly_escape_unsafe_string(alloca(_l * 4 + 1), (s), _l);                                                                  \
     })
 
-# define QUICLY_MIN(x, y) ((x) < (y) ? (x) : (y))
-
 struct st_quicly_cipher_context_t {
     ptls_aead_context_t *aead;
     ptls_cipher_context_t *header_protection;
@@ -3583,7 +3581,8 @@ UpdateState:
     }
     stream->conn->super.stats.num_bytes.stream_data_sent += end_off - off;
     if (off < stream->sendstate.size_inflight)
-        stream->conn->super.stats.num_bytes.stream_data_resent += QUICLY_MIN(stream->sendstate.size_inflight, end_off) - off;
+        stream->conn->super.stats.num_bytes.stream_data_resent +=
+            (stream->sendstate.size_inflight < end_off ? stream->sendstate.size_inflight : end_off) - off;
     QUICLY_PROBE(STREAM_SEND, stream->conn, stream->conn->stash.now, stream, off, end_off - off, is_fin);
     QUICLY_PROBE(QUICTRACE_SEND_STREAM, stream->conn, stream->conn->stash.now, stream, off, end_off - off, is_fin);
     /* update sendstate (and also MAX_DATA counter) */


### PR DESCRIPTION
## Overview
We currently count the number of lost QUIC packets, but we don't have any statistics related to resent Bytes.  This implements counters for lost and resent Bytes.

## Test
See https://github.com/h2o/h2o/pull/2811.
