### PR TITLE
add options for testing retransmission behavior

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -316,9 +316,12 @@ struct st_quicly_context_t {
      */
     uint16_t ack_frequency;
     /**
-     * destroy the packet being sent at given ratio
+     * destroy the packet being sent at given ratio (xorshift with given seed is used for each connection)
      */
-    uint16_t destroy_packet_ratio;
+    struct {
+        uint16_t ratio;
+        uint64_t seed;
+    } destroy_packet;
     /**
      * expand client hello so that it does not fit into one datagram
      */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -320,6 +320,10 @@ struct st_quicly_context_t {
      */
     unsigned expand_client_hello : 1;
     /**
+     * intentionally fragment stream payload; this is useful for testing retransmission
+     */
+    unsigned fragment_payload : 1;
+    /**
      *
      */
     quicly_cid_encryptor_t *cid_encryptor;

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -316,6 +316,10 @@ struct st_quicly_context_t {
      */
     uint16_t ack_frequency;
     /**
+     * destroy the packet being sent at given ratio
+     */
+    uint16_t destroy_packet_ratio;
+    /**
      * expand client hello so that it does not fit into one datagram
      */
     unsigned expand_client_hello : 1;

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -28,6 +28,7 @@
 #define DEFAULT_MAX_CRYPTO_BYTES 65536
 #define DEFAULT_INITCWND_PACKETS 10
 #define DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT 3
+#define DEFAULT_DESTROY_PACKET_SEED 88172645463325252
 
 /* profile that employs IETF specified values */
 const quicly_context_t quicly_spec_context = {NULL,                                                 /* tls */
@@ -45,7 +46,7 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                               QUICLY_PROTOCOL_VERSION_1,
                                               DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                               0, /* ack_frequency */
-                                              0, /* destroy_packet_ratio */
+                                              {0, DEFAULT_DESTROY_PACKET_SEED}, /* destroy_packet */
                                               0, /* enlarge_client_hello */
                                               0, /* fragment_payload */
                                               NULL,
@@ -75,7 +76,7 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                     QUICLY_PROTOCOL_VERSION_1,
                                                     DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                                     0, /* ack_frequency */
-                                                    0, /* destroy_packet_ratio */
+                                                    {0, DEFAULT_DESTROY_PACKET_SEED}, /* destroy_packet */
                                                     0, /* enlarge_client_hello */
                                                     0, /* fragment_payload */
                                                     NULL,

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -45,6 +45,7 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                               QUICLY_PROTOCOL_VERSION_1,
                                               DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                               0, /* ack_frequency */
+                                              0, /* destroy_packet_ratio */
                                               0, /* enlarge_client_hello */
                                               0, /* fragment_payload */
                                               NULL,
@@ -74,6 +75,7 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                     QUICLY_PROTOCOL_VERSION_1,
                                                     DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                                     0, /* ack_frequency */
+                                                    0, /* destroy_packet_ratio */
                                                     0, /* enlarge_client_hello */
                                                     0, /* fragment_payload */
                                                     NULL,

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -46,6 +46,7 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                               DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                               0, /* ack_frequency */
                                               0, /* enlarge_client_hello */
+                                              0, /* fragment_payload */
                                               NULL,
                                               NULL, /* on_stream_open */
                                               &quicly_default_stream_scheduler,
@@ -74,6 +75,7 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                     DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                                     0, /* ack_frequency */
                                                     0, /* enlarge_client_hello */
+                                                    0, /* fragment_payload */
                                                     NULL,
                                                     NULL, /* on_stream_open */
                                                     &quicly_default_stream_scheduler,

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3111,6 +3111,15 @@ static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, int
                                                    s->dst_payload_from - s->payload_buf.datagram, conn->egress.packet_number,
                                                    coalesced);
 
+    /* packet drill: intentionally destroy the packet at given ratio */
+    if (conn->super.ctx->destroy_packet_ratio > 0) {
+        uint16_t rand_ratio;
+        conn->super.ctx->tls->random_bytes(&rand_ratio, sizeof(rand_ratio));
+        rand_ratio %= 1024;
+        if (rand_ratio < conn->super.ctx->destroy_packet_ratio)
+            s->dst[-1] ^= 1;
+    }
+
     /* update CC, commit sentmap */
     if (s->target.ack_eliciting) {
         packet_bytes_in_flight = s->dst - s->target.first_byte_at;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3606,7 +3606,8 @@ int quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t *s)
         } else {
             header[0] = QUICLY_FRAME_TYPE_STREAM_BASE;
         }
-        if (!quicly_sendstate_is_open(&stream->sendstate) && off == stream->sendstate.final_size) {
+        if (off == stream->sendstate.final_size) {
+            assert(!quicly_sendstate_is_open(&stream->sendstate));
             /* special case for emitting FIN only */
             header[0] |= QUICLY_FRAME_TYPE_STREAM_BIT_FIN;
             if ((ret = allocate_ack_eliciting_frame(stream->conn, s, hp - header, &sent, on_ack_stream)) != 0)
@@ -3643,7 +3644,8 @@ int quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t *s)
     }
     { /* cap len to the current range */
         uint64_t range_capacity = stream->sendstate.pending.ranges[0].end - off;
-        if (!quicly_sendstate_is_open(&stream->sendstate) && off + range_capacity > stream->sendstate.final_size) {
+        if (off + range_capacity > stream->sendstate.final_size) {
+            assert(!quicly_sendstate_is_open(&stream->sendstate));
             assert(range_capacity > 1); /* see the special case above */
             range_capacity -= 1;
         }
@@ -3666,7 +3668,8 @@ int quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t *s)
     adjust_stream_frame_layout(&s->dst, s->dst_end, &len, &wrote_all, &frame_type_at);
 
     /* determine if the frame incorporates FIN */
-    if (!quicly_sendstate_is_open(&stream->sendstate) && off + len == stream->sendstate.final_size) {
+    if (off + len == stream->sendstate.final_size) {
+        assert(!quicly_sendstate_is_open(&stream->sendstate));
         assert(frame_type_at != NULL);
         is_fin = 1;
         *frame_type_at |= QUICLY_FRAME_TYPE_STREAM_BIT_FIN;

--- a/src/cli.c
+++ b/src/cli.c
@@ -1052,6 +1052,8 @@ static void usage(const char *cmd)
            "  -x named-group            named group to be used (default: secp256r1)\n"
            "  -X                        max bidirectional stream count (default: 100)\n"
            "  -y cipher-suite           cipher-suite to be used (default: all)\n"
+           "  -Y ratio                  destroy the packet being sent at given ratio\n"
+           "                            (default: 0)\n"
            "  -h                        print this help\n"
            "\n",
            cmd);
@@ -1095,7 +1097,7 @@ int main(int argc, char **argv)
         address_token_aead.dec = ptls_aead_new(&ptls_openssl_aes128gcm, &ptls_openssl_sha256, 0, secret, "");
     }
 
-    while ((ch = getopt(argc, argv, "a:b:B:c:C:Dd:k:Ee:Ff:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvw:W:x:X:y:h")) != -1) {
+    while ((ch = getopt(argc, argv, "a:b:B:c:C:Dd:k:Ee:Ff:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvw:W:x:X:Y:y:h")) != -1) {
         switch (ch) {
         case 'a':
             assert(negotiated_protocols.count < PTLS_ELEMENTSOF(negotiated_protocols.list));
@@ -1295,6 +1297,14 @@ int main(int argc, char **argv)
                 exit(1);
             }
             break;
+        case 'Y': {
+            double ratio;
+            if (sscanf(optarg, "%lf", &ratio) != 1 || !(0 <= ratio && ratio <= 1)) {
+                fprintf(stderr, "failed to parse packet destroy ratio (-Y): %s\n", optarg);
+                exit(1);
+            }
+            ctx.destroy_packet_ratio = (uint16_t)(ratio * 1024);
+        } break;
         case 'y': {
             size_t i;
             for (i = 0; cipher_suites[i] != NULL; ++i)

--- a/src/cli.c
+++ b/src/cli.c
@@ -1303,7 +1303,7 @@ int main(int argc, char **argv)
                 fprintf(stderr, "failed to parse packet destroy ratio (-Y): %s\n", optarg);
                 exit(1);
             }
-            ctx.destroy_packet_ratio = (uint16_t)(ratio * 1024);
+            ctx.destroy_packet.ratio = (uint16_t)(ratio * 1024);
         } break;
         case 'y': {
             size_t i;

--- a/src/cli.c
+++ b/src/cli.c
@@ -1022,6 +1022,7 @@ static void usage(const char *cmd)
            "  -E                        expand Client Hello (sends multiple client Initials)\n"
            "  -f fraction               increases the induced ack frequency to specified\n"
            "                            fraction of CWND (default: 0)\n"
+           "  -F                        introduce fragmentation\n"
            "  -G                        enable UDP generic segmentation offload\n"
            "  -i interval               interval to reissue requests (in milliseconds)\n"
            "  -I timeout                idle timeout (in milliseconds; default: 600,000)\n"
@@ -1094,7 +1095,7 @@ int main(int argc, char **argv)
         address_token_aead.dec = ptls_aead_new(&ptls_openssl_aes128gcm, &ptls_openssl_sha256, 0, secret, "");
     }
 
-    while ((ch = getopt(argc, argv, "a:b:B:c:C:Dd:k:Ee:f:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvw:W:x:X:y:h")) != -1) {
+    while ((ch = getopt(argc, argv, "a:b:B:c:C:Dd:k:Ee:Ff:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvw:W:x:X:y:h")) != -1) {
         switch (ch) {
         case 'a':
             assert(negotiated_protocols.count < PTLS_ELEMENTSOF(negotiated_protocols.list));
@@ -1155,6 +1156,9 @@ int main(int argc, char **argv)
                 exit(1);
             }
             setvbuf(quicly_trace_fp, NULL, _IONBF, 0);
+            break;
+        case 'F':
+            ctx.fragment_payload = 1;
             break;
         case 'f': {
             double fraction;

--- a/t/test.c
+++ b/t/test.c
@@ -98,6 +98,70 @@ quicly_stream_callbacks_t stream_callbacks = {
     on_destroy, quicly_streambuf_egress_shift, quicly_streambuf_egress_emit, on_egress_stop, on_ingress_receive, on_ingress_reset};
 size_t on_destroy_callcnt;
 
+static void test_adjust_stream_frame_layout(void)
+{
+#define TEST(_is_crypto, _capacity, check)                                                                                         \
+    do {                                                                                                                           \
+        uint8_t buf[] = {0xff, 0x04, 'h', 'e', 'l', 'l', 'o', 0, 0, 0};                                                            \
+        uint8_t *dst = buf + 2, *const dst_end = buf + _capacity, *frame_type_at = _is_crypto ? NULL : buf;                        \
+        size_t len = 5;                                                                                                            \
+        int wrote_all = 1;                                                                                                         \
+        buf[0] = _is_crypto ? 0x06 : 0x08;                                                                                         \
+        adjust_stream_frame_layout(&dst, dst_end, &len, &wrote_all, &frame_type_at);                                               \
+        do {                                                                                                                       \
+            check                                                                                                                  \
+        } while (0);                                                                                                               \
+    } while (0);
+
+    /* test CRYPTO frames that fit and don't when length is inserted */
+    TEST(1, 10, {
+        ok(dst == buf + 8);
+        ok(len == 5);
+        ok(wrote_all);
+        ok(frame_type_at == NULL);
+        ok(memcmp(buf, "\x06\x04\x05hello", 8) == 0);
+    });
+    TEST(1, 8, {
+        ok(dst == buf + 8);
+        ok(len == 5);
+        ok(wrote_all);
+        ok(frame_type_at == NULL);
+        ok(memcmp(buf, "\x06\x04\x05hello", 8) == 0);
+    });
+    TEST(1, 7, {
+        ok(dst == buf + 7);
+        ok(len == 4);
+        ok(!wrote_all);
+        ok(frame_type_at == NULL);
+        ok(memcmp(buf, "\x06\x04\x04hell", 7) == 0);
+    });
+
+    /* test STREAM frames */
+    TEST(0, 9, {
+        ok(dst == buf + 8);
+        ok(len == 5);
+        ok(wrote_all);
+        ok(frame_type_at == buf);
+        ok(memcmp(buf, "\x0a\x04\x05hello", 8) == 0);
+    });
+    TEST(0, 8, {
+        ok(dst == buf + 8);
+        ok(len == 5);
+        ok(wrote_all);
+        ok(frame_type_at == buf + 1);
+        ok(memcmp(buf, "\x00\x08\x04hello", 8) == 0);
+    });
+    TEST(0, 7, {
+        ok(dst == buf + 7);
+        ok(len == 5);
+        ok(wrote_all);
+        ok(frame_type_at == buf);
+        ok(memcmp(buf, "\x08\x04hello", 7) == 0);
+    });
+
+#undef TEST
+}
+
 static int64_t get_now_cb(quicly_now_t *self)
 {
     return quic_now;
@@ -700,6 +764,7 @@ int main(int argc, char **argv)
     subtest("maxsender", test_maxsender);
     subtest("sentmap", test_sentmap);
     subtest("loss", test_loss);
+    subtest("adjust-stream-frame-layout", test_adjust_stream_frame_layout);
     subtest("test-vector", test_vector);
     subtest("test-retry-aead", test_retry_aead);
     subtest("transport-parameters", test_transport_parameters);


### PR DESCRIPTION
This PR adds two fields to `quicly_context_t` as well as command line options for controlling them in `cli`.

* `fragment_payload` - cause fragmentation of stream data being sent
* `destroy_packet` - ratio at which packets being sent should be destroyed (so that they would be rejected by the receiver)

These options can be together used as a way of testing retransmission behavior regardless of type of the payload (assuming that the message being transmitted is longer than one byte).