### PR TITLE
provide way to set appdata at the moment `quicly_conn_t` is instantiated

### DIFF
--- a/examples/echo.c
+++ b/examples/echo.c
@@ -175,7 +175,7 @@ static void process_msg(int is_client, quicly_conn_t **conns, struct msghdr *msg
             quicly_receive(conns[i], NULL, msg->msg_name, &decoded);
         } else if (!is_client) {
             /* assume that the packet is a new connection */
-            quicly_accept(conns + i, &ctx, NULL, msg->msg_name, &decoded, NULL, &next_cid, NULL);
+            quicly_accept(conns + i, &ctx, NULL, msg->msg_name, &decoded, NULL, &next_cid, NULL, NULL);
         }
     }
 }
@@ -386,7 +386,7 @@ int main(int argc, char **argv)
         /* initiate a connection, and open a stream */
         int ret;
         if ((ret = quicly_connect(&client, &ctx, host, (struct sockaddr *)&sa, NULL, &next_cid, ptls_iovec_init(NULL, 0), NULL,
-                                  NULL)) != 0) {
+                                  NULL, NULL)) != 0) {
             fprintf(stderr, "quicly_connect failed:%d\n", ret);
             exit(1);
         }

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -1075,11 +1075,12 @@ int quicly_decode_transport_parameter_list(quicly_transport_parameters_t *params
 /**
  * Initiates a new connection.
  * @param new_cid the CID to be used for the connection. path_id is ignored.
+ * @param appdata initial value to be set to `*quicly_get_data(conn)`
  */
 int quicly_connect(quicly_conn_t **conn, quicly_context_t *ctx, const char *server_name, struct sockaddr *dest_addr,
                    struct sockaddr *src_addr, const quicly_cid_plaintext_t *new_cid, ptls_iovec_t address_token,
                    ptls_handshake_properties_t *handshake_properties,
-                   const quicly_transport_parameters_t *resumed_transport_params);
+                   const quicly_transport_parameters_t *resumed_transport_params, void *appdata);
 /**
  * accepts a new connection
  * @param new_cid        The CID to be used for the connection. When an error is being returned, the application can reuse the CID
@@ -1087,11 +1088,12 @@ int quicly_connect(quicly_conn_t **conn, quicly_context_t *ctx, const char *serv
  * @param address_token  An validated address validation token, if any.  Applications MUST validate the address validation token
  *                       before calling this function, dropping the ones that failed to validate.  When a token is supplied,
  *                       `quicly_accept` will consult the values being supplied assuming that the remote peer's address has been
- * validated.
+ *                       validated.
+ * @param appdata        initial value to be set to `*quicly_get_data(conn)`
  */
 int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *dest_addr, struct sockaddr *src_addr,
                   quicly_decoded_packet_t *packet, quicly_address_token_plaintext_t *address_token,
-                  const quicly_cid_plaintext_t *new_cid, ptls_handshake_properties_t *handshake_properties);
+                  const quicly_cid_plaintext_t *new_cid, ptls_handshake_properties_t *handshake_properties, void *appdata);
 /**
  *
  */

--- a/src/cli.c
+++ b/src/cli.c
@@ -539,7 +539,7 @@ static int run_client(int fd, struct sockaddr *sa, const char *host)
         perror("bind(2) failed");
         return 1;
     }
-    ret = quicly_connect(&conn, &ctx, host, sa, NULL, &next_cid, resumption_token, &hs_properties, &resumed_transport_params);
+    ret = quicly_connect(&conn, &ctx, host, sa, NULL, &next_cid, resumption_token, &hs_properties, &resumed_transport_params, NULL);
     assert(ret == 0);
     ++next_cid.master_id;
     enqueue_requests(conn);
@@ -832,7 +832,7 @@ static int run_server(int fd, struct sockaddr *sa, socklen_t salen)
                             break;
                         } else {
                             /* new connection */
-                            int ret = quicly_accept(&conn, &ctx, NULL, &remote.sa, &packet, token, &next_cid, NULL);
+                            int ret = quicly_accept(&conn, &ctx, NULL, &remote.sa, &packet, token, &next_cid, NULL, NULL);
                             if (ret == 0) {
                                 assert(conn != NULL);
                                 ++next_cid.master_id;

--- a/t/lossy.c
+++ b/t/lossy.c
@@ -176,7 +176,7 @@ static void test_even(void)
         quicly_decoded_packet_t decoded;
 
         ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, NULL, new_master_id(), ptls_iovec_init(NULL, 0),
-                             NULL, NULL);
+                             NULL, NULL, NULL);
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &destaddr, &srcaddr, &raw, &num_packets, rawbuf, sizeof(rawbuf));
@@ -184,7 +184,7 @@ static void test_even(void)
         ok(num_packets == 1);
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL, NULL);
         ok(ret == 0);
         cond_up.cb(&cond_up);
     }
@@ -283,7 +283,7 @@ static void loss_core(void)
         quicly_decoded_packet_t decoded;
 
         ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, NULL, new_master_id(), ptls_iovec_init(NULL, 0),
