### PR TITLE
[pico] too aggressive

### DIFF
--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -82,6 +82,10 @@ typedef struct st_quicly_cc_t {
              * Stash of acknowledged bytes, used during congestion avoidance.
              */
             uint32_t stash;
+            /**
+             * Number of bytes required to be acked in order to increase CWND by 1 MTU.
+             */
+            uint32_t bytes_per_mtu_increase;
         } pico;
         /**
          * State information for CUBIC congestion control.

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -30,7 +30,30 @@ static uint32_t calc_bytes_per_mtu_increase(uint32_t cwnd, uint32_t rtt, uint32_
 {
     /* Reno: CWND size after reduction */
     uint32_t reno = cwnd * QUICLY_RENO_BETA;
-    /* Cubic: Average of `(CWND / RTT) * K / 0.3CWND`, where K and CWND have two modes due to "fast convergence." */
+
+    /* Cubic: Cubic reaches original CWND (i.e., Wmax) in K seconds, therefore:
+     *   amount_to_increase = 0.3 * Wmax
+     *   amount_to_be_acked = K * Wmax / RTT_at_Wmax
+     * where
+     *   K = (0.3 / 0.4 * Wmax / MTU)^(1/3)
+     *
+     * Hence:
+     *   bytes_per_mtu_increase = amount_to_be_acked / amount_to_increase * MTU
+     *     = (K * Wmax / RTT_at_Wmax) / (0.3 * Wmax) * MTU
+     *     = K * MTU / (0.3 * RTT_at_Wmax)
+     *
+     * In addition, we have to adjust the value to take fast convergence into account. On a path with stable capacity, 50% of
+     * congestion events adjust Wmax to 0.85x of before calculating K. If that happens, the modified K (K') is:
+     *
+     *   K' = (0.3 / 0.4 * 0.85 * Wmax / MTU)^(1/3) = 0.85^(1/3) * K
+     *
+     * where K' represents the time to reach 0.85 * Wmax. As the cubic curve is point symmetric at the point where this curve
+     * reaches 0.85 * Wmax, it would take 2 * K' seconds to reach Wmax.
+     *
+     * Therefore, by amortizing the two modes, the congestion period of Cubic with fast convergence is calculated as:
+     *
+     *   bytes_per_mtu_increase = ((1 + 0.85^(1/3) * 2) / 2) * K * MTU / (0.3 * RTT_at_Wmax)
+     */
     uint32_t cubic = 1.447 / 0.3 * 1000 * cbrt(0.3 / 0.4 * cwnd / mtu) / rtt * mtu;
 
     return reno < cubic ? reno : cubic;


### PR DESCRIPTION
Trying to reach the bottleneck buffer limit once every second is too aggressive.

This PR changes the strategy to AIMD with beta of 0.7 (equal to Cubic).

The concept behind the congestion avoidance phase remains the same - the increase ratio is chosen so that Pico will hit the peak as fast as Cubic does.