### PR TITLE
implement reliable reset extension

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -492,7 +492,7 @@ struct st_quicly_conn_streamgroup_state_t {
         uint64_t padding, ping, ack, reset_stream, stop_sending, crypto, new_token, stream, max_data, max_stream_data,             \
             max_streams_bidi, max_streams_uni, data_blocked, stream_data_blocked, streams_blocked, new_connection_id,              \
             retire_connection_id, path_challenge, path_response, transport_close, application_close, handshake_done, datagram,     \
-            ack_frequency;                                                                                                         \
+            reliable_reset_stream, ack_frequency;                                                                                  \
     } num_frames_sent, num_frames_received;                                                                                        \
     /**                                                                                                                            \
      * Total number of PTOs observed during the connection.                                                                        \
@@ -744,6 +744,10 @@ struct st_quicly_stream_t {
             quicly_linklist_t control; /* links to conn_t::control (or to conn_t::streams_blocked if the blocked flag is set) */
             quicly_linklist_t default_scheduler;
         } pending_link;
+        /**
+         * if the stream is closed using reliable reset
+         */
+        unsigned is_reliable_reset : 1;
     } _send_aux;
     /**
      *
@@ -1141,6 +1145,10 @@ int quicly_get_or_open_stream(quicly_conn_t *conn, uint64_t stream_id, quicly_st
  *
  */
 void quicly_reset_stream(quicly_stream_t *stream, int err);
