### PR TITLE
Export handshake_confirmed_msec through stats

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -511,6 +511,10 @@ typedef struct st_quicly_stats_t {
      * largest number of packets contained in the sentmap
      */
     size_t num_sentmap_packets_largest;
+    /**
+     * Time took until handshake is confirmed. UINT64_MAX if handshake is not confirmed yet.
+     */
+    uint64_t handshake_confirmed_msec;
 } quicly_stats_t;
 
 /**

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1214,6 +1214,7 @@ int quicly_get_stats(quicly_conn_t *conn, quicly_stats_t *stats)
     stats->cc = conn->egress.cc;
     quicly_ratemeter_report(&conn->egress.ratemeter, &stats->delivery_rate);
     stats->num_sentmap_packets_largest = conn->egress.loss.sentmap.num_packets_largest;
+    stats->handshake_confirmed_msec = conn->super.stats.handshake_confirmed_msec;
 
     return 0;
 }


### PR DESCRIPTION
This is a follow up PR of #514, that it failed to export `handshake_confirmed_msec` to applications.