### PR TITLE
reset sender state correctly when receiving MAX_DATA, otherwise DATA_BLOCKED would not be sent

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5201,7 +5201,7 @@ static int handle_max_data_frame(quicly_conn_t *conn, struct st_quicly_handle_pa
     if (frame.max_data <= conn->egress.max_data.permitted)
         return 0;
     conn->egress.max_data.permitted = frame.max_data;
-    conn->egress.data_blocked = QUICLY_SENDER_STATE_UNACKED; /* DATA_BLOCKED has not been sent for the new limit */
+    conn->egress.data_blocked = QUICLY_SENDER_STATE_NONE; /* DATA_BLOCKED has not been sent for the new limit */
 
     return 0;
 }


### PR DESCRIPTION
Inside quicly, [a quad-state type called `quicly_sender_state_t`](https://github.com/h2o/quicly/blob/482610bf84af287648c42c0cc0e3429915421979/include/quicly.h#L570-L587) is used for reliably delivering control signals to the peer. The type has four states: NONE (initial), SEND (to be sent), UNACKED (inflight), ACKED (final).

In case of DATA_BLOCKED and STREAM_DATA_BLOCKED frames, when progress is blocked by flow control, we want to start (re)transmitting the blocked frames until we receive an ACK or a new credit is provided by the peer (through MAX_DATA and STREAM_DATA frames).

Once the new credit is provided, the state has to be reinitialized to NONE, so that we could repeat the procedure for that new credit value.

For stream-level flow control, we [correctly reset the state to NONE](https://github.com/h2o/quicly/blob/482610bf84af287648c42c0cc0e3429915421979/lib/quicly.c#L5042).

But, for connection-level flow control, we are [incorrectly setting the state to UNACKED](https://github.com/h2o/quicly/blob/482610bf84af287648c42c0cc0e3429915421979/lib/quicly.c#L5204).

This leads to quicly never sending DATA_BLOCKED frames once a MAX_DATA frame carrying an updated credit value is received. That is because [quicly does not send a DATA_BLOCKED frame when the state is set to UNACKED](https://github.com/h2o/quicly/blob/482610bf84af287648c42c0cc0e3429915421979/lib/quicly.c#L4472-L4473), and because [ACK for DATA_BLOCKED frame becomes a no-op once the credit value is changed](https://github.com/h2o/quicly/blob/482610bf84af287648c42c0cc0e3429915421979/lib/quicly.c#L2799).

TODO: write test.