### PR TITLE
Adaptive loss thresholds to handle packet reorders

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -478,6 +478,10 @@ typedef struct st_quicly_stats_t {
      */
     quicly_rtt_t rtt;
     /**
+     * Loss thresholds.
+     */
+    quicly_loss_thresholds_t loss_thresholds;
+    /**
      * Congestion control stats (experimental; TODO cherry-pick what can be exposed as part of a stable API).
      */
     quicly_cc_t cc;

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -111,6 +111,19 @@ typedef struct quicly_loss_t {
      */
     const uint8_t *ack_delay_exponent;
     /**
+     * Controls loss thresholds.
+     */
+    struct {
+        /**
+         * boolean
+         */
+        uint8_t use_packet_based;
+        /**
+         * time threshold percentile, relative to RTT (i.e., 1024 is one RTT)
+         */
+        uint16_t time_based_percentile;
+    } loss_thresholds;
+    /**
      * The number of consecutive PTOs (PTOs that have fired without receiving an ack).
      */
     int8_t pto_count;
@@ -236,6 +249,7 @@ inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, u
                          .max_ack_delay = max_ack_delay,
                          .ack_delay_exponent = ack_delay_exponent,
                          .pto_count = 0,
+                         .loss_thresholds = {.use_packet_based = 1, .time_based_percentile = 1024 / 8 /* start from 1/8 RTT */},
                          .time_of_last_packet_sent = 0,
                          .largest_acked_packet_plus1 = {0},
                          .total_bytes_sent = 0,

--- a/lib/loss.c
+++ b/lib/loss.c
@@ -49,7 +49,7 @@ int quicly_loss_detect_loss(quicly_loss_t *loss, int64_t now, uint32_t max_ack_d
      * detection. if no timer is required, loss_time is set to INT64_MAX. */
 
     const uint32_t delay_until_lost = ((loss->rtt.latest > loss->rtt.smoothed ? loss->rtt.latest : loss->rtt.smoothed) *
-                                           (1024 + loss->loss_thresholds.time_based_percentile) +
+                                           (1024 + loss->thresholds.time_based_percentile) +
                                        1023) /
                                       1024;
     quicly_sentmap_iter_t iter;

--- a/lib/loss.c
+++ b/lib/loss.c
@@ -58,7 +58,7 @@ int quicly_loss_detect_loss(quicly_loss_t *loss, int64_t now, uint32_t max_ack_d
 
 #define CHECK_TIME_THRESHOLD(sent) ((sent)->sent_at <= now - delay_until_lost)
 #define CHECK_PACKET_THRESHOLD(sent)                                                                                               \
-    (loss->loss_thresholds.use_packet_based &&                                                                                     \
+    (loss->thresholds.use_packet_based &&                                                                                          \
      (int64_t)(sent)->packet_number <= largest_acked_signed - QUICLY_LOSS_DEFAULT_PACKET_THRESHOLD)
 
     loss->loss_time = INT64_MAX;

--- a/lib/loss.c
+++ b/lib/loss.c
@@ -48,10 +48,18 @@ int quicly_loss_detect_loss(quicly_loss_t *loss, int64_t now, uint32_t max_ack_d
     /* This function ensures that the value returned in loss_time is when the next application timer should be set for loss
      * detection. if no timer is required, loss_time is set to INT64_MAX. */
 
-    const uint32_t delay_until_lost = ((loss->rtt.latest > loss->rtt.smoothed ? loss->rtt.latest : loss->rtt.smoothed) * 9 + 7) / 8;
+    const uint32_t delay_until_lost = ((loss->rtt.latest > loss->rtt.smoothed ? loss->rtt.latest : loss->rtt.smoothed) *
+                                           (1024 + loss->loss_thresholds.time_based_percentile) +
+                                       1023) /
+                                      1024;
     quicly_sentmap_iter_t iter;
     const quicly_sent_packet_t *sent;
     int ret;
+
+#define CHECK_TIME_THRESHOLD(sent) ((sent)->sent_at <= now - delay_until_lost)
+#define CHECK_PACKET_THRESHOLD(sent)                                                                                               \
+    (loss->loss_thresholds.use_packet_based &&                                                                                     \
+     (int64_t)(sent)->packet_number <= largest_acked_signed - QUICLY_LOSS_DEFAULT_PACKET_THRESHOLD)
 
     loss->loss_time = INT64_MAX;
 
@@ -62,12 +70,9 @@ int quicly_loss_detect_loss(quicly_loss_t *loss, int64_t now, uint32_t max_ack_d
      * windows. Once marked as lost, cc_bytes_in_flight becomes zero. */
     while ((sent = quicly_sentmap_get(&iter))->packet_number != UINT64_MAX) {
         int64_t largest_acked_signed = loss->largest_acked_packet_plus1[sent->ack_epoch] - 1;
-        if ((int64_t)sent->packet_number < largest_acked_signed &&
-            (sent->sent_at <= now - delay_until_lost ||                                                      /* time threshold */
-             (int64_t)sent->packet_number <= largest_acked_signed - QUICLY_LOSS_DEFAULT_PACKET_THRESHOLD)) { /* packet threshold */
+        if ((int64_t)sent->packet_number < largest_acked_signed && (CHECK_TIME_THRESHOLD(sent) || CHECK_PACKET_THRESHOLD(sent))) {
             if (sent->cc_bytes_in_flight != 0) {
-                on_loss_detected(loss, sent,
-                                 (int64_t)sent->packet_number > largest_acked_signed - QUICLY_LOSS_DEFAULT_PACKET_THRESHOLD);
+                on_loss_detected(loss, sent, !CHECK_PACKET_THRESHOLD(sent));
                 if ((ret = quicly_sentmap_update(&loss->sentmap, &iter, QUICLY_SENTMAP_EVENT_LOST)) != 0)
                     return ret;
             } else {
@@ -81,6 +86,9 @@ int quicly_loss_detect_loss(quicly_loss_t *loss, int64_t now, uint32_t max_ack_d
             quicly_sentmap_skip(&iter);
         }
     }
+
+#undef CHECK_TIME_THRESHOLD
+#undef CHECK_PACKET_THRESHOLD
 
     if (!is_1rtt_only) {
         if ((ret = quicly_loss_init_sentmap_iter(loss, &iter, now, max_ack_delay, 0)) != 0)

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1207,6 +1207,7 @@ int quicly_get_stats(quicly_conn_t *conn, quicly_stats_t *stats)
 
     /* set or generate the non-pre-built stats fields here */
     stats->rtt = conn->egress.loss.rtt;
+    stats->loss_thresholds = conn->egress.loss.thresholds;
     stats->cc = conn->egress.cc;
     quicly_ratemeter_report(&conn->egress.ratemeter, &stats->delivery_rate);
 


### PR DESCRIPTION
Implements:
* [x] Adaptive loss threshold.  When receiving the first ACK carrying late ACKs, disable packet-based threshold. Then, for each successive ACK carrying late ACKs, double the time threshold until it reaches 1 RTT.
* [x] Export loss threshold being used through `quicly_stats_t`.
* [ ] Add tests.

The adaptive logic being implemented is dumb, but it would be sufficient as a stop-gap solution. The cost of calling out late acks depends on the sensitivity of the congestion controller to loss events - we can revisit the design of adaptive thresholds after we have more data (obtained through the added stats) or after we switch to a loss-resilient CC.