### PR TITLE
[sentmap] split packet-level and frame-level structure

### DIFF
--- a/t/sentmap.c
+++ b/t/sentmap.c
@@ -76,7 +76,7 @@ static void test_basic(void)
         }
     }
     ok(quicly_sentmap_get(&iter)->packet_number == UINT64_MAX);
-    ok(num_blocks(&map) == 150 / 16 + 1);
+    ok(num_blocks(&map) == 50 / 16 + 1);
 
     /* pop acks between 11 <= packet_number <= 40 */
     quicly_sentmap_init_iter(&map, &iter);
@@ -96,7 +96,7 @@ static void test_basic(void)
         ++cnt;
     }
     ok(cnt == 20);
-    ok(num_blocks(&map) == 30 / 16 + 1 + 1 + 30 / 16 + 1);
+    ok(num_blocks(&map) == 10 / 16 + 1 + 1 + 10 / 16 + 1);
 
     quicly_sentmap_dispose(&map);
 }


### PR DESCRIPTION
 Doing so improves the iteration speed at the cost of memory footprint.

At the moment, for sentmap, we use a linked-list of blocks, that consists with either packet-level information or frame-level information. Therefore, the cost of iterating through the sentmap becomes a cost, if there are excessive number of frame-level entries being associated to each packet-level information. #487 tries to solve the problem by reducing the number of frame-level entries.

This PR tries to solve the problem by splitting the packet-level and frame-level structure. Frame-level information is stored *as part of* the packet-level structure when the number of frame-level entries is below 4. If not, they are allocated using `malloc`.