### PR TITLE
never trim stream frames / don't send broken frames when `on_send_emit` fails

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3583,8 +3583,8 @@ int quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t *s)
 {
     uint64_t off = stream->sendstate.pending.ranges[0].start;
     quicly_sent_t *sent;
-    uint8_t *dst; /* points to the current write position within the frame being built, while `s->dst` points to the beginning of
-                   * the frame. */
+    uint8_t *dst; /* this pointer points to the current write position within the frame being built, while `s->dst` points to the
+                   * beginning of the frame. */
     size_t len;
     int ret, wrote_all, is_fin;
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3606,7 +3606,8 @@ int quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t *s)
         } else {
             header[0] = QUICLY_FRAME_TYPE_STREAM_BASE;
         }
-        if (!quicly_sendstate_is_open(&stream->sendstate) && off == stream->sendstate.final_size) {
+        if (off == stream->sendstate.final_size) {
+            assert(!quicly_sendstate_is_open(&stream->sendstate));
             /* special case for emitting FIN only */
             header[0] |= QUICLY_FRAME_TYPE_STREAM_BIT_FIN;
             if ((ret = allocate_ack_eliciting_frame(stream->conn, s, hp - header, &sent, on_ack_stream)) != 0)
@@ -3643,7 +3644,8 @@ int quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t *s)
     }
     { /* cap len to the current range */
         uint64_t range_capacity = stream->sendstate.pending.ranges[0].end - off;
-        if (!quicly_sendstate_is_open(&stream->sendstate) && off + range_capacity > stream->sendstate.final_size) {
+        if (off + range_capacity > stream->sendstate.final_size) {
+            assert(!quicly_sendstate_is_open(&stream->sendstate));
             assert(range_capacity > 1); /* see the special case above */
             range_capacity -= 1;
         }
@@ -3666,7 +3668,8 @@ int quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t *s)
     adjust_stream_frame_layout(&s->dst, s->dst_end, &len, &wrote_all, &frame_type_at);
 
     /* determine if the frame incorporates FIN */
-    if (!quicly_sendstate_is_open(&stream->sendstate) && off + len == stream->sendstate.final_size) {
+    if (off + len == stream->sendstate.final_size) {
+        assert(!quicly_sendstate_is_open(&stream->sendstate));
         assert(frame_type_at != NULL);
         is_fin = 1;
         *frame_type_at |= QUICLY_FRAME_TYPE_STREAM_BIT_FIN;

--- a/t/test.c
+++ b/t/test.c
@@ -103,11 +103,11 @@ static void test_adjust_stream_frame_layout(void)
 #define TEST(_is_crypto, _capacity, check)                                                                                         \
     do {                                                                                                                           \
         uint8_t buf[] = {0xff, 0x04, 'h', 'e', 'l', 'l', 'o', 0, 0, 0};                                                            \
-        uint8_t *dst = buf + 2, *const dst_end = buf + _capacity, *frame_type_at = _is_crypto ? NULL : buf;                        \
+        uint8_t *dst = buf + 2, *const dst_end = buf + _capacity, *frame_at = buf;                                                 \
         size_t len = 5;                                                                                                            \
         int wrote_all = 1;                                                                                                         \
         buf[0] = _is_crypto ? 0x06 : 0x08;                                                                                         \
-        adjust_stream_frame_layout(&dst, dst_end, &len, &wrote_all, &frame_type_at);                                               \
+        adjust_stream_frame_layout(&dst, dst_end, &len, &wrote_all, &frame_at);                                                    \
         do {                                                                                                                       \
             check                                                                                                                  \
         } while (0);                                                                                                               \
@@ -118,21 +118,21 @@ static void test_adjust_stream_frame_layout(void)
         ok(dst == buf + 8);
         ok(len == 5);
         ok(wrote_all);
-        ok(frame_type_at == NULL);
+        ok(frame_at == buf);
         ok(memcmp(buf, "\x06\x04\x05hello", 8) == 0);
     });
     TEST(1, 8, {
         ok(dst == buf + 8);
         ok(len == 5);
         ok(wrote_all);
-        ok(frame_type_at == NULL);
+        ok(frame_at == buf);
         ok(memcmp(buf, "\x06\x04\x05hello", 8) == 0);
     });
     TEST(1, 7, {
         ok(dst == buf + 7);
         ok(len == 4);
         ok(!wrote_all);
-        ok(frame_type_at == NULL);
+        ok(frame_at == buf);
         ok(memcmp(buf, "\x06\x04\x04hell", 7) == 0);
     });
 
@@ -141,21 +141,21 @@ static void test_adjust_stream_frame_layout(void)
         ok(dst == buf + 8);
         ok(len == 5);
         ok(wrote_all);
-        ok(frame_type_at == buf);
+        ok(frame_at == buf);
         ok(memcmp(buf, "\x0a\x04\x05hello", 8) == 0);
     });
     TEST(0, 8, {
         ok(dst == buf + 8);
         ok(len == 5);
         ok(wrote_all);
-        ok(frame_type_at == buf + 1);
+        ok(frame_at == buf + 1);
         ok(memcmp(buf, "\x00\x08\x04hello", 8) == 0);
     });
     TEST(0, 7, {
         ok(dst == buf + 7);
         ok(len == 5);
         ok(wrote_all);
-        ok(frame_type_at == buf);
+        ok(frame_at == buf);
         ok(memcmp(buf, "\x08\x04hello", 7) == 0);
     });
 

