### PR TITLE
Mitigate sentmap size explosion

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -485,6 +485,10 @@ typedef struct st_quicly_stats_t {
      * Estimated delivery rate, in bytes/second.
      */
     quicly_rate_t delivery_rate;
+    /**
+     * maximum number of packets contained in the sentmap
+     */
+    size_t num_sentmap_packets_max;
 } quicly_stats_t;
 
 /**

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -316,6 +316,11 @@ struct st_quicly_context_t {
      */
     uint32_t handshake_timeout_rtt_multiplier;
     /**
+     * if the number of Initial/Handshake packets sent during the handshake phase exceeds this limit, treat it as an error and close
+     * the connection.
+     */
+    uint64_t max_initial_handshake_packets;
+    /**
      * expand client hello so that it does not fit into one datagram
      */
     unsigned expand_client_hello : 1;
@@ -482,7 +487,11 @@ struct st_quicly_conn_streamgroup_state_t {
     /**                                                                                                                            \
      * number of timeouts occurred during handshake due to no progress being made (see `handshake_timeout_rtt_multiplier`)         \
      */                                                                                                                            \
-    uint64_t num_handshake_timeouts
+    uint64_t num_handshake_timeouts;                                                                                               \
+    /**                                                                                                                            \
+     * Total number of events where `initial_handshake_sent` exceeds limit.                                                        \
+     */                                                                                                                            \
+    uint64_t num_initial_handshake_exceeded
 
 typedef struct st_quicly_stats_t {
     /**

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -404,10 +404,10 @@ struct st_quicly_conn_streamgroup_state_t {
 };
 
 /**
- * Values that do not need to be gathered upon the invocation of `quicly_get_stats`. We use typedef to define the same fields in
- * the same order for quicly_stats_t and `struct st_quicly_conn_public_t::stats`.
+ * Aggregatable counters that do not need to be gathered upon the invocation of `quicly_get_stats`. We use typedef to define the
+ * same fields in the same order for quicly_stats_t and `struct st_quicly_conn_public_t::stats`.
  */
-#define QUICLY_STATS_PREBUILT_FIELDS                                                                                               \
+#define QUICLY_STATS_PREBUILT_COUNTERS                                                                                             \
     struct {                                                                                                                       \
         /**                                                                                                                        \
          * Total number of packets received.                                                                                       \
@@ -482,10 +482,6 @@ struct st_quicly_conn_streamgroup_state_t {
      */                                                                                                                            \
     uint64_t num_ptos;                                                                                                             \
     /**                                                                                                                            \
-     * Time took until handshake is confirmed. UINT64_MAX if handshake is not confirmed yet.                                       \
-     */                                                                                                                            \
-    uint64_t handshake_confirmed_msec;                                                                                             \
-    /**                                                                                                                            \
      * number of timeouts occurred during handshake due to no progress being made (see `handshake_timeout_rtt_multiplier`)         \
      */                                                                                                                            \
     uint64_t num_handshake_timeouts;                                                                                               \
@@ -498,7 +494,7 @@ typedef struct st_quicly_stats_t {
     /**
      * The pre-built fields. This MUST be the first member of `quicly_stats_t` so that we can use `memcpy`.
      */
-    QUICLY_STATS_PREBUILT_FIELDS;
+    QUICLY_STATS_PREBUILT_COUNTERS;
     /**
      * RTT stats.
      */
@@ -583,7 +579,11 @@ struct _st_quicly_conn_public_t {
     quicly_cid_t original_dcid;
     struct st_quicly_default_scheduler_state_t _default_scheduler;
     struct {
-        QUICLY_STATS_PREBUILT_FIELDS;
+        QUICLY_STATS_PREBUILT_COUNTERS;
+        /**
+         * Time took until handshake is confirmed. UINT64_MAX if handshake is not confirmed yet.
+         */
+        uint64_t handshake_confirmed_msec;
     } stats;
     uint32_t version;
     void *data;

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -512,9 +512,9 @@ typedef struct st_quicly_stats_t {
      */
     quicly_rate_t delivery_rate;
     /**
-     * maximum number of packets contained in the sentmap
+     * largest number of packets contained in the sentmap
      */
-    size_t num_sentmap_packets_max;
+    size_t num_sentmap_packets_largest;
 } quicly_stats_t;
 
 /**

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -312,6 +312,10 @@ struct st_quicly_context_t {
      */
     uint16_t ack_frequency;
     /**
+     * if the handshake does not complete within this value * RTT, close connection
+     */
+    uint32_t handshake_timeout_rtt_multiplier;
+    /**
      * expand client hello so that it does not fit into one datagram
      */
     unsigned expand_client_hello : 1;
@@ -474,7 +478,11 @@ struct st_quicly_conn_streamgroup_state_t {
     /**                                                                                                                            \
      * Time spent during handshake. UINT64_MAX if still in handshake.                                                              \
      */                                                                                                                            \
-    uint64_t handshake_msec
+    uint64_t handshake_msec;                                                                                                       \
+    /**                                                                                                                            \
+     * number of timeouts occurred during handshake due to no progress being made (see `handshake_timeout_rtt_multiplier`)         \
+     */                                                                                                                            \
+    uint64_t num_handshake_timeouts
 
 typedef struct st_quicly_stats_t {
     /**

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -482,9 +482,9 @@ struct st_quicly_conn_streamgroup_state_t {
      */                                                                                                                            \
     uint64_t num_ptos;                                                                                                             \
     /**                                                                                                                            \
-     * Time spent during handshake. UINT64_MAX if still in handshake.                                                              \
+     * Time took until handshake is confirmed. UINT64_MAX if handshake is not confirmed yet.                                       \
      */                                                                                                                            \
-    uint64_t handshake_msec;                                                                                                       \
+    uint64_t handshake_confirmed_msec;                                                                                             \
     /**                                                                                                                            \
      * number of timeouts occurred during handshake due to no progress being made (see `handshake_timeout_rtt_multiplier`)         \
      */                                                                                                                            \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -312,7 +312,8 @@ struct st_quicly_context_t {
      */
     uint16_t ack_frequency;
     /**
-     * if the handshake does not complete within this value * RTT, close connection
+     * If the handshake does not complete within this value * RTT, close connection.
+     * When RTT is not observed, timeout is calculated relative to initial RTT (333ms by default).
      */
     uint32_t handshake_timeout_rtt_multiplier;
     /**

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -427,6 +427,10 @@ struct st_quicly_conn_streamgroup_state_t {
          * Total number of packets for which acknowledgements were received after being marked lost.                               \
          */                                                                                                                        \
         uint64_t late_acked;                                                                                                       \
+        /**                                                                                                                        \
+         * Total number of Initial and Handshake packets sent.                                                                     \
+         */                                                                                                                        \
+        uint64_t initial_handshake_sent;                                                                                           \
     } num_packets;                                                                                                                 \
     struct {                                                                                                                       \
         /**                                                                                                                        \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -466,7 +466,11 @@ struct st_quicly_conn_streamgroup_state_t {
     /**                                                                                                                            \
      * Total number of PTOs observed during the connection.                                                                        \
      */                                                                                                                            \
-    uint64_t num_ptos
+    uint64_t num_ptos;                                                                                                             \
+    /**                                                                                                                            \
+     * Time spent during handshake. UINT64_MAX if still in handshake.                                                              \
+     */                                                                                                                            \
+    uint64_t handshake_msec
 
 typedef struct st_quicly_stats_t {
     /**

--- a/include/quicly/sentmap.h
+++ b/include/quicly/sentmap.h
@@ -211,9 +211,9 @@ struct st_quicly_sentmap_t {
      */
     size_t num_packets;
     /**
-     * maximum number recorded for num_packets
+     * largest number recorded for num_packets
      */
-    size_t num_packets_max;
+    size_t num_packets_largest;
     /**
      * bytes in-flight
      */
@@ -303,8 +303,8 @@ inline void quicly_sentmap_commit(quicly_sentmap_t *map, uint16_t bytes_in_fligh
     map->_pending_packet = NULL;
 
     ++map->num_packets;
-    if (map->num_packets > map->num_packets_max)
-        map->num_packets_max = map->num_packets;
+    if (map->num_packets > map->num_packets_largest)
+        map->num_packets_largest = map->num_packets;
 }
 
 inline quicly_sent_t *quicly_sentmap_allocate(quicly_sentmap_t *map, quicly_sent_acked_cb acked)

--- a/include/quicly/sentmap.h
+++ b/include/quicly/sentmap.h
@@ -211,6 +211,10 @@ struct st_quicly_sentmap_t {
      */
     size_t num_packets;
     /**
+     * maximum number recorded for num_packets
+     */
+    size_t num_packets_max;
+    /**
      * bytes in-flight
      */
     size_t bytes_in_flight;
@@ -299,6 +303,8 @@ inline void quicly_sentmap_commit(quicly_sentmap_t *map, uint16_t bytes_in_fligh
     map->_pending_packet = NULL;
 
     ++map->num_packets;
+    if (map->num_packets > map->num_packets_max)
+        map->num_packets_max = map->num_packets;
 }
 
 inline quicly_sent_t *quicly_sentmap_allocate(quicly_sentmap_t *map, quicly_sent_acked_cb acked)

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -28,6 +28,7 @@
 #define DEFAULT_MAX_CRYPTO_BYTES 65536
 #define DEFAULT_INITCWND_PACKETS 10
 #define DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT 3
+#define DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER 400
 
 /* profile that employs IETF specified values */
 const quicly_context_t quicly_spec_context = {NULL,                                                 /* tls */
@@ -45,6 +46,7 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                               QUICLY_PROTOCOL_VERSION_1,
                                               DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                               0, /* ack_frequency */
+                                              DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
                                               0, /* enlarge_client_hello */
                                               NULL,
                                               NULL, /* on_stream_open */
@@ -73,6 +75,7 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                     QUICLY_PROTOCOL_VERSION_1,
                                                     DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                                     0, /* ack_frequency */
+                                                    DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
                                                     0, /* enlarge_client_hello */
                                                     NULL,
                                                     NULL, /* on_stream_open */

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -29,6 +29,7 @@
 #define DEFAULT_INITCWND_PACKETS 10
 #define DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT 3
 #define DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER 400
+#define DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS 1000
 
 /* profile that employs IETF specified values */
 const quicly_context_t quicly_spec_context = {NULL,                                                 /* tls */
@@ -47,6 +48,7 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                               DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                               0, /* ack_frequency */
                                               DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
+                                              DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
                                               0, /* enlarge_client_hello */
                                               NULL,
                                               NULL, /* on_stream_open */
@@ -76,6 +78,7 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                     DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                                     0, /* ack_frequency */
                                                     DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
+                                                    DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
                                                     0, /* enlarge_client_hello */
                                                     NULL,
                                                     NULL, /* on_stream_open */

--- a/lib/loss.c
+++ b/lib/loss.c
@@ -32,14 +32,23 @@ int quicly_loss_init_sentmap_iter(quicly_loss_t *loss, quicly_sentmap_iter_t *it
      * below 32 packets. This exception (the threshold of 32) exists to be capable of recognizing excessively late-ACKs when under
      * heavy loss; in such case, 32 is more than enough, yet small enough that the memory footprint does not matter. */
     const quicly_sent_packet_t *sent;
-    while ((sent = quicly_sentmap_get(iter))->sent_at <= retire_before && sent->cc_bytes_in_flight == 0) {
-        int ret;
+    int ret = 0;
+    while ((sent = quicly_sentmap_get(iter))->sent_at <= retire_before) {
         if (!is_closing && loss->sentmap.num_packets < 32)
             break;
+        if (sent->cc_bytes_in_flight != 0) {
+            /* cannot retire packets with cc_bytes_in_flight, but we may find retirable ones later in the map */
+            quicly_sentmap_skip(iter);
+            continue;
+        }
         if ((ret = quicly_sentmap_update(&loss->sentmap, iter, QUICLY_SENTMAP_EVENT_EXPIRED)) != 0)
-            return ret;
+            break;
     }
-    return 0;
+
+    /* rewind iter to the head of the sentmap, before returning it to the caller */
+    quicly_sentmap_init_iter(&loss->sentmap, iter);
+
+    return ret;
 }
 
 int quicly_loss_detect_loss(quicly_loss_t *loss, int64_t now, uint32_t max_ack_delay, int is_1rtt_only,

--- a/lib/loss.c
+++ b/lib/loss.c
@@ -32,8 +32,8 @@ int quicly_loss_init_sentmap_iter(quicly_loss_t *loss, quicly_sentmap_iter_t *it
      * below 32 packets. This exception (the threshold of 32) exists to be capable of recognizing excessively late-ACKs when under
      * heavy loss; in such case, 32 is more than enough, yet small enough that the memory footprint does not matter. */
     const quicly_sent_packet_t *sent;
-    int ret = 0;
     while ((sent = quicly_sentmap_get(iter))->sent_at <= retire_before) {
+        int ret;
         if (!is_closing && loss->sentmap.num_packets < 32)
             break;
         if (sent->cc_bytes_in_flight != 0) {
@@ -42,13 +42,13 @@ int quicly_loss_init_sentmap_iter(quicly_loss_t *loss, quicly_sentmap_iter_t *it
             continue;
         }
         if ((ret = quicly_sentmap_update(&loss->sentmap, iter, QUICLY_SENTMAP_EVENT_EXPIRED)) != 0)
-            break;
+            return ret;
     }
 
     /* rewind iter to the head of the sentmap, before returning it to the caller */
     quicly_sentmap_init_iter(&loss->sentmap, iter);
 
-    return ret;
+    return 0;
 }
 
 int quicly_loss_detect_loss(quicly_loss_t *loss, int64_t now, uint32_t max_ack_delay, int is_1rtt_only,

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3088,6 +3088,12 @@ static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, int
         /* length is always 2 bytes, see _do_prepare_packet */
         length |= 0x4000;
         quicly_encode16(s->dst_payload_from - QUICLY_SEND_PN_SIZE - 2, length);
+        switch (*s->target.first_byte_at & QUICLY_PACKET_TYPE_BITMASK) {
+        case QUICLY_PACKET_TYPE_INITIAL:
+        case QUICLY_PACKET_TYPE_HANDSHAKE:
+            conn->super.stats.num_packets.initial_handshake_sent++;
+            break;
+        }
     } else {
         if (conn->egress.packet_number >= conn->application->cipher.egress.key_update_pn.next) {
             int ret;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -388,6 +388,10 @@ struct st_quicly_conn_t {
         uint8_t should_rearm_on_send : 1;
     } idle_timeout;
     /**
+     * records the time when this connection was created
+     */
+    int64_t created_at;
+    /**
      * structure to hold various data used internally
      */
     struct {
@@ -1474,6 +1478,10 @@ static int discard_handshake_context(quicly_conn_t *conn, size_t epoch)
     if ((ret = discard_sentmap_by_epoch(conn, 1u << epoch)) != 0)
         return ret;
     destroy_handshake_flow(conn, epoch);
+    if (epoch == QUICLY_EPOCH_HANDSHAKE) {
+        assert(conn->stash.now != 0);
+        conn->super.stats.handshake_msec = conn->stash.now - conn->created_at;
+    }
     free_handshake_space(epoch == QUICLY_EPOCH_INITIAL ? &conn->initial : &conn->handshake);
 
     return 0;
@@ -2085,6 +2093,8 @@ static quicly_conn_t *create_connection(quicly_context_t *ctx, uint32_t protocol
     memset(conn, 0, sizeof(*conn));
     conn->super.ctx = ctx;
     lock_now(conn, 0);
+    conn->created_at = conn->stash.now;
+    conn->super.stats.handshake_msec = UINT64_MAX;
     set_address(&conn->super.local.address, local_addr);
     set_address(&conn->super.remote.address, remote_addr);
     quicly_local_cid_init_set(&conn->super.local.cid_set, ctx->cid_encryptor, local_cid);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4356,12 +4356,12 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
     if ((conn->initial != NULL || conn->handshake != NULL) &&
         conn->created_at + (uint64_t)conn->super.ctx->handshake_timeout_rtt_multiplier * conn->egress.loss.rtt.smoothed <=
             conn->stash.now) {
-        QUICLY_PROBE(HANDSHAKE_TIMEOUT, conn, conn->stash.now);
+        QUICLY_PROBE(HANDSHAKE_TIMEOUT, conn, conn->stash.now, conn->stash.now - conn->created_at, conn->egress.loss.rtt.smoothed);
         conn->super.stats.num_handshake_timeouts++;
         goto CloseNow;
     }
     if (conn->super.stats.num_packets.initial_handshake_sent >= conn->super.ctx->max_initial_handshake_packets) {
-        QUICLY_PROBE(INITIAL_HANDSHAKE_PACKET_EXCEED, conn, conn->stash.now);
+        QUICLY_PROBE(INITIAL_HANDSHAKE_PACKET_EXCEED, conn, conn->stash.now, conn->super.stats.num_packets.initial_handshake_sent);
         conn->super.stats.num_initial_handshake_exceeded++;
         goto CloseNow;
     }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1213,7 +1213,7 @@ int quicly_get_stats(quicly_conn_t *conn, quicly_stats_t *stats)
     stats->rtt = conn->egress.loss.rtt;
     stats->cc = conn->egress.cc;
     quicly_ratemeter_report(&conn->egress.ratemeter, &stats->delivery_rate);
-    stats->num_sentmap_packets_max = conn->egress.loss.sentmap.num_packets_max;
+    stats->num_sentmap_packets_largest = conn->egress.loss.sentmap.num_packets_largest;
 
     return 0;
 }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1209,6 +1209,7 @@ int quicly_get_stats(quicly_conn_t *conn, quicly_stats_t *stats)
     stats->rtt = conn->egress.loss.rtt;
     stats->cc = conn->egress.cc;
     quicly_ratemeter_report(&conn->egress.ratemeter, &stats->delivery_rate);
+    stats->num_sentmap_packets_max = conn->egress.loss.sentmap.num_packets_max;
 
     return 0;
 }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4360,6 +4360,11 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
         conn->super.stats.num_handshake_timeouts++;
         goto CloseNow;
     }
+    if (conn->super.stats.num_packets.initial_handshake_sent >= conn->super.ctx->max_initial_handshake_packets) {
+        QUICLY_PROBE(INITIAL_HANDSHAKE_PACKET_EXCEED, conn, conn->stash.now);
+        conn->super.stats.num_initial_handshake_exceeded++;
+        goto CloseNow;
+    }
     if (conn->egress.loss.alarm_at <= conn->stash.now) {
         if ((ret = quicly_loss_on_alarm(&conn->egress.loss, conn->stash.now, conn->super.remote.transport_params.max_ack_delay,
                                         conn->initial == NULL && conn->handshake == NULL, &min_packets_to_send, &restrict_sending,

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4360,7 +4360,7 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
         conn->super.stats.num_handshake_timeouts++;
         goto CloseNow;
     }
-    if (conn->super.stats.num_packets.initial_handshake_sent >= conn->super.ctx->max_initial_handshake_packets) {
+    if (conn->super.stats.num_packets.initial_handshake_sent > conn->super.ctx->max_initial_handshake_packets) {
         QUICLY_PROBE(INITIAL_HANDSHAKE_PACKET_EXCEED, conn, conn->stash.now, conn->super.stats.num_packets.initial_handshake_sent);
         conn->super.stats.num_initial_handshake_exceeded++;
         goto CloseNow;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1480,7 +1480,7 @@ static int discard_handshake_context(quicly_conn_t *conn, size_t epoch)
     destroy_handshake_flow(conn, epoch);
     if (epoch == QUICLY_EPOCH_HANDSHAKE) {
         assert(conn->stash.now != 0);
-        conn->super.stats.handshake_msec = conn->stash.now - conn->created_at;
+        conn->super.stats.handshake_confirmed_msec = conn->stash.now - conn->created_at;
     }
     free_handshake_space(epoch == QUICLY_EPOCH_INITIAL ? &conn->initial : &conn->handshake);
 
@@ -2094,7 +2094,7 @@ static quicly_conn_t *create_connection(quicly_context_t *ctx, uint32_t protocol
     conn->super.ctx = ctx;
     lock_now(conn, 0);
     conn->created_at = conn->stash.now;
-    conn->super.stats.handshake_msec = UINT64_MAX;
+    conn->super.stats.handshake_confirmed_msec = UINT64_MAX;
     set_address(&conn->super.local.address, local_addr);
     set_address(&conn->super.remote.address, remote_addr);
     quicly_local_cid_init_set(&conn->super.local.cid_set, ctx->cid_encryptor, local_cid);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4623,7 +4623,8 @@ int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *s
 
     if (conn->super.state >= QUICLY_STATE_CLOSING) {
         quicly_sentmap_iter_t iter;
-        init_acks_iter(conn, &iter);
+        if ((ret = init_acks_iter(conn, &iter)) != 0)
+            goto Exit;
         /* check if the connection can be closed now (after 3 pto) */
         if (conn->super.state == QUICLY_STATE_DRAINING ||
             conn->super.stats.num_frames_sent.transport_close + conn->super.stats.num_frames_sent.application_close != 0) {
@@ -4950,7 +4951,8 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
         break;
     }
 
-    init_acks_iter(conn, &iter);
+    if ((ret = init_acks_iter(conn, &iter)) != 0)
+        return ret;
 
     /* TODO log PNs being ACKed too late */
 

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -47,6 +47,7 @@ provider quicly {
     probe version_switch(struct st_quicly_conn_t *conn, int64_t at, uint32_t new_version);
     probe idle_timeout(struct st_quicly_conn_t *conn, int64_t at);
     probe handshake_timeout(struct st_quicly_conn_t *conn, int64_t at);
+    probe initial_handshake_packet_exceed(struct st_quicly_conn_t *conn, int64_t at);
     probe stateless_reset_receive(struct st_quicly_conn_t *conn, int64_t at);
 
     probe crypto_handshake(struct st_quicly_conn_t *conn, int64_t at, int ret);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -46,8 +46,8 @@ provider quicly {
     probe receive(struct st_quicly_conn_t *conn, int64_t at, const char *dcid, const void *bytes, size_t bytes_len);
     probe version_switch(struct st_quicly_conn_t *conn, int64_t at, uint32_t new_version);
     probe idle_timeout(struct st_quicly_conn_t *conn, int64_t at);
-    probe handshake_timeout(struct st_quicly_conn_t *conn, int64_t at);
-    probe initial_handshake_packet_exceed(struct st_quicly_conn_t *conn, int64_t at);
+    probe handshake_timeout(struct st_quicly_conn_t *conn, int64_t at, int64_t elapsed, uint32_t rtt_smoothed);
+    probe initial_handshake_packet_exceed(struct st_quicly_conn_t *conn, int64_t at, uint64_t num_packets);
     probe stateless_reset_receive(struct st_quicly_conn_t *conn, int64_t at);
 
     probe crypto_handshake(struct st_quicly_conn_t *conn, int64_t at, int ret);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -46,6 +46,7 @@ provider quicly {
     probe receive(struct st_quicly_conn_t *conn, int64_t at, const char *dcid, const void *bytes, size_t bytes_len);
     probe version_switch(struct st_quicly_conn_t *conn, int64_t at, uint32_t new_version);
     probe idle_timeout(struct st_quicly_conn_t *conn, int64_t at);
+    probe handshake_timeout(struct st_quicly_conn_t *conn, int64_t at);
     probe stateless_reset_receive(struct st_quicly_conn_t *conn, int64_t at);
 
     probe crypto_handshake(struct st_quicly_conn_t *conn, int64_t at, int ret);

--- a/t/lossy.c
+++ b/t/lossy.c
@@ -536,6 +536,10 @@ static void test_bidirectional(void)
 
 void test_lossy(void)
 {
+    uint64_t handshake_timeout_backup = quic_ctx.handshake_timeout_rtt_multiplier;
+    /* loss tests tend to incur gigantic (and artificial) latencies, which easily trigger handshake timeout.
+     * for this test, we totally disable handshake timeout so we can focus on the loss test */
+    quic_ctx.handshake_timeout_rtt_multiplier = UINT32_MAX;
     subtest("even", test_even);
 
     uint64_t idle_timeout_backup = quic_ctx.transport_params.max_idle_timeout;
@@ -544,4 +548,5 @@ void test_lossy(void)
     quic_ctx.transport_params.max_idle_timeout = (uint64_t)600 * 1000; /* 600 seconds */
     subtest("bidirectional", test_bidirectional);
     quic_ctx.transport_params.max_idle_timeout = idle_timeout_backup;
+    quic_ctx.handshake_timeout_rtt_multiplier = handshake_timeout_backup;
 }


### PR DESCRIPTION
A malicious or erroneous client could send Initial/Handshake packets repeatedly and indefinitely grow the number of `sentmap` entries in the server side quicly.

This PR address the issue in the following three ways.
1. When scanning sentmap for expiring entries, scan towards the end of the map to minimize the size of the sentmap, as opposed to stop at the first non-expirable packet.  (d570ded14482d61dc20817731db084e5ba8a8369)
2. If the handshake does not complete within certain timeframe (defined as a multiple of RTT), treat it as an error and close the connection (b506330e79977fac34b51d64a72eae5f6becaaa9)
3. If the number of Initial/Handshake packets sent exceeds a threshold, treat it as an error and close the connection (66e3ec6e0cc68e109adffad9c5ee61363f98f00d)