+/**
+ *
+ */
+int quicly_reset_stream_reliable(quicly_stream_t *stream, uint64_t reliable_size, int err);
 /**
  *
  */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -264,6 +264,10 @@ typedef struct st_quicly_transport_parameters_t {
     /**
      *
      */
+    uint8_t reliable_reset_stream : 1;
+    /**
+     *
+     */
     uint64_t active_connection_id_limit;
     /**
      *

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -72,7 +72,7 @@ extern "C" {
 #define QUICLY_MAX_STREAM_DATA_FRAME_CAPACITY (1 + 8 + 8)
 #define QUICLY_MAX_STREAMS_FRAME_CAPACITY (1 + 8)
 #define QUICLY_PING_FRAME_CAPACITY 1
-#define QUICLY_RST_FRAME_CAPACITY (1 + 8 + 8 + 8 + 8) /* last 8 for reliable_reset_stream extension */
+#define QUICLY_RST_FRAME_CAPACITY (8 + 8 + 8 + 8 + 8) /* for reliable_reset_stream allocate space for type and reliable_size */
 #define QUICLY_DATA_BLOCKED_FRAME_CAPACITY (1 + 8)
 #define QUICLY_STREAM_DATA_BLOCKED_FRAME_CAPACITY (1 + 8 + 8)
 #define QUICLY_STREAMS_BLOCKED_FRAME_CAPACITY (1 + 8)
@@ -456,7 +456,11 @@ Error:
 inline uint8_t *quicly_encode_reset_stream_frame(uint8_t *dst, uint64_t stream_id, uint16_t app_error_code, uint64_t final_size,
                                                  uint64_t reliable_size)
 {
-    *dst++ = reliable_size != 0 ? QUICLY_FRAME_TYPE_RELIABLE_RESET_STREAM : QUICLY_FRAME_TYPE_RESET_STREAM;
+    if (reliable_size == 0) {
+        *dst++ = QUICLY_FRAME_TYPE_RESET_STREAM;
+    } else {
+        dst = quicly_encodev(dst, QUICLY_FRAME_TYPE_RELIABLE_RESET_STREAM);
+    }
     dst = quicly_encodev(dst, stream_id);
     dst = quicly_encodev(dst, app_error_code);
     dst = quicly_encodev(dst, final_size);

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -26,6 +26,7 @@
 extern "C" {
 #endif
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -37,7 +38,7 @@ extern "C" {
 #define QUICLY_FRAME_TYPE_PING 1
 #define QUICLY_FRAME_TYPE_ACK 2
 #define QUICLY_FRAME_TYPE_ACK_ECN 3
-#define QUICLY_FRAME_TYPE_RESET_STREAM 4 /* RESET_STREAM */
+#define QUICLY_FRAME_TYPE_RESET_STREAM 4
 #define QUICLY_FRAME_TYPE_STOP_SENDING 5
 #define QUICLY_FRAME_TYPE_CRYPTO 6
 #define QUICLY_FRAME_TYPE_NEW_TOKEN 7
@@ -59,6 +60,7 @@ extern "C" {
 #define QUICLY_FRAME_TYPE_HANDSHAKE_DONE 30
 #define QUICLY_FRAME_TYPE_DATAGRAM_NOLEN 48
 #define QUICLY_FRAME_TYPE_DATAGRAM_WITHLEN 49
+#define QUICLY_FRAME_TYPE_RELIABLE_RESET_STREAM 0x72
 #define QUICLY_FRAME_TYPE_ACK_FREQUENCY 0xaf
 
 #define QUICLY_FRAME_TYPE_STREAM_BITS 0x7
@@ -70,7 +72,7 @@ extern "C" {
 #define QUICLY_MAX_STREAM_DATA_FRAME_CAPACITY (1 + 8 + 8)
 #define QUICLY_MAX_STREAMS_FRAME_CAPACITY (1 + 8)
 #define QUICLY_PING_FRAME_CAPACITY 1
-#define QUICLY_RST_FRAME_CAPACITY (1 + 8 + 8 + 8)
+#define QUICLY_RST_FRAME_CAPACITY (1 + 8 + 8 + 8 + 8) /* last 8 for reliable_reset_stream extension */
 #define QUICLY_DATA_BLOCKED_FRAME_CAPACITY (1 + 8)
 #define QUICLY_STREAM_DATA_BLOCKED_FRAME_CAPACITY (1 + 8 + 8)
 #define QUICLY_STREAMS_BLOCKED_FRAME_CAPACITY (1 + 8)
@@ -109,15 +111,18 @@ static int quicly_decode_stream_frame(uint8_t type_flags, const uint8_t **src, c
 static uint8_t *quicly_encode_crypto_frame_header(uint8_t *dst, uint8_t *dst_end, uint64_t offset, size_t *data_len);
 static int quicly_decode_crypto_frame(const uint8_t **src, const uint8_t *end, quicly_stream_frame_t *frame);
 
-static uint8_t *quicly_encode_reset_stream_frame(uint8_t *dst, uint64_t stream_id, uint16_t app_error_code, uint64_t final_size);
+static uint8_t *quicly_encode_reset_stream_frame(uint8_t *dst, uint64_t stream_id, uint16_t app_error_code, uint64_t final_size,
+                                                 uint64_t reliable_size);
 
 typedef struct st_quicly_reset_stream_frame_t {
     uint64_t stream_id;
     uint16_t app_error_code;
     uint64_t final_size;
+    uint64_t reliable_size;
 } quicly_reset_stream_frame_t;
 
-static int quicly_decode_reset_stream_frame(const uint8_t **src, const uint8_t *end, quicly_reset_stream_frame_t *frame);
+static int quicly_decode_reset_stream_frame(uint64_t frame_type, const uint8_t **src, const uint8_t *end,
+                                            quicly_reset_stream_frame_t *frame);
 
 typedef struct st_quicly_transport_close_frame_t {
     uint16_t error_code;
@@ -448,16 +453,20 @@ Error:
     return QUICLY_TRANSPORT_ERROR_FRAME_ENCODING;
 }
 
-inline uint8_t *quicly_encode_reset_stream_frame(uint8_t *dst, uint64_t stream_id, uint16_t app_error_code, uint64_t final_size)
+inline uint8_t *quicly_encode_reset_stream_frame(uint8_t *dst, uint64_t stream_id, uint16_t app_error_code, uint64_t final_size,
+                                                 uint64_t reliable_size)
 {
-    *dst++ = QUICLY_FRAME_TYPE_RESET_STREAM;
+    *dst++ = reliable_size != 0 ? QUICLY_FRAME_TYPE_RELIABLE_RESET_STREAM : QUICLY_FRAME_TYPE_RESET_STREAM;
     dst = quicly_encodev(dst, stream_id);
     dst = quicly_encodev(dst, app_error_code);
     dst = quicly_encodev(dst, final_size);
+    if (reliable_size != 0)
+        dst = quicly_encodev(dst, reliable_size);
     return dst;
 }
 
-inline int quicly_decode_reset_stream_frame(const uint8_t **src, const uint8_t *end, quicly_reset_stream_frame_t *frame)
+inline int quicly_decode_reset_stream_frame(uint64_t frame_type, const uint8_t **src, const uint8_t *end,
+                                            quicly_reset_stream_frame_t *frame)
 {
     uint64_t error_code;
 
@@ -467,6 +476,10 @@ inline int quicly_decode_reset_stream_frame(const uint8_t **src, const uint8_t *
         goto Error;
     frame->app_error_code = (uint16_t)error_code;
     frame->final_size = quicly_decodev(src, end);
+    if (frame_type != QUICLY_FRAME_TYPE_RESET_STREAM) {
+        assert(frame_type == QUICLY_FRAME_TYPE_RELIABLE_RESET_STREAM);
+        frame->reliable_size = quicly_decodev(src, end);
+    }
     return 0;
 Error:
     return QUICLY_TRANSPORT_ERROR_FRAME_ENCODING;

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -483,7 +483,10 @@ inline int quicly_decode_reset_stream_frame(uint64_t frame_type, const uint8_t *
     if (frame_type != QUICLY_FRAME_TYPE_RESET_STREAM) {
         assert(frame_type == QUICLY_FRAME_TYPE_RELIABLE_RESET_STREAM);
         frame->reliable_size = quicly_decodev(src, end);
+    } else {
+        frame->reliable_size = 0;
     }
+
     return 0;
 Error:
     return QUICLY_TRANSPORT_ERROR_FRAME_ENCODING;

--- a/include/quicly/recvstate.h
+++ b/include/quicly/recvstate.h
@@ -44,6 +44,10 @@ typedef struct st_quicly_recvstate_t {
      * end_of_stream offset (or UINT64_MAX)
      */
     uint64_t eos;
+    /**
+     *
+     */
+    uint64_t reliable_size;
 } quicly_recvstate_t;
 
 void quicly_recvstate_init(quicly_recvstate_t *state);
@@ -57,7 +61,7 @@ static size_t quicly_recvstate_bytes_available(quicly_recvstate_t *state);
  * backward from the end of given range).
  */
 int quicly_recvstate_update(quicly_recvstate_t *state, uint64_t off, size_t *len, int is_fin, size_t max_ranges);
-int quicly_recvstate_reset(quicly_recvstate_t *state, uint64_t eos_at, uint64_t *bytes_missing);
+int quicly_recvstate_reset(quicly_recvstate_t *state, uint64_t final_size, uint64_t reliable_size, uint64_t *bytes_missing);
 
 /* inline definitions */
 

--- a/include/quicly/streambuf.h
+++ b/include/quicly/streambuf.h
@@ -128,6 +128,10 @@ void quicly_streambuf_egress_emit(quicly_stream_t *stream, size_t off, void *dst
 static int quicly_streambuf_egress_write(quicly_stream_t *stream, const void *src, size_t len);
 static int quicly_streambuf_egress_write_vec(quicly_stream_t *stream, quicly_sendbuf_vec_t *vec);
 int quicly_streambuf_egress_shutdown(quicly_stream_t *stream);
+/**
+ * Resets the stream while making sure that all bytes up to `reliable_size` are received.
+ */
+int quicly_streambuf_egress_reset(quicly_stream_t *stream, uint64_t reliable_size, int err);
 static void quicly_streambuf_ingress_shift(quicly_stream_t *stream, size_t delta);
 static ptls_iovec_t quicly_streambuf_ingress_get(quicly_stream_t *stream);
 /**

--- a/lib/recvstate.c
+++ b/lib/recvstate.c
@@ -22,11 +22,19 @@
 #include "quicly/constants.h"
 #include "quicly/recvstate.h"
 
+static int reliable_reset_is_satisfied(quicly_recvstate_t *state)
+{
+    assert(state->reliable_size != UINT64_MAX);
+    assert(state->received.num_ranges != 0);
+    return state->received.ranges[0].start == 0 && state->reliable_size <= state->received.ranges[0].end;
+}
+
 void quicly_recvstate_init(quicly_recvstate_t *state)
 {
     quicly_ranges_init_with_range(&state->received, 0, 0);
     state->data_off = 0;
     state->eos = UINT64_MAX;
+    state->reliable_size = UINT64_MAX;
 }
 
 void quicly_recvstate_init_closed(quicly_recvstate_t *state)
@@ -34,6 +42,7 @@ void quicly_recvstate_init_closed(quicly_recvstate_t *state)
     quicly_ranges_init(&state->received);
     state->data_off = 0;
     state->eos = 0;
+    state->reliable_size = 0;
 }
 
 void quicly_recvstate_dispose(quicly_recvstate_t *state)
@@ -81,8 +90,13 @@ int quicly_recvstate_update(quicly_recvstate_t *state, uint64_t off, size_t *len
         if (state->received.num_ranges > max_ranges)
             return QUICLY_ERROR_STATE_EXHAUSTION;
     }
-    if (state->received.num_ranges == 1 && state->received.ranges[0].start == 0 && state->received.ranges[0].end == state->eos)
-        goto Complete;
+    if (state->reliable_size == UINT64_MAX) {
+        if (state->received.num_ranges == 1 && state->received.ranges[0].start == 0 && state->received.ranges[0].end == state->eos)
+            goto Complete;
+    } else {
+        if (reliable_reset_is_satisfied(state))
+            goto Complete;
+    }
 
     return 0;
 
@@ -91,21 +105,28 @@ Complete:
     return 0;
 }
 
-int quicly_recvstate_reset(quicly_recvstate_t *state, uint64_t eos_at, uint64_t *bytes_missing)
+int quicly_recvstate_reset(quicly_recvstate_t *state, uint64_t final_size, uint64_t reliable_size, uint64_t *bytes_missing)
 {
     assert(!quicly_recvstate_transfer_complete(state));
 
     /* validate */
-    if (state->eos != UINT64_MAX && state->eos != eos_at)
+    if (state->eos != UINT64_MAX && state->eos != final_size)
         return QUICLY_TRANSPORT_ERROR_FINAL_SIZE;
-    if (eos_at < state->received.ranges[state->received.num_ranges - 1].end)
+    if (final_size < state->received.ranges[state->received.num_ranges - 1].end)
         return QUICLY_TRANSPORT_ERROR_FINAL_SIZE;
 
     /* calculate bytes missing */
-    *bytes_missing = eos_at - state->received.ranges[state->received.num_ranges - 1].end;
+    *bytes_missing = final_size - state->received.ranges[state->received.num_ranges - 1].end;
 
-    /* clear the received range */
-    quicly_ranges_clear(&state->received);
+    state->reliable_size = reliable_size;
+
+    /* if all stream bytes that have to be received have been received, clear the received range to indicate that */
+    if (reliable_reset_is_satisfied(state)) {
+        quicly_ranges_clear(&state->received);
+    } else {
+        /* otherwise, retain offsets to be used later when more STREAM frames are received */
+        state->eos = final_size;
+    }
 
     return 0;
 }

--- a/lib/streambuf.c
+++ b/lib/streambuf.c
@@ -249,6 +249,14 @@ int quicly_streambuf_egress_shutdown(quicly_stream_t *stream)
     return quicly_stream_sync_sendbuf(stream, 1);
 }
 
+int quicly_streambuf_egress_reset(quicly_stream_t *stream, uint64_t reliable_size, int err)
+{
+    assert(quicly_get_remote_transport_parameters(stream->conn)->reliable_reset_stream &&
+           "use of reliable-reset-stream extension must be negotiated");
+    quicly_reset_stream_reliable(stream, reliable_size, err);
+    return quicly_stream_sync_sendbuf(stream, 1);
+}
+
 int quicly_streambuf_ingress_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len)
 {
     quicly_streambuf_t *sbuf = stream->data;

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -92,6 +92,9 @@ provider quicly {
     probe reset_stream_send(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint16_t error_code, uint64_t final_size);
     probe reset_stream_receive(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint16_t error_code, uint64_t final_size);
 
+    probe reliable_reset_stream_send(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint16_t error_code, uint64_t final_size, uint64_t reliable_size);
+    probe reliable_reset_stream_receive(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint16_t error_code, uint64_t final_size, uint64_t reliable_size);
+
     probe stop_sending_send(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint16_t error_code);
     probe stop_sending_receive(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint16_t error_code);
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -121,6 +121,7 @@ static void on_stop_sending(quicly_stream_t *stream, int err);
 static void on_receive_reset(quicly_stream_t *stream, int err);
 static void server_on_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len);
 static void client_on_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len);
+static void client_on_receive_reset(quicly_stream_t *stream, int err);
 
 static const quicly_stream_callbacks_t server_stream_callbacks = {quicly_streambuf_destroy,
                                                                   quicly_streambuf_egress_shift,
@@ -133,7 +134,7 @@ static const quicly_stream_callbacks_t server_stream_callbacks = {quicly_streamb
                                                                   quicly_streambuf_egress_emit,
                                                                   on_stop_sending,
                                                                   client_on_receive,
-                                                                  on_receive_reset};
+                                                                  client_on_receive_reset};
 
 static void dump_stats(FILE *fp, quicly_conn_t *conn)
 {
@@ -339,8 +340,38 @@ static void server_on_receive(quicly_stream_t *stream, size_t off, const void *s
     send_header(stream, is_http1, 404, "text/plain; charset=utf-8");
     send_str(stream, "not found\n");
 Sent:
-    quicly_streambuf_egress_shutdown(stream);
+    if (ctx.transport_params.reliable_reset_stream && quicly_get_remote_transport_parameters(stream->conn)->reliable_reset_stream) {
+        quicly_streambuf_t *sbuf = stream->data;
+        quicly_streambuf_egress_reset(stream, sbuf->egress.bytes_written, QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(123));
+    } else {
+        quicly_streambuf_egress_shutdown(stream);
+    }
     quicly_streambuf_ingress_shift(stream, len);
+}
+
+static void client_on_receive_complete(quicly_stream_t *stream)
+{
+    struct st_stream_data_t *stream_data = stream->data;
+
+    if (stream_data->outfp != NULL)
+        fclose(stream_data->outfp);
+    static size_t num_resp_received;
+    ++num_resp_received;
+    if (reqs[num_resp_received].path == NULL) {
+        if (request_interval != 0) {
+            enqueue_requests_at = ctx.now->cb(ctx.now) + request_interval;
+        } else {
+            dump_stats(stderr, stream->conn);
+            quicly_close(stream->conn, 0, "");
+        }
+    }
+}
+
+static void client_on_receive_reset(quicly_stream_t *stream, int err)
+{
+    on_receive_reset(stream, err);
+    if (quicly_recvstate_transfer_complete(&stream->recvstate))
+        client_on_receive_complete(stream);
 }
 
 static void client_on_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len)
@@ -360,20 +391,8 @@ static void client_on_receive(quicly_stream_t *stream, size_t off, const void *s
         quicly_streambuf_ingress_shift(stream, input.len);
     }
 
-    if (quicly_recvstate_transfer_complete(&stream->recvstate)) {
-        if (stream_data->outfp != NULL)
-            fclose(stream_data->outfp);
-        static size_t num_resp_received;
-        ++num_resp_received;
-        if (reqs[num_resp_received].path == NULL) {
-            if (request_interval != 0) {
-                enqueue_requests_at = ctx.now->cb(ctx.now) + request_interval;
-            } else {
-                dump_stats(stderr, stream->conn);
-                quicly_close(stream->conn, 0, "");
-            }
-        }
-    }
+    if (quicly_recvstate_transfer_complete(&stream->recvstate))
+        client_on_receive_complete(stream);
 }
 
 static int on_stream_open(quicly_stream_open_t *self, quicly_stream_t *stream)
@@ -1113,8 +1132,10 @@ int main(int argc, char **argv)
         address_token_aead.dec = ptls_aead_new(&ptls_openssl_aes128gcm, &ptls_openssl_sha256, 0, secret, "");
     }
 
-    static const struct option longopts[] = {
-        {"ech-key", required_argument, NULL, 0}, {"ech-configs", required_argument, NULL, 0}, {NULL}};
+    static const struct option longopts[] = {{"ech-key", required_argument, NULL, 0},
+                                             {"ech-configs", required_argument, NULL, 0},
+                                             {"reliable-reset", no_argument, NULL, 0},
+                                             {NULL}};
     while ((ch = getopt_long(argc, argv, "a:b:B:c:C:Dd:k:Ee:f:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvw:W:x:X:y:h", longopts,
                              &opt_index)) != -1) {
         switch (ch) {
@@ -1123,6 +1144,8 @@ int main(int argc, char **argv)
                 ech_setup_key(&tlsctx, optarg);
             } else if (strcmp(longopts[opt_index].name, "ech-configs") == 0) {
                 ech_setup_configs(optarg);
+            } else if (strcmp(longopts[opt_index].name, "reliable-reset") == 0) {
+                ctx.transport_params.reliable_reset_stream = 1;
             } else {
                 assert(!"unexpected longname");
             }


### PR DESCRIPTION
As proposed in https://marten-seemann.github.io/draft-seemann-quic-reliable-stream-reset/draft-seemann-quic-reliable-stream-reset.html.

Changes to the state machine can be found in 76ac2e0.

The sender design is, when a reliable reset is requested, pretend as if the stream was closed at current Final Size (i.e., amount of data that have already left the sender). But instead of sending FIN, send a RELIABLE_RESET_STREAM frame with the Reliable Size field set to the Final Size.

On the receiver-side, the reset signal is surfaced using the same API (i.e., `on_receive_reset`). But instead of clearing receive state (i.e., list of byte blocks that have been received), we continue running the receive state machinery until all bytes up to `min(FinalSize, ReliableSize)` have been received.