### PR TITLE
opportunistically reduce the number of ack ranges added to sentmap

### DIFF
--- a/include/quicly/sentmap.h
+++ b/include/quicly/sentmap.h
@@ -91,12 +91,29 @@ typedef enum en_quicly_sentmap_event_t {
  */
 typedef int (*quicly_sent_acked_cb)(quicly_sentmap_t *map, const quicly_sent_packet_t *packet, int acked, quicly_sent_t *data);
 
+struct st_quicly_sent_ack_additional_t {
+    uint8_t gap;
+    uint8_t length;
+};
+
 struct st_quicly_sent_t {
     quicly_sent_acked_cb acked;
     union {
         quicly_sent_packet_t packet;
         struct {
-            quicly_range_t range;
+            uint64_t start;
+            union {
+                struct {
+                    uint64_t start_length;
+                    uint8_t num_additional;
+                    struct st_quicly_sent_ack_additional_t additional[3];
+                } ranges64;
+                struct {
+                    uint8_t start_length;
+                    uint8_t num_additional;
+                    struct st_quicly_sent_ack_additional_t additional[7];
+                } ranges8;
+            };
         } ack;
         struct {
             quicly_stream_id_t stream_id;

--- a/include/quicly/sentmap.h
+++ b/include/quicly/sentmap.h
@@ -96,6 +96,11 @@ struct st_quicly_sent_ack_additional_t {
     uint8_t length;
 };
 
+/**
+ * Describes what is inside a packet or frame being sent. Within the sentmap, each packet-level entry (identified by .acked ==
+ * quicly_sentmap__type_packet) is followed by a number of frame-level entries. Size of `quicly_sent_t` is kept as 256 bits (64-bit
+ * * 4).
+ */
 struct st_quicly_sent_t {
     quicly_sent_acked_cb acked;
     union {

--- a/include/quicly/sentmap.h
+++ b/include/quicly/sentmap.h
@@ -100,17 +100,18 @@ struct st_quicly_sent_t {
     quicly_sent_acked_cb acked;
     union {
         quicly_sent_packet_t packet;
+        /**
+         * ACK frame. Represents up to 8 ack ranges. If not full, `additional` list is terminated by .gap = 0.
+         */
         struct {
             uint64_t start;
             union {
                 struct {
                     uint64_t start_length;
-                    uint8_t num_additional;
-                    struct st_quicly_sent_ack_additional_t additional[3];
+                    struct st_quicly_sent_ack_additional_t additional[4];
                 } ranges64;
                 struct {
                     uint8_t start_length;
-                    uint8_t num_additional;
                     struct st_quicly_sent_ack_additional_t additional[7];
                 } ranges8;
             };

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2530,43 +2530,70 @@ static int decrypt_packet(ptls_cipher_context_t *header_protection,
     return 0;
 }
 
-static int on_ack_ack(quicly_sentmap_t *map, const quicly_sent_packet_t *packet, int acked, quicly_sent_t *sent)
+static int do_on_ack_ack(quicly_conn_t *conn, const quicly_sent_packet_t *packet, uint64_t start, uint64_t start_length,
+                         struct st_quicly_sent_ack_additional_t *additional, size_t num_additional)
+{
+    /* find the pn space */
+    struct st_quicly_pn_space_t *space;
+    switch (packet->ack_epoch) {
+    case QUICLY_EPOCH_INITIAL:
+        space = &conn->initial->super;
+        break;
+    case QUICLY_EPOCH_HANDSHAKE:
+        space = &conn->handshake->super;
+        break;
+    case QUICLY_EPOCH_1RTT:
+        space = &conn->application->super;
+        break;
+    default:
+        assert(!"FIXME");
+        return QUICLY_TRANSPORT_ERROR_INTERNAL;
+    }
+
+    /* subtract given ACK ranges */
+    int ret;
+    uint64_t end = start + start_length;
+    if ((ret = quicly_ranges_subtract(&space->ack_queue, start, end)) != 0)
+        return ret;
+    for (size_t i = 0; i < num_additional; ++i) {
+        start = end + additional[i].gap;
+        end = start + additional[i].length;
+        if ((ret = quicly_ranges_subtract(&space->ack_queue, start, end)) != 0)
+            return ret;
+    }
+
+    /* make adjustments */
+    if (space->ack_queue.num_ranges == 0) {
+        space->largest_pn_received_at = INT64_MAX;
+        space->unacked_count = 0;
+    } else if (space->ack_queue.num_ranges > QUICLY_MAX_ACK_BLOCKS) {
+        quicly_ranges_drop_by_range_indices(&space->ack_queue, space->ack_queue.num_ranges - QUICLY_MAX_ACK_BLOCKS,
+                                            space->ack_queue.num_ranges);
+    }
+
+    return 0;
+}
+
+static int on_ack_ack_ranges64(quicly_sentmap_t *map, const quicly_sent_packet_t *packet, int acked, quicly_sent_t *sent)
 {
     quicly_conn_t *conn = (quicly_conn_t *)((char *)map - offsetof(quicly_conn_t, egress.loss.sentmap));
 
     /* TODO log */
 
-    if (acked) {
-        /* find the pn space */
-        struct st_quicly_pn_space_t *space;
-        switch (packet->ack_epoch) {
-        case QUICLY_EPOCH_INITIAL:
-            space = &conn->initial->super;
-            break;
-        case QUICLY_EPOCH_HANDSHAKE:
-            space = &conn->handshake->super;
-            break;
-        case QUICLY_EPOCH_1RTT:
-            space = &conn->application->super;
-            break;
-        default:
-            assert(!"FIXME");
-            return QUICLY_TRANSPORT_ERROR_INTERNAL;
-        }
-        /* subtract given ACK range, then make adjustments */
-        int ret;
-        if ((ret = quicly_ranges_subtract(&space->ack_queue, sent->data.ack.range.start, sent->data.ack.range.end)) != 0)
-            return ret;
-        if (space->ack_queue.num_ranges == 0) {
-            space->largest_pn_received_at = INT64_MAX;
-            space->unacked_count = 0;
-        } else if (space->ack_queue.num_ranges > QUICLY_MAX_ACK_BLOCKS) {
-            quicly_ranges_drop_by_range_indices(&space->ack_queue, space->ack_queue.num_ranges - QUICLY_MAX_ACK_BLOCKS,
-                                                space->ack_queue.num_ranges);
-        }
-    }
+    return acked ? do_on_ack_ack(conn, packet, sent->data.ack.start, sent->data.ack.ranges64.start_length,
+                                 sent->data.ack.ranges64.additional, sent->data.ack.ranges64.num_additional)
+                 : 0;
+}
 
-    return 0;
+static int on_ack_ack_ranges8(quicly_sentmap_t *map, const quicly_sent_packet_t *packet, int acked, quicly_sent_t *sent)
+{
+    quicly_conn_t *conn = (quicly_conn_t *)((char *)map - offsetof(quicly_conn_t, egress.loss.sentmap));
+
+    /* TODO log */
+
+    return acked ? do_on_ack_ack(conn, packet, sent->data.ack.start, sent->data.ack.ranges8.start_length,
+                                 sent->data.ack.ranges8.additional, sent->data.ack.ranges8.num_additional)
+                 : 0;
 }
 
 static int on_ack_stream_ack_one(quicly_conn_t *conn, quicly_stream_id_t stream_id, quicly_sendstate_sent_t *sent)
@@ -3312,12 +3339,40 @@ Emit: /* emit an ACK frame */
     s->dst = dst;
 
     { /* save what's inflight */
-        size_t i;
-        for (i = 0; i != space->ack_queue.num_ranges; ++i) {
+        size_t range_index = 0;
+        while (range_index < space->ack_queue.num_ranges) {
             quicly_sent_t *sent;
-            if ((sent = quicly_sentmap_allocate(&conn->egress.loss.sentmap, on_ack_ack)) == NULL)
+            struct st_quicly_sent_ack_additional_t *additional;
+            uint8_t additional_capacity, *num_additional;
+            /* allocate */
+            if ((sent = quicly_sentmap_allocate(&conn->egress.loss.sentmap, on_ack_ack_ranges8)) == NULL)
                 return PTLS_ERROR_NO_MEMORY;
-            sent->data.ack.range = space->ack_queue.ranges[i];
+            /* store the first range, as well as preparing references to the additional slots */
+            sent->data.ack.start = space->ack_queue.ranges[range_index].start;
+            uint64_t length = space->ack_queue.ranges[range_index].end - space->ack_queue.ranges[range_index].start;
+            if (length < UINT8_MAX) {
+                sent->data.ack.ranges8.start_length = length;
+                additional = sent->data.ack.ranges8.additional;
+                additional_capacity = PTLS_ELEMENTSOF(sent->data.ack.ranges8.additional);
+                num_additional = &sent->data.ack.ranges8.num_additional;
+            } else {
+                sent->acked = on_ack_ack_ranges64;
+                sent->data.ack.ranges64.start_length = length;
+                additional = sent->data.ack.ranges64.additional;
+                additional_capacity = PTLS_ELEMENTSOF(sent->data.ack.ranges64.additional);
+                num_additional = &sent->data.ack.ranges64.num_additional;
+            }
+            /* store additional ranges, if possible */
+            for (++range_index, *num_additional = 0;
+                 range_index < space->ack_queue.num_ranges && *num_additional < additional_capacity;
+                 ++range_index, ++*num_additional) {
+                uint64_t gap = space->ack_queue.ranges[range_index].start - space->ack_queue.ranges[range_index - 1].end;
+                uint64_t length = space->ack_queue.ranges[range_index].end - space->ack_queue.ranges[range_index].start;
+                if (gap > UINT8_MAX || length > UINT8_MAX)
+                    break;
+                additional[*num_additional].gap = gap;
+                additional[*num_additional].length = length;
+            }
         }
     }
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3350,7 +3350,7 @@ Emit: /* emit an ACK frame */
             /* store the first range, as well as preparing references to the additional slots */
             sent->data.ack.start = space->ack_queue.ranges[range_index].start;
             uint64_t length = space->ack_queue.ranges[range_index].end - space->ack_queue.ranges[range_index].start;
-            if (length < UINT8_MAX) {
+            if (length <= UINT8_MAX) {
                 sent->data.ack.ranges8.start_length = length;
                 additional = sent->data.ack.ranges8.additional;
                 additional_capacity = PTLS_ELEMENTSOF(sent->data.ack.ranges8.additional);


### PR DESCRIPTION
At the moment, each ACK range takes up to 64 `quicly_sent_t` slots, where 64 is the maximum number of ACK ranges that quicly retains.

These become a pressure when the peer reaches the end of its slow start, because:
1. quicly acting as a receiver will be sending many ACKs, each of them carrying lots of ranges,
2. memory used to retain sentmap for one ACK can become as large as 2KB.

This PR mitigates the pressure by opportunistically storing at most 8 ranges within one `quicly_sent_t`.

This PR should at least mitigate #364, by reducing the number of entries in the sentmap to 1/8. If that's not enough, we can reduce the numbers of entries _further_ by 1/4, by adopting #488. Anyways, the first step would be to adopt this PR, as it fixes the memory footprint issue as well (see the 2nd point above).