### PR TITLE
calc delivery rate

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -440,6 +440,10 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t lost;                                                                                                             \
         /**                                                                                                                        \
+         * Total number of bytes for which acknowledgements have been received.                                                    \
+         */                                                                                                                        \
+        uint64_t ack_received;                                                                                                     \
+        /**                                                                                                                        \
          * Total amount of stream-level payload being sent                                                                         \
          */                                                                                                                        \
         uint64_t stream_data_sent;                                                                                                 \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -458,13 +458,17 @@ struct st_quicly_conn_streamgroup_state_t {
     struct {                                                                                                                       \
         uint64_t padding, ping, ack, reset_stream, stop_sending, crypto, new_token, stream, max_data, max_stream_data,             \
             max_streams_bidi, max_streams_uni, data_blocked, stream_data_blocked, streams_blocked, new_connection_id,              \
-            retire_connection_id, path_challenge, path_response, transport_close, application_close, handshake_done,               \
-            datagram, ack_frequency;                                                                                               \
+            retire_connection_id, path_challenge, path_response, transport_close, application_close, handshake_done, datagram,     \
+            ack_frequency;                                                                                                         \
     } num_frames_sent, num_frames_received;                                                                                        \
     /**                                                                                                                            \
      * Total number of PTOs observed during the connection.                                                                        \
      */                                                                                                                            \
-    uint64_t num_ptos
+    uint64_t num_ptos;                                                                                                             \
+    /**                                                                                                                            \
+     * Delivery rate (bytes/sec).                                                                                                  \
+     */                                                                                                                            \
+    uint32_t delivery_rate
 
 typedef struct st_quicly_stats_t {
     /**

--- a/include/quicly/sentmap.h
+++ b/include/quicly/sentmap.h
@@ -60,6 +60,11 @@ typedef struct st_quicly_sent_packet_t {
      * number of bytes in-flight for the packet, from the context of CC (becomes zero when deemed lost, but not when PTO fires)
      */
     uint16_t cc_bytes_in_flight;
+    /**
+     * Lower 32-bits of stats.bytes.ack_received when the packet is being sent, if egress has never been application-limited for the
+     * previous round-trip. Used by the delivery rate estimator.
+     */
+    uint32_t bytes_acked_l32;
 } quicly_sent_packet_t;
 
 typedef enum en_quicly_sentmap_event_t {
@@ -221,7 +226,7 @@ static int quicly_sentmap_is_open(quicly_sentmap_t *map);
 /**
  * prepares a write
  */
-int quicly_sentmap_prepare(quicly_sentmap_t *map, uint64_t packet_number, int64_t now, uint8_t ack_epoch);
+int quicly_sentmap_prepare(quicly_sentmap_t *map, uint64_t packet_number, int64_t now, uint8_t ack_epoch, uint32_t bytes_acked_l32);
 /**
  * commits a write
  */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4847,6 +4847,7 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
             QUICLY_PROBE(PACKET_ACKED, conn, conn->stash.now, pn_acked, is_late_ack);
             if (sent->cc_bytes_in_flight != 0) {
                 bytes_acked += sent->cc_bytes_in_flight;
+                conn->super.stats.num_bytes.ack_received += sent->cc_bytes_in_flight;
             }
             if ((ret = quicly_sentmap_update(&conn->egress.loss.sentmap, &iter, QUICLY_SENTMAP_EVENT_ACKED)) != 0)
                 return ret;

--- a/lib/sentmap.c
+++ b/lib/sentmap.c
@@ -92,13 +92,14 @@ void quicly_sentmap_dispose(quicly_sentmap_t *map)
     }
 }
 
-int quicly_sentmap_prepare(quicly_sentmap_t *map, uint64_t packet_number, int64_t now, uint8_t ack_epoch)
+int quicly_sentmap_prepare(quicly_sentmap_t *map, uint64_t packet_number, int64_t now, uint8_t ack_epoch, uint32_t bytes_acked_l32)
 {
     assert(map->_pending_packet == NULL);
 
     if ((map->_pending_packet = quicly_sentmap_allocate(map, quicly_sentmap__type_packet)) == NULL)
         return PTLS_ERROR_NO_MEMORY;
-    map->_pending_packet->data.packet = (quicly_sent_packet_t){packet_number, now, ack_epoch};
+    map->_pending_packet->data.packet = (quicly_sent_packet_t){
+        .packet_number = packet_number, .sent_at = now, .ack_epoch = ack_epoch, .bytes_acked_l32 = bytes_acked_l32};
     return 0;
 }
 

