### PR TITLE
qlog-adapter: accept stdin

### DIFF
--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -351,8 +351,7 @@ def main():
         try:
             infile = open(fn, "r")
         except OSError as e:
-            print("Failed to open %s: %s" % (fn, e.strerror))
-            sys.exit(1)
+            sys.exit("Failed to open %s: %s" % (fn, e.strerror))
 
     source_events = load_quicly_events(infile)
     print(json.dumps({

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -328,7 +328,7 @@ FRAME_EVENT_HANDLERS = {
 def usage():
     print(r"""
 Usage:
-    python qlog-adapter.py [inTrace.jsonl]
+    python3 qlog-adapter.py [inTrace.jsonl]
 
     If the argument is omitted, inTrace will be read from stdin.
 """.strip())

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -328,7 +328,7 @@ FRAME_EVENT_HANDLERS = {
 def usage():
     print(r"""
 Usage:
-    python3 qlog-adapter.py [inTrace.jsonl]
+    ./misc/qlog-adapter.py [inTrace.jsonl]
 
     If the argument is omitted, inTrace will be read from stdin.
 """.strip())

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -328,22 +328,32 @@ FRAME_EVENT_HANDLERS = {
 def usage():
     print(r"""
 Usage:
-    python qlog-adapter.py inTrace.jsonl
+    python qlog-adapter.py [inTrace.jsonl]
+
+    If the argument is omitted, inTrace will be read from stdin.
 """.strip())
 
 def load_quicly_events(infile):
     events = []
-    with open(infile, "r") as fh:
-        for line in fh:
-            events.append(json.loads(line))
+    for line in infile:
+        events.append(json.loads(line))
     return events
 
 def main():
-    if len(sys.argv) != 2:
+    if len(sys.argv) > 2:
         usage()
         sys.exit(1)
 
-    (_, infile) = sys.argv
+    if len(sys.argv) == 1:
+        infile = sys.stdin
+    else:
+        (_, fn) = sys.argv
+        try:
+            infile = open(fn, "r")
+        except OSError as e:
+            print("Failed to open %s: %s" % (fn, e.strerror))
+            sys.exit(1)
+
     source_events = load_quicly_events(infile)
     print(json.dumps({
         "qlog_format": "NDJSON",


### PR DESCRIPTION
It would be natural for this type of tool to be used like
```
cmd-emits-h2olog | qlog-adapter.py > qlog-file
```
This patch modifies qlog-adapter's behavior so that if an input file name is omitted, it reads input from stdin.