--- a/t/test.c
+++ b/t/test.c
@@ -98,6 +98,70 @@ quicly_stream_callbacks_t stream_callbacks = {
     on_destroy, quicly_streambuf_egress_shift, quicly_streambuf_egress_emit, on_egress_stop, on_ingress_receive, on_ingress_reset};
 size_t on_destroy_callcnt;
 
+static void test_adjust_stream_frame_layout(void)
+{
+#define TEST(_is_crypto, _capacity, check)                                                                                         \
+    do {                                                                                                                           \
+        uint8_t buf[] = {0xff, 0x04, 'h', 'e', 'l', 'l', 'o', 0, 0, 0};                                                            \
+        uint8_t *dst = buf + 2, *const dst_end = buf + _capacity, *frame_type_at = _is_crypto ? NULL : buf;                        \
+        size_t len = 5;                                                                                                            \
+        int wrote_all = 1;                                                                                                         \
+        buf[0] = _is_crypto ? 0x06 : 0x08;                                                                                         \
+        adjust_stream_frame_layout(&dst, dst_end, &len, &wrote_all, &frame_type_at);                                               \
+        do {                                                                                                                       \
+            check                                                                                                                  \
+        } while (0);                                                                                                               \
+    } while (0);
+
+    /* test CRYPTO frames that fit and don't when length is inserted */
+    TEST(1, 10, {
+        ok(dst == buf + 8);
+        ok(len == 5);
+        ok(wrote_all);
+        ok(frame_type_at == NULL);
+        ok(memcmp(buf, "\x06\x04\x05hello", 8) == 0);
+    });
+    TEST(1, 8, {
+        ok(dst == buf + 8);
+        ok(len == 5);
+        ok(wrote_all);
+        ok(frame_type_at == NULL);
+        ok(memcmp(buf, "\x06\x04\x05hello", 8) == 0);
+    });
+    TEST(1, 7, {
+        ok(dst == buf + 7);
+        ok(len == 4);
+        ok(!wrote_all);
+        ok(frame_type_at == NULL);
+        ok(memcmp(buf, "\x06\x04\x04hell", 7) == 0);
+    });
+
+    /* test STREAM frames */
+    TEST(0, 9, {
+        ok(dst == buf + 8);
+        ok(len == 5);
+        ok(wrote_all);
+        ok(frame_type_at == buf);
+        ok(memcmp(buf, "\x0a\x04\x05hello", 8) == 0);
+    });
+    TEST(0, 8, {
+        ok(dst == buf + 8);
+        ok(len == 5);
+        ok(wrote_all);
+        ok(frame_type_at == buf + 1);
+        ok(memcmp(buf, "\x00\x08\x04hello", 8) == 0);
+    });
+    TEST(0, 7, {
+        ok(dst == buf + 7);
+        ok(len == 5);
+        ok(wrote_all);
+        ok(frame_type_at == buf);
+        ok(memcmp(buf, "\x08\x04hello", 7) == 0);
+    });
+
+#undef TEST
+}
+
 static int64_t get_now_cb(quicly_now_t *self)
 {
     return quic_now;
@@ -700,6 +764,7 @@ int main(int argc, char **argv)
     subtest("maxsender", test_maxsender);
     subtest("sentmap", test_sentmap);
     subtest("loss", test_loss);
+    subtest("adjust-stream-frame-layout", test_adjust_stream_frame_layout);
     subtest("test-vector", test_vector);
     subtest("test-retry-aead", test_retry_aead);
     subtest("transport-parameters", test_transport_parameters);


### PR DESCRIPTION
`quicly_send_stream` runs in the following steps:
1. create frame header omitting the length field
2. let application (`on_send_emit`) write payload
3. if application stopped short of filling the entire packet, change the frame type to one that carries the length field

In step 3, the payload gets trimmed if there is not enough space to insert the length field.

While **this is not a bug** (the adjustments are correctly implemented), it is unnecessary. Instead of converting the frame format, it is possible to prepend a PADDING frame before the STREAM frame, continuing the use of the frame format (that omits the length field).

This pull request changes the approach as described, as well as refactoring the code reducing the state and adding unit tests.

In addition, de43fa3 fixes a bug that sends half-built STREAM frames when the application fails within `on_send_emit`. Such failure can happen when the application does not have a send buffer but pulls the payload from somewhere at the moment `on_send_emit` is called (e.g., file handler of H2O calling pread (2)).