-                             NULL, NULL);
+                             NULL, NULL, NULL);
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &destaddr, &srcaddr, &raw, &num_packets, rawbuf, sizeof(rawbuf));
@@ -292,7 +292,7 @@ static void loss_core(void)
         quic_now += 10;
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL, NULL);
         ok(ret == 0);
         quic_now += 10;
     }

--- a/t/simple.c
+++ b/t/simple.c
@@ -36,7 +36,7 @@ static void test_handshake(void)
 
     /* send CH */
     ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, NULL, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
-                         NULL);
+                         NULL, NULL);
     ok(ret == 0);
     num_packets = PTLS_ELEMENTSOF(packets);
     ret = quicly_send(client, &dest, &src, packets, &num_packets, packetsbuf, sizeof(packetsbuf));
@@ -47,7 +47,7 @@ static void test_handshake(void)
     /* receive CH, send handshake upto ServerFinished */
     num_decoded = decode_packets(decoded, packets, num_packets);
     ok(num_decoded == 1);
-    ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, decoded, NULL, new_master_id(), NULL);
+    ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, decoded, NULL, new_master_id(), NULL, NULL);
     ok(ret == 0);
     ok(quicly_get_state(server) == QUICLY_STATE_CONNECTED);
     ok(quicly_connection_is_ready(server));
@@ -548,7 +548,7 @@ static void tiny_connection_window(void)
         quicly_decoded_packet_t decoded;
 
         ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, NULL, new_master_id(), ptls_iovec_init(NULL, 0),
-                             NULL, NULL);
+                             NULL, NULL, NULL);
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &dest, &src, &raw, &num_packets, rawbuf, sizeof(rawbuf));
@@ -557,7 +557,7 @@ static void tiny_connection_window(void)
         ok(quicly_get_first_timeout(client) > quic_ctx.now->cb(quic_ctx.now));
         decode_packets(&decoded, &raw, 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL, NULL);
         ok(ret == 0);
     }
 

--- a/t/simulator.c
+++ b/t/simulator.c
@@ -309,7 +309,7 @@ static void net_endpoint_forward(struct net_node *_self, struct net_packet *pack
         } else {
             assert(self->accept_ctx != NULL && "a packet for which we do not have state must be a new connection request");
             if (quicly_accept(&conn->quic, self->accept_ctx, &packet->dest.sa, &packet->src->addr.sa, &qp, NULL, &next_quic_cid,
-                              NULL) == 0) {
+                              NULL, NULL) == 0) {
                 assert(conn->quic != NULL);
                 ++next_quic_cid.master_id;
                 conn->egress = &packet->src->super;
@@ -598,7 +598,7 @@ int main(int argc, char **argv)
             net_endpoint_init(client_node);
             client_node->start_at = now + start;
             int ret = quicly_connect(&client_node->conns[0].quic, &quicctx, "hello.example.com", &server_node.node.addr.sa,
-                                     &client_node->addr.sa, &next_quic_cid, ptls_iovec_init(NULL, 0), NULL, NULL);
+                                     &client_node->addr.sa, &next_quic_cid, ptls_iovec_init(NULL, 0), NULL, NULL, NULL);
             ++next_quic_cid.master_id;
             assert(ret == 0);
             quicly_stream_t *stream;

--- a/t/stream-concurrency.c
+++ b/t/stream-concurrency.c
@@ -40,7 +40,7 @@ void test_stream_concurrency(void)
         quicly_decoded_packet_t decoded;
 
         ret = quicly_connect(&client, &quic_ctx, "example.com", &fake_address.sa, NULL, new_master_id(), ptls_iovec_init(NULL, 0),
-                             NULL, NULL);
+                             NULL, NULL, NULL);
         ok(ret == 0);
         num_packets = 1;
         ret = quicly_send(client, &dest, &src, &raw, &num_packets, rawbuf, sizeof(rawbuf));
@@ -48,7 +48,7 @@ void test_stream_concurrency(void)
         ok(num_packets == 1);
         ok(decode_packets(&decoded, &raw, 1) == 1);
         ok(num_packets == 1);
-        ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
+        ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL, NULL);
         ok(ret == 0);
         transmit(server, client);
     }

--- a/t/test.c
+++ b/t/test.c
@@ -625,7 +625,7 @@ static void test_nondecryptable_initial(void)
     ok(num_decoded == 1);
 
     /* decryption should fail */
-    ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL);
+    ret = quicly_accept(&server, &quic_ctx, NULL, &fake_address.sa, &decoded, NULL, new_master_id(), NULL, NULL);
     ok(ret == QUICLY_ERROR_DECRYPTION_FAILED);
 #undef PACKET_LEN
 #undef HEADER_LEN
@@ -639,7 +639,7 @@ static void test_set_cc(void)
     int ret;
 
     ret = quicly_connect(&conn, &quic_ctx, "example.com", &fake_address.sa, NULL, new_master_id(), ptls_iovec_init(NULL, 0), NULL,
-                         NULL);
+                         NULL, NULL);
     ok(ret == 0);
 
     quicly_stats_t stats;


### PR DESCRIPTION
See https://github.com/h2o/h2o/pull/3184 for rationale.