### PR TITLE
[bug-fix] should_send_max_streams() can access conn->super.ctx after it is freed

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1585,9 +1585,8 @@ void quicly_free(quicly_conn_t *conn)
         QUICLY_PROBE(CONN_STATS, conn, conn->stash.now, &stats, sizeof(stats));
     }
 #endif
-    update_open_count(conn->super.ctx, -1);
-
     destroy_all_streams(conn, 0, 1);
+    update_open_count(conn->super.ctx, -1);
     clear_datagram_frame_payloads(conn);
 
     quicly_maxsender_dispose(&conn->ingress.max_data.sender);


### PR DESCRIPTION
## Overview
It's currently possible for `should_send_max_streams()` to access `conn->super.ctx` after it is released.

Function `quicly_free()` calls `update_open_count()` which can result in `conn->super.ctx` being released.  However, `destroy_all_streams()` is then called, which arrives at `should_send_max_streams()` where `conn->super.ctx` is accessed.
