### PR TITLE
qlog-adapter: start reading from idx == 0

### DIFF
--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -73,7 +73,7 @@ def handle_packet_received(events, idx):
 def handle_packet_sent(events, idx):
     frames = []
     i = idx-1
-    while i > 0 and events[i]["type"] != "packet-prepare":
+    while i >= 0 and events[i]["type"] != "packet-prepare":
         handler = FRAME_EVENT_HANDLERS.get(events[i]["type"])
         if handler:
             frames.append(handler(events[i]))


### PR DESCRIPTION
This fixes an issue that qlog-adapter ignored the first event (idx == 0) when gathering sent frame information.