--- a/t/loss.c
+++ b/t/loss.c
@@ -59,11 +59,11 @@ static void test_time_detection(void)
     ok(loss.loss_time == INT64_MAX);
 
     /* commit 3 packets (pn=0..2); check that loss timer is not active */
-    ok(quicly_sentmap_prepare(&loss.sentmap, 0, now, QUICLY_EPOCH_INITIAL) == 0);
+    ok(quicly_sentmap_prepare(&loss.sentmap, 0, now, QUICLY_EPOCH_INITIAL, 0) == 0);
     quicly_sentmap_commit(&loss.sentmap, 10);
-    ok(quicly_sentmap_prepare(&loss.sentmap, 1, now, QUICLY_EPOCH_INITIAL) == 0);
+    ok(quicly_sentmap_prepare(&loss.sentmap, 1, now, QUICLY_EPOCH_INITIAL, 0) == 0);
     quicly_sentmap_commit(&loss.sentmap, 10);
-    ok(quicly_sentmap_prepare(&loss.sentmap, 2, now, QUICLY_EPOCH_INITIAL) == 0);
+    ok(quicly_sentmap_prepare(&loss.sentmap, 2, now, QUICLY_EPOCH_INITIAL, 0) == 0);
     quicly_sentmap_commit(&loss.sentmap, 10);
     ok(quicly_loss_detect_loss(&loss, now, quicly_spec_context.transport_params.max_ack_delay, 0, on_loss_detected) == 0);
     ok(loss.loss_time == INT64_MAX);
@@ -103,13 +103,13 @@ static void test_pn_detection(void)
     ok(loss.loss_time == INT64_MAX);
 
     /* commit 4 packets (pn=0..3); check that loss timer is not active */
-    ok(quicly_sentmap_prepare(&loss.sentmap, 0, now, QUICLY_EPOCH_INITIAL) == 0);
+    ok(quicly_sentmap_prepare(&loss.sentmap, 0, now, QUICLY_EPOCH_INITIAL, 0) == 0);
     quicly_sentmap_commit(&loss.sentmap, 10);
-    ok(quicly_sentmap_prepare(&loss.sentmap, 1, now, QUICLY_EPOCH_INITIAL) == 0);
+    ok(quicly_sentmap_prepare(&loss.sentmap, 1, now, QUICLY_EPOCH_INITIAL, 0) == 0);
     quicly_sentmap_commit(&loss.sentmap, 10);
-    ok(quicly_sentmap_prepare(&loss.sentmap, 2, now, QUICLY_EPOCH_INITIAL) == 0);
+    ok(quicly_sentmap_prepare(&loss.sentmap, 2, now, QUICLY_EPOCH_INITIAL, 0) == 0);
     quicly_sentmap_commit(&loss.sentmap, 10);
-    ok(quicly_sentmap_prepare(&loss.sentmap, 3, now, QUICLY_EPOCH_INITIAL) == 0);
+    ok(quicly_sentmap_prepare(&loss.sentmap, 3, now, QUICLY_EPOCH_INITIAL, 0) == 0);
     quicly_sentmap_commit(&loss.sentmap, 10);
     ok(quicly_loss_detect_loss(&loss, now, quicly_spec_context.transport_params.max_ack_delay, 0, on_loss_detected) == 0);
     ok(loss.loss_time == INT64_MAX);
@@ -144,9 +144,9 @@ static void test_slow_cert_verify(void)
     ok(loss.loss_time == INT64_MAX);
 
     /* sent Handshake+1RTT packet */
-    ok(quicly_sentmap_prepare(&loss.sentmap, 1, now, QUICLY_EPOCH_HANDSHAKE) == 0);
+    ok(quicly_sentmap_prepare(&loss.sentmap, 1, now, QUICLY_EPOCH_HANDSHAKE, 0) == 0);
     quicly_sentmap_commit(&loss.sentmap, 10);
