### PR TITLE
[cli] use 8-byte CIDs when OpenSSL 3.0 is used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         include:
           - name: default
             command: make -f misc/docker-ci.mk
+          - name: openssl-3.0
+            command: make -f misc/docker-ci.mk CONTAINER_NAME=h2oserver/h2o-ci:ubuntu2204
           - name: asan
             command: make -f misc/docker-ci.mk CMAKE_ARGS='-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS=-fsanitize=address -DCMAKE_CXX_FLAGS=-fsanitize=address' CHECK_ENVS='ASAN_OPTIONS=detect_leaks=0'
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -31,6 +31,10 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <picotls.h>
+#include <openssl/err.h>
+#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/provider.h>
+#endif
 #if QUICLY_HAVE_FUSION
 #include "picotls/fusion.h"
 #endif
@@ -1081,6 +1085,14 @@ int main(int argc, char **argv)
     socklen_t salen;
     unsigned udpbufsize = 0;
     int ch, opt_index, fd;
+
+    ERR_load_crypto_strings();
+    OpenSSL_add_all_algorithms();
+#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x30000000L
+    /* Explicitly load the legacy provider in addition to default, as we test Blowfish in one of the tests. */
+    (void)OSSL_PROVIDER_load(NULL, "legacy");
+    (void)OSSL_PROVIDER_load(NULL, "default");
+#endif
 
     reqs = malloc(sizeof(*reqs));
     memset(reqs, 0, sizeof(*reqs));


### PR DESCRIPTION
cli uses blowfish for generating 8-byte CIDs, however when OpenSSL 3.0 is used, blowfish is not available by default.

This PR adds code that loads the "legacy" provider explicitly so that blowfish can be used.