### PR TITLE
quic-interop: change alpn from hq-29 to hq-interop

### DIFF
--- a/misc/quic-interop-runner/run_endpoint.sh
+++ b/misc/quic-interop-runner/run_endpoint.sh
@@ -36,25 +36,25 @@ if [ "$ROLE" == "client" ]; then
             # Client needs to be run twice. First, with one request.
             FILE=`echo $FILES | cut -f1 -d" "`
             echo "/quicly/cli -P /$FILE $SERVER 443"
-            /quicly/cli -P "/"$FILE $TEST_PARAMS -a "hq-29" -x x25519 -x secp256r1 -e /logs/$TESTCASE.out $SERVER 443
+            /quicly/cli -P "/"$FILE $TEST_PARAMS -a "hq-interop" -x x25519 -x secp256r1 -e /logs/$TESTCASE.out $SERVER 443
 
             # Second time, with rest of the requests.
             CLI_LIST=`echo $CLI_LIST | cut -f3- -d" "`
             echo "/quicly/cli $CLI_LIST $SERVER 443"
-            /quicly/cli $CLI_LIST $TEST_PARAMS -a "hq-29" -x x25519 -x secp256r1 -e /logs/$TESTCASE.out $SERVER 443
+            /quicly/cli $CLI_LIST $TEST_PARAMS -a "hq-interop" -x x25519 -x secp256r1 -e /logs/$TESTCASE.out $SERVER 443
             rm -f previous_sessions.bin
 
         elif [ "$TESTCASE" == "multiconnect" ]; then
             # Client needs to be run once per file.
             for FILE in $FILES; do
                 echo "/quicly/cli /$FILE $SERVER 443"
-                /quicly/cli -P "/"$FILE $TEST_PARAMS -a "hq-29" -x x25519 -x secp256r1 -e /logs/$TESTCASE.out $SERVER 443
+                /quicly/cli -P "/"$FILE $TEST_PARAMS -a "hq-interop" -x x25519 -x secp256r1 -e /logs/$TESTCASE.out $SERVER 443
             done
 
         else
             # Client is run once for all files.
             echo "/quicly/cli $CLI_LIST $SERVER 443"
-            /quicly/cli $CLI_LIST $TEST_PARAMS -a "hq-29" -x x25519 -x secp256r1 -e /logs/$TESTCASE.out $SERVER 443
+            /quicly/cli $CLI_LIST $TEST_PARAMS -a "hq-interop" -x x25519 -x secp256r1 -e /logs/$TESTCASE.out $SERVER 443
         fi
 
         # Cleanup.
@@ -75,5 +75,5 @@ elif [ "$ROLE" == "server" ]; then
     echo "Starting quicly server ..."
     echo "SERVER_PARAMS:" $SERVER_PARAMS "TEST_PARAMS:" $TEST_PARAMS
     echo "/quicly/cli $SERVER_PARAMS $TEST_PARAMS -k /certs/priv.key -c /certs/cert.pem -e /logs/$TESTCASE.out 0.0.0.0 443"
-    /quicly/cli $SERVER_PARAMS $TEST_PARAMS -k /certs/priv.key -c /certs/cert.pem -x x25519 -x secp256r1 -a "hq-29" -e /logs/$TESTCASE.out 0.0.0.0 443
+    /quicly/cli $SERVER_PARAMS $TEST_PARAMS -k /certs/priv.key -c /certs/cert.pem -x x25519 -x secp256r1 -a "hq-interop" -e /logs/$TESTCASE.out 0.0.0.0 443
 fi


### PR DESCRIPTION
I was taking a look at https://interop.seemann.io/ and noticed some failures. After some local debugging, it seems to be the ALPN.