### PR TITLE
Initial support for client/server-only operation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ INCLUDE(CMakePushCheckState)
 INCLUDE(CheckCSourceCompiles)
 INCLUDE(deps/picotls/cmake/dtrace-utils.cmake)
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  # on Darwin, try and pick up openssl from homebrew
+  set(CMAKE_PREFIX_PATH /usr/local/opt/openssl@1.1 /usr/local/opt/openssl)
+endif()
+
 FIND_PACKAGE(OpenSSL REQUIRED)
 IF (OPENSSL_FOUND AND (OPENSSL_VERSION VERSION_LESS "1.0.2"))
     MESSAGE(FATAL "OpenSSL 1.0.2 or above is missing")

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -911,7 +911,9 @@ uint32_t quicly_num_streams_by_group(quicly_conn_t *conn, int uni, int locally_i
 /**
  *
  */
+#if !defined(QUICLY_CLIENT) && !defined(QUICLY_SERVER)
 static int quicly_is_client(quicly_conn_t *conn);
+#endif
 /**
  *
  */
@@ -1260,7 +1262,7 @@ extern const quicly_stream_callbacks_t quicly_stream_noop_callbacks;
 
 #define QUICLY_LOG_CONN(_type, _conn, _block)                                                                                      \
     do {                                                                                                                           \
-        if (!ptls_log.is_active)                                                                                                   \
+        if (!PTLS_LOG_IS_ACTIVE(ptls_log))                                                                                         \
             break;                                                                                                                 \
         quicly_conn_t *_c = (_conn);                                                                                               \
         if (ptls_skip_tracing(_c->crypto.tls))                                                                                     \
@@ -1332,8 +1334,14 @@ inline const quicly_transport_parameters_t *quicly_get_remote_transport_paramete
 
 inline int quicly_is_client(quicly_conn_t *conn)
 {
+#if defined(QUICLY_CLIENT) && !defined(QUICLY_SERVER)
+    return 1;
+#elif !defined(QUICLY_CLIENT) && defined(QUICLY_SERVER)
+    return 0;
+#else
     struct _st_quicly_conn_public_t *c = (struct _st_quicly_conn_public_t *)conn;
     return (c->local.bidi.next_stream_id & 1) == 0;
+#endif
 }
 
 inline quicly_stream_id_t quicly_get_local_next_stream_id(quicly_conn_t *conn, int uni)

--- a/particle/firmware/build.mk
+++ b/particle/firmware/build.mk
@@ -1,0 +1,38 @@
+INCLUDE_DIRS+=$(SOURCE_PATH)
+CPPSRC+=main.cpp
+
+INCLUDE_DIRS+=\
+	$(SOURCE_PATH)/include-quicly \
+	$(SOURCE_PATH)/include-picotls \
+	$(SOURCE_PATH)/include-klib \
+
+QUICLY_SRC+=\
+	lib-picotls/hpke.c \
+	lib-picotls/picotls.c \
+	lib-quicly/cc-reno.c \
+	lib-quicly/defaults.c \
+	lib-quicly/frame.c \
+	lib-quicly/local_cid.c \
+	lib-quicly/loss.c \
+	lib-quicly/quicly.c \
+	lib-quicly/ranges.c \
+	lib-quicly/rate.c \
+	lib-quicly/recvstate.c \
+	lib-quicly/remote_cid.c \
+	lib-quicly/retire_cid.c \
+	lib-quicly/sendstate.c \
+	lib-quicly/sentmap.c \
+	lib-quicly/streambuf.c \
+
+CSRC+=$(QUICLY_SRC) quic.c
+
+EXTRA_CFLAGS+=-Wno-undef -Wno-pointer-to-int-cast -Wno-unused-variable -Wno-unused-but-set-variable -Werror
+EXTRA_CFLAGS+=-fstack-usage -ffast-math
+EXTRA_CFLAGS+=-DNDEBUG -DQUICLY_CLIENT -DPICOTLS_CLIENT
+
+# TODO: figure out how to do this using make rules
+$(shell	cd $(SOURCE_PATH) && ln -sf ../../deps/klib ./include-klib)
+$(shell	cd $(SOURCE_PATH) && ln -sf ../../deps/picotls/include ./include-picotls)
+$(shell	cd $(SOURCE_PATH) && ln -sf ../../deps/picotls/lib ./lib-picotls)
+$(shell	cd $(SOURCE_PATH) && ln -sf ../../include ./include-quicly)
+$(shell	cd $(SOURCE_PATH) && ln -sf ../../lib ./lib-quicly)

--- a/particle/firmware/main.cpp
+++ b/particle/firmware/main.cpp
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Copyright (c) 2016-2020, NetApp, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <Particle.h>
+
+#include "quic.h"
+
+
+SYSTEM_MODE(MANUAL);
+// SYSTEM_THREAD(ENABLED);
+
+#if !defined(NDEBUG) || defined(DSTACK)
+static SerialDebugOutput serial;
+#endif
+
+static const int led = D7;
+
+
+// don't use entropy from cloud
+void random_seed_from_cloud(unsigned int seed) {}
+
+
+static ApplicationWatchdog wd(60000, System.reset);
+
+extern "C" void ping(void)
+{
+    wd.checkin();
+}
+
+
+void button_action()
+{
+    Serial.begin(9600);
+    delay(1000);
+
+    WiFi.on();
+    WiFi.connect(WIFI_CONNECT_SKIP_LISTEN);
+    waitUntil(WiFi.ready);
+    digitalWrite(led, HIGH);
+
+    DEBUG("Particle Device OS: %lu.%lu.%lu",
+           (System.versionNumber() & 0xff000000) >> 24,
+           (System.versionNumber() & 0x00ff0000) >> 16,
+           (System.versionNumber() & 0x0000ff00) >> 8);
+
+    quic_transaction();
+
+    WiFi.off();
+    digitalWrite(led, LOW);
+}
+
+
+void setup()
+{
+    // let's gather some entropy and seed the RNG
+    const int temp = analogRead(A0);
+    const int volt = analogRead(BATT);
+    randomSeed(((temp << 12) | volt));
+
+    pinMode(led, OUTPUT);
+    button_action();
+}
+
+
+void loop()
+{
+    System.sleep(BTN, FALLING);
+    if (System.sleepResult().reason() == WAKEUP_REASON_PIN)
+        button_action();
+}

--- a/particle/firmware/quic.c
+++ b/particle/firmware/quic.c
@@ -1,0 +1,284 @@
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <fcntl.h>
+
+#include "quicly.h"
+#include "quicly/streambuf.h"
+
+#define MAX_BURST_PACKETS 10
+
+static const unsigned verbosity = 0;
+static int suppress_output = 0;
+static int64_t enqueue_requests_at = 0;
+static int send_datagram_frame = 0;
+
+static void hexdump(const char *title, const uint8_t *p, size_t l)
+{
+    fprintf(stderr, "%s (%zu bytes):\n", title, l);
+
+    while (l != 0) {
+        int i;
+        fputs("   ", stderr);
+        for (i = 0; i < 16; ++i) {
+            fprintf(stderr, " %02x", *p++);
+            if (--l == 0)
+                break;
+        }
+        fputc('\n', stderr);
+    }
+}
+
+static struct {
+    ptls_iovec_t config_list;
+    struct {
+        struct {
+            ptls_hpke_kem_t *kem;
+            ptls_key_exchange_context_t *ctx;
+        } list[16];
+        size_t count;
+    } keyex;
+    struct {
+        ptls_iovec_t configs;
+        char *fn;
+    } retry;
+} ech;
+
+static void ech_save_retry_configs(void)
+{
+    if (ech.retry.configs.base == NULL)
+        return;
+
+    FILE *fp;
+    if ((fp = fopen(ech.retry.fn, "wt")) == NULL) {
+        // fprintf(stderr, "failed to write to ECH config file:%s:%d\n", ech.retry.fn, errno);
+        exit(1);
+    }
+    fwrite(ech.retry.configs.base, 1, ech.retry.configs.len, fp);
+    fclose(fp);
+}
+
+static void send_str(quicly_stream_t *stream, const char *s)
+{
+    quicly_streambuf_egress_write(stream, s, strlen(s));
+}
+
+/**
+ * list of requests to be processed, terminated by reqs[N].path == NULL
+ */
+struct {
+    const char *path;
+    int to_file;
+} *reqs;
+
+struct st_stream_data_t {
+    quicly_streambuf_t streambuf;
+    FILE *outfp;
+};
+
+static void enqueue_requests(quicly_conn_t *conn)
+{
+    size_t i;
+    int ret;
+
+    for (i = 0; reqs[i].path != NULL; ++i) {
+        char req[1024], destfile[1024];
+        quicly_stream_t *stream;
+        ret = quicly_open_stream(conn, &stream, 0);
+        assert(ret == 0);
+        sprintf(req, "GET %s\r\n", reqs[i].path);
+        send_str(stream, req);
+        quicly_streambuf_egress_shutdown(stream);
+
+        if (reqs[i].to_file && !suppress_output) {
+            struct st_stream_data_t *stream_data = stream->data;
+            sprintf(destfile, "%s.downloaded", strrchr(reqs[i].path, '/') + 1);
+            stream_data->outfp = fopen(destfile, "w");
+            if (stream_data->outfp == NULL) {
+                // fprintf(stderr, "failed to open destination file:%s:%d\n", reqs[i].path, errno);
+                exit(1);
+            }
+        }
+    }
+    enqueue_requests_at = INT64_MAX;
+}
+
+static void send_packets_default(int fd, struct sockaddr *dest, struct iovec *packets, size_t num_packets)
+{
+    for (size_t i = 0; i != num_packets; ++i) {
+        struct msghdr mess;
+        memset(&mess, 0, sizeof(mess));
+        mess.msg_name = dest;
+        mess.msg_namelen = quicly_get_socklen(dest);
+        mess.msg_iov = &packets[i];
+        mess.msg_iovlen = 1;
+        if (verbosity >= 2)
+            hexdump("sendmsg", packets[i].iov_base, packets[i].iov_len);
+        int ret;
+        while ((ret = (int)sendmsg(fd, &mess, 0)) == -1 && errno == EINTR)
+            ;
+        // if (ret == -1)
+        //     perror("sendmsg failed");
+    }
+}
+
+static void (*send_packets)(int, struct sockaddr *, struct iovec *, size_t) = send_packets_default;
+
+static int send_pending(int fd, quicly_conn_t *conn)
+{
+    quicly_address_t dest, src;
+    struct iovec packets[MAX_BURST_PACKETS];
+    uint8_t buf[MAX_BURST_PACKETS * quicly_get_context(conn)->transport_params.max_udp_payload_size];
+    size_t num_packets = MAX_BURST_PACKETS;
+    int ret;
+
+    if ((ret = quicly_send(conn, &dest, &src, packets, &num_packets, buf, sizeof(buf))) == 0 && num_packets != 0)
+        send_packets(fd, &dest.sa, packets, num_packets);
+
+    return ret;
+}
+
+static int run_client(int fd, struct sockaddr *sa, const char *host)
+{
+    quicly_context_t ctx;
+    quicly_cid_plaintext_t next_cid;
+    ptls_iovec_t resumption_token;
+    ptls_handshake_properties_t hs_properties;
+    quicly_transport_parameters_t resumed_transport_params;
+
+    struct sockaddr_in local;
+    int ret;
+    quicly_conn_t *conn = NULL;
+
+    memset(&local, 0, sizeof(local));
+    local.sin_family = AF_INET;
+    if (bind(fd, (void *)&local, sizeof(local)) != 0) {
+        // perror("bind(2) failed");
+        return 1;
+    }
+    ret = quicly_connect(&conn, &ctx, host, sa, NULL, &next_cid, resumption_token, &hs_properties, &resumed_transport_params);
+    assert(ret == 0);
+    ++next_cid.master_id;
+    enqueue_requests(conn);
+    send_pending(fd, conn);
+
+    while (1) {
+        fd_set readfds;
+        struct timeval *tv, tvbuf;
+        do {
+            int64_t timeout_at = conn != NULL ? quicly_get_first_timeout(conn) : INT64_MAX;
+            if (enqueue_requests_at < timeout_at)
+                timeout_at = enqueue_requests_at;
+            if (timeout_at != INT64_MAX) {
+                quicly_context_t *ctx = quicly_get_context(conn);
+                int64_t delta = timeout_at - ctx->now->cb(ctx->now);
+                if (delta > 0) {
+                    tvbuf.tv_sec = delta / 1000;
+                    tvbuf.tv_usec = (delta % 1000) * 1000;
+                } else {
+                    tvbuf.tv_sec = 0;
+                    tvbuf.tv_usec = 0;
+                }
+                tv = &tvbuf;
+            } else {
+                tv = NULL;
+            }
+            FD_ZERO(&readfds);
+            FD_SET(fd, &readfds);
+        } while (select(fd + 1, &readfds, NULL, NULL, tv) == -1 && errno == EINTR);
+        if (enqueue_requests_at <= ctx.now->cb(ctx.now))
+            enqueue_requests(conn);
+        if (FD_ISSET(fd, &readfds)) {
+            while (1) {
+                uint8_t buf[ctx.transport_params.max_udp_payload_size];
+                struct msghdr mess;
+                struct sockaddr sa;
+                struct iovec vec;
+                memset(&mess, 0, sizeof(mess));
+                mess.msg_name = &sa;
+                mess.msg_namelen = sizeof(sa);
+                vec.iov_base = buf;
+                vec.iov_len = sizeof(buf);
+                mess.msg_iov = &vec;
+                mess.msg_iovlen = 1;
+                ssize_t rret;
+                while ((rret = recvmsg(fd, &mess, 0)) == -1 && errno == EINTR)
+                    ;
+                if (rret <= 0)
+                    break;
+                if (verbosity >= 2)
+                    hexdump("recvmsg", buf, rret);
+                size_t off = 0;
+                while (off != rret) {
+                    quicly_decoded_packet_t packet;
+                    if (quicly_decode_packet(&ctx, &packet, buf, rret, &off) == SIZE_MAX)
+                        break;
+                    quicly_receive(conn, NULL, &sa, &packet);
+                    if (send_datagram_frame && quicly_connection_is_ready(conn)) {
+                        const char *message = "hello datagram!";
+                        ptls_iovec_t datagram = ptls_iovec_init(message, strlen(message));
+                        quicly_send_datagram_frames(conn, &datagram, 1);
+                        send_datagram_frame = 0;
+                    }
+                }
+            }
+        }
+        if (conn != NULL) {
+            ret = send_pending(fd, conn);
+            if (ret != 0) {
+                ech_save_retry_configs();
+                quicly_free(conn);
+                conn = NULL;
+                if (ret == QUICLY_ERROR_FREE_CONNECTION) {
+                    return 0;
+                } else {
+                    // fprintf(stderr, "quicly_send returned %d\n", ret);
+                    return 1;
+                }
+            }
+        }
+    }
+}
+
+static inline int resolve_address(struct sockaddr *sa, socklen_t *salen, const char *host, const char *port, int family, int type,
+                                  int proto)
+{
+    struct addrinfo hints, *res;
+    int err;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = family;
+    hints.ai_socktype = type;
+    hints.ai_protocol = proto;
+    hints.ai_flags = AI_ADDRCONFIG | AI_NUMERICSERV | AI_PASSIVE;
+    if ((err = getaddrinfo(host, port, &hints, &res)) != 0 || res == NULL) {
+        // fprintf(stderr, "failed to resolve address:%s:%s:%d\n", host, port, err);
+        return -1;
+    }
+
+    memcpy(sa, res->ai_addr, res->ai_addrlen);
+    *salen = res->ai_addrlen;
+
+    freeaddrinfo(res);
+    return 0;
+}
+
+int quic_transaction(void)
+{
+    struct sockaddr_storage sa;
+    socklen_t salen;
+    const char host[] = "quant.eggert.org";
+    const char port[] = "4433";
+    int fd;
+
+    if (resolve_address((void *)&sa, &salen, host, port, AF_INET, SOCK_DGRAM, IPPROTO_UDP) != 0)
+        exit(1);
+
+    if ((fd = socket(sa.ss_family, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
+        // perror("socket(2) failed");
+        return 1;
+    }
+    fcntl(fd, F_SETFL, O_NONBLOCK);
+
+    return run_client(fd, (void *)&sa, host);
+}

--- a/particle/firmware/quic.h
+++ b/particle/firmware/quic.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int quic_transaction(void);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Trying to experiment with quicly/picotls on IoT boards. This PR is trying to collect changes that can reduce the code size, such as:
* PICOTLS_CLIENT and PICOTLS_SERVER define, to only enable one mode

