### PR TITLE
Remove QUICLY_DEBUG blocks

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -46,10 +46,6 @@ extern "C" {
 #include "quicly/cid.h"
 #include "quicly/remote_cid.h"
 
-#ifndef QUICLY_DEBUG
-#define QUICLY_DEBUG 0
-#endif
-
 /* invariants! */
 #define QUICLY_LONG_HEADER_BIT 0x80
 #define QUICLY_QUIC_BIT 0x40

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -398,13 +398,6 @@ static int default_setup_cipher(quicly_crypto_engine_t *engine, quicly_conn_t *c
         ret = PTLS_ERROR_NO_MEMORY;
         goto Exit;
     }
-    if (QUICLY_DEBUG) {
-        char *secret_hex = quicly_hexdump(secret, hash->digest_size, SIZE_MAX),
-             *hpkey_hex = quicly_hexdump(hpkey, aead->ctr_cipher->key_size, SIZE_MAX);
-        fprintf(stderr, "%s:\n  aead-secret: %s\n  hp-key: %s\n", __FUNCTION__, secret_hex, hpkey_hex);
-        free(secret_hex);
-        free(hpkey_hex);
-    }
 
     ret = 0;
 Exit:

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2490,8 +2490,6 @@ static int do_decrypt_packet(ptls_cipher_context_t *header_protection,
 
     /* AEAD decryption */
     if ((ret = (*aead_cb)(aead_ctx, *pn, packet, aead_off, &ptlen)) != 0) {
-        if (QUICLY_DEBUG)
-            fprintf(stderr, "%s: aead decryption failure (pn: %" PRIu64 ",code:%d)\n", __FUNCTION__, *pn, ret);
         return ret;
     }
     if (*next_expected_pn <= *pn)
@@ -2529,20 +2527,10 @@ static int decrypt_packet(ptls_cipher_context_t *header_protection,
     if ((packet->octets.base[0] & (QUICLY_PACKET_IS_LONG_HEADER(packet->octets.base[0]) ? QUICLY_LONG_HEADER_RESERVED_BITS
                                                                                         : QUICLY_SHORT_HEADER_RESERVED_BITS)) !=
         0) {
-        if (QUICLY_DEBUG)
-            fprintf(stderr, "%s: non-zero reserved bits (pn: %" PRIu64 ")\n", __FUNCTION__, *pn);
         return QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION;
     }
     if (payload->len == 0) {
-        if (QUICLY_DEBUG)
-            fprintf(stderr, "%s: payload length is zero (pn: %" PRIu64 ")\n", __FUNCTION__, *pn);
         return QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION;
-    }
-
-    if (QUICLY_DEBUG) {
-        char *payload_hex = quicly_hexdump(payload->base, payload->len, 4);
-        fprintf(stderr, "%s: AEAD payload:\n%s", __FUNCTION__, payload_hex);
-        free(payload_hex);
     }
 
     return 0;


### PR DESCRIPTION
As discussed, these are no longer really used as they were mostly useful during early stages of development.