### PR TITLE
fix C++ compatibility, and making sure it compiles in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ SET(CMAKE_C_FLAGS "-std=c99 -Wall -g -DQUICLY_USE_TRACER=1 ${CC_WARNING_FLAGS} $
 SET(CMAKE_C_FLAGS_DEBUG "-O0")
 SET(CMAKE_C_FLAGS_RELEASE "-O2")
 
+# C++ flags are used only in tests
+SET(CMAKE_CXX_FLAGS "-Wall")
+
 INCLUDE_DIRECTORIES(
     ${OPENSSL_INCLUDE_DIR}
     deps/klib
@@ -135,9 +138,11 @@ TARGET_LINK_LIBRARIES(examples-echo quicly ${OPENSSL_LIBRARIES} ${CMAKE_DL_LIBS}
 
 ADD_EXECUTABLE(udpfw t/udpfw.c)
 
+ADD_EXECUTABLE(cpp-compat t/cpp-compat.cc)
+
 ADD_CUSTOM_TARGET(check env BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} WITH_DTRACE=${WITH_DTRACE} prove --exec "sh -c" -v ${CMAKE_CURRENT_BINARY_DIR}/*.t t/*.t
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    DEPENDS cli test.t)
+    DEPENDS cli test.t cpp-compat)
 
 ADD_CUSTOM_TARGET(format clang-format -i `git ls-files include lib src t | egrep '\\.[ch]$$'`)
 

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -247,16 +247,21 @@ inline uint32_t quicly_rtt_get_pto(quicly_rtt_t *rtt, uint32_t max_ack_delay, ui
 inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, const uint16_t *max_ack_delay,
                              const uint8_t *ack_delay_exponent)
 {
-    *r = (quicly_loss_t){.conf = conf,
-                         .max_ack_delay = max_ack_delay,
-                         .ack_delay_exponent = ack_delay_exponent,
-                         .pto_count = 0,
-                         .thresholds = {.use_packet_based = 1, .time_based_percentile = 1024 / 8 /* start from 1/8 RTT */},
-                         .time_of_last_packet_sent = 0,
-                         .largest_acked_packet_plus1 = {0},
-                         .total_bytes_sent = 0,
-                         .loss_time = INT64_MAX,
-                         .alarm_at = INT64_MAX};
+    *r = (quicly_loss_t){
+        .conf = conf,
+        .max_ack_delay = max_ack_delay,
+        .ack_delay_exponent = ack_delay_exponent,
+        .thresholds =
+            {
+                .use_packet_based = 1, .time_based_percentile = 1024 / 8, /* start from 1/8 RTT */
+            },
+        .pto_count = 0,
+        .time_of_last_packet_sent = 0,
+        .largest_acked_packet_plus1 = {0},
+        .total_bytes_sent = 0,
+        .loss_time = INT64_MAX,
+        .alarm_at = INT64_MAX,
+    };
     quicly_rtt_init(&r->rtt, conf, initial_rtt);
     quicly_sentmap_init(&r->sentmap);
 }

--- a/t/cpp-compat.cc
+++ b/t/cpp-compat.cc
@@ -1,0 +1,7 @@
+extern "C" {
+#include "quicly.h"
+}
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
Because h2olog is written in C++ and its component `#include`s quicly.h, it must be compatible with C++. 

diagnostics: https://github.com/h2o/h2o/actions/runs/3149823967/jobs/5121893761

```
/h2o/deps/quicly/include/quicly/loss.h: In function 'void quicly_loss_init(quicly_loss_t*, const quicly_loss_conf_t*, uint32_t, const uint16_t*, const uint8_t*)':
/h2o/deps/quicly/include/quicly/loss.h:259:47: error: designator order for field 'quicly_loss_t::thresholds' does not match declaration order in 'quicly_loss_t'
  259 |                          .alarm_at = INT64_MAX};
      |                                               ^
In file included from /h2o/deps/quicly/include/quicly.h:40,
                 from /h2o/src/h2olog/json.h:8,
                 from /h2o/src/h2olog/json.cc:2:
```