### PR TITLE
qlog-adapter: Add handler for `max_streams_receive`

### DIFF
--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -137,6 +137,17 @@ def handle_max_streams_send(event):
         "maximum": event["maximum"]
     }
 
+def handle_max_streams_receive(event):
+    if event["is-unidirectional"]:
+        stream_type = "unidirectional"
+    else:
+        stream_type = "bidirectional"
+    return {
+        "frame_type": "max_streams",
+        "stream_type": stream_type,
+        "maximum": event["maximum"]
+    }
+
 def handle_max_stream_data_receive(event):
     return {
         "frame_type": "max_stream_data",
@@ -304,6 +315,7 @@ FRAME_EVENT_HANDLERS = {
     "max-data-receive": handle_max_data_receive,
     "max-data-send": handle_max_data_send,
     "max-streams-send": handle_max_streams_send,
+    "max-streams-receive": handle_max_streams_receive,
     "max-stream-data-receive": handle_max_stream_data_receive,
     "max-stream-data-send": handle_max_stream_data_send,
     "new-connection-id-receive": handle_new_connection_id_receive,


### PR DESCRIPTION
The `receive` handler is missing while the `send` version exists. I assume this is due to an error.