-    ok(quicly_sentmap_prepare(&loss.sentmap, 2, now, QUICLY_EPOCH_1RTT) == 0);
+    ok(quicly_sentmap_prepare(&loss.sentmap, 2, now, QUICLY_EPOCH_1RTT, 0) == 0);
     quicly_sentmap_commit(&loss.sentmap, 10);
     last_retransmittable_sent_at = now;
     quicly_loss_update_alarm(&loss, now, last_retransmittable_sent_at, 1, 0, 1, 0, 1);
@@ -168,9 +168,9 @@ static void test_slow_cert_verify(void)
     ok(num_packets_lost == 0);
 
     /* therefore send probes */
-    ok(quicly_sentmap_prepare(&loss.sentmap, 3, now, QUICLY_EPOCH_HANDSHAKE) == 0);
+    ok(quicly_sentmap_prepare(&loss.sentmap, 3, now, QUICLY_EPOCH_HANDSHAKE, 0) == 0);
     quicly_sentmap_commit(&loss.sentmap, 10);
-    ok(quicly_sentmap_prepare(&loss.sentmap, 4, now, QUICLY_EPOCH_1RTT) == 0);
+    ok(quicly_sentmap_prepare(&loss.sentmap, 4, now, QUICLY_EPOCH_1RTT, 0) == 0);
     quicly_sentmap_commit(&loss.sentmap, 10);
 
     now += 10;

--- a/t/sentmap.c
+++ b/t/sentmap.c
@@ -56,7 +56,7 @@ static void test_basic(void)
     /* save 50 packets, with 2 frames each */
     for (at = 0; at < 10; ++at) {
         for (i = 1; i <= 5; ++i) {
-            quicly_sentmap_prepare(&map, at * 5 + i, at, QUICLY_EPOCH_INITIAL);
+            quicly_sentmap_prepare(&map, at * 5 + i, at, QUICLY_EPOCH_INITIAL, 0);
             quicly_sentmap_allocate(&map, on_acked);
             quicly_sentmap_allocate(&map, on_acked);
             quicly_sentmap_commit(&map, 1);
@@ -113,10 +113,10 @@ static void test_late_ack(void)
     quicly_sentmap_init(&map);
 
     /* commit pn 1, 2 */
-    quicly_sentmap_prepare(&map, 1, 0, QUICLY_EPOCH_INITIAL);
+    quicly_sentmap_prepare(&map, 1, 0, QUICLY_EPOCH_INITIAL, 0);
     quicly_sentmap_allocate(&map, on_acked);
     quicly_sentmap_commit(&map, 10);
-    quicly_sentmap_prepare(&map, 2, 0, QUICLY_EPOCH_INITIAL);
+    quicly_sentmap_prepare(&map, 2, 0, QUICLY_EPOCH_INITIAL, 0);
     quicly_sentmap_allocate(&map, on_acked);
     quicly_sentmap_commit(&map, 20);
     ok(map.bytes_in_flight == 30);
@@ -157,10 +157,10 @@ static void test_pto(void)
     quicly_sentmap_init(&map);
 
     /* commit pn 1, 2 */
-    quicly_sentmap_prepare(&map, 1, 0, QUICLY_EPOCH_INITIAL);
+    quicly_sentmap_prepare(&map, 1, 0, QUICLY_EPOCH_INITIAL, 0);
     quicly_sentmap_allocate(&map, on_acked);
     quicly_sentmap_commit(&map, 10);
-    quicly_sentmap_prepare(&map, 2, 0, QUICLY_EPOCH_INITIAL);
+    quicly_sentmap_prepare(&map, 2, 0, QUICLY_EPOCH_INITIAL, 0);
     quicly_sentmap_allocate(&map, on_acked);
     quicly_sentmap_commit(&map, 20);
     ok(map.bytes_in_flight == 30);


### PR DESCRIPTION
At the moment, the rate is purely calculated by the ack rate, rather than using `min(ack_rate, delivery_rate)` as specified in https://tools.ietf.org/id/draft-cheng-iccrg-delivery-rate-estimation-00.html.

I tend to believe that the actual delivery rate would be reflected better by something  like `average(ack_rate)` measured over some time, because doing so would take the jitter in both directions into account, wheres capping it by `min` takes jitter in only one direction into account.

But what you need depends on the purpose.