### PR TITLE
ignore MAX_STREAM_DATA frames that do not carry a new limit

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4914,7 +4914,7 @@ static int handle_max_stream_data_frame(quicly_conn_t *conn, struct st_quicly_ha
     if ((stream = quicly_get_stream(conn, frame.stream_id)) == NULL)
         return 0;
 
-    if (frame.max_stream_data < stream->_send_aux.max_stream_data)
+    if (frame.max_stream_data <= stream->_send_aux.max_stream_data)
         return 0;
     stream->_send_aux.max_stream_data = frame.max_stream_data;
     stream->_send_aux.blocked = QUICLY_SENDER_STATE_NONE;


### PR DESCRIPTION
Otherwise we'd see ping-pong of STREAM_DATA_BLOCKED vs. STREAM_DATA.

Closes #484.

Check if similar bug exists for other limits:
* [x] MAX_DATA - looks good
* [x] MAX_STREAMS - confirmed using simulator that the problem does not exist