### PR TITLE
implement path migration

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -462,6 +462,10 @@ struct st_quicly_conn_streamgroup_state_t {
          * Total number of packets received out of order.                                                                          \
          */                                                                                                                        \
         uint64_t received_out_of_order;                                                                                            \
+        /**                                                                                                                        \
+         * Total number of packets acknowledged that were sent after the first path migration.                                     \
+         */                                                                                                                        \
+        uint64_t ack_received_post_migration;                                                                                      \
     } num_packets;                                                                                                                 \
     struct {                                                                                                                       \
         /**                                                                                                                        \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -560,10 +560,6 @@ struct _st_quicly_conn_public_t {
          */
         quicly_local_cid_set_t cid_set;
         /**
-         * the local address (may be AF_UNSPEC)
-         */
-        quicly_address_t address;
-        /**
          * the SCID used in long header packets. Equivalent to local_cid[seq=0]. Retaining the value separately is the easiest way
          * of staying away from the complexity caused by remote peer sending RCID frames before the handshake concludes.
          */
@@ -578,10 +574,6 @@ struct _st_quicly_conn_public_t {
          * CIDs received from the remote peer
          */
         quicly_remote_cid_set_t cid_set;
-        /**
-         * the remote address (cannot be AF_UNSPEC)
-         */
-        quicly_address_t address;
         struct st_quicly_conn_streamgroup_state_t bidi, uni;
         quicly_transport_parameters_t transport_params;
         struct {
@@ -927,11 +919,11 @@ static quicly_stream_id_t quicly_get_remote_next_stream_id(quicly_conn_t *conn, 
 /**
  * Returns the local address of the connection. This may be AF_UNSPEC, indicating that the operating system is choosing the address.
  */
-static struct sockaddr *quicly_get_sockname(quicly_conn_t *conn);
+struct sockaddr *quicly_get_sockname(quicly_conn_t *conn);
 /**
  * Returns the remote address of the connection. This would never be AF_UNSPEC.
  */
-static struct sockaddr *quicly_get_peername(quicly_conn_t *conn);
+struct sockaddr *quicly_get_peername(quicly_conn_t *conn);
 /**
  *
  */
@@ -1083,8 +1075,8 @@ int quicly_decode_transport_parameter_list(quicly_transport_parameters_t *params
  */
 int quicly_connect(quicly_conn_t **conn, quicly_context_t *ctx, const char *server_name, struct sockaddr *dest_addr,
                    struct sockaddr *src_addr, const quicly_cid_plaintext_t *new_cid, ptls_iovec_t address_token,
-                   ptls_handshake_properties_t *handshake_properties,
-                   const quicly_transport_parameters_t *resumed_transport_params, void *appdata);
+                   ptls_handshake_properties_t *handshake_properties, const quicly_transport_parameters_t *resumed_transport_params,
+                   void *appdata);
 /**
  * accepts a new connection
  * @param new_cid        The CID to be used for the connection. When an error is being returned, the application can reuse the CID
@@ -1352,18 +1344,6 @@ inline quicly_stream_id_t quicly_get_remote_next_stream_id(quicly_conn_t *conn, 
 {
     struct _st_quicly_conn_public_t *c = (struct _st_quicly_conn_public_t *)conn;
     return uni ? c->remote.uni.next_stream_id : c->remote.bidi.next_stream_id;
-}
-
-inline struct sockaddr *quicly_get_sockname(quicly_conn_t *conn)
-{
-    struct _st_quicly_conn_public_t *c = (struct _st_quicly_conn_public_t *)conn;
-    return &c->local.address.sa;
-}
-
-inline struct sockaddr *quicly_get_peername(quicly_conn_t *conn)
-{
-    struct _st_quicly_conn_public_t *c = (struct _st_quicly_conn_public_t *)conn;
-    return &c->remote.address.sa;
 }
 
 inline uint32_t quicly_get_protocol_version(quicly_conn_t *conn)

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -462,10 +462,6 @@ struct st_quicly_conn_streamgroup_state_t {
          * Total number of packets received out of order.                                                                          \
          */                                                                                                                        \
         uint64_t received_out_of_order;                                                                                            \
-        /**                                                                                                                        \
-         * Total number of packets acknowledged that were sent after the first path migration.                                     \
-         */                                                                                                                        \
-        uint64_t ack_received_post_migration;                                                                                      \
     } num_packets;                                                                                                                 \
     struct {                                                                                                                       \
         /**                                                                                                                        \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -331,7 +331,8 @@ struct st_quicly_context_t {
      */
     uint64_t max_probe_packets;
     /**
-     * once path validation fails for the specified number of times, packets arriving on new tuples will be dropped
+     * Once path validation fails for the specified number of paths, packets arriving on new tuples will be dropped. Setting this
+     * value to zero effectively disables the endpoint responding to path migration attempts.
      */
     uint64_t max_path_validation_failures;
     /**

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -327,6 +327,10 @@ struct st_quicly_context_t {
      */
     uint64_t max_initial_handshake_packets;
     /**
+     * maximum number of probe packets (i.e., packets carrying PATH_CHALLENGE frames) to be sent before calling a path unreachable
+     */
+    uint64_t max_probe_packets;
+    /**
      * expand client hello so that it does not fit into one datagram
      */
     unsigned expand_client_hello : 1;

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -462,6 +462,14 @@ struct st_quicly_conn_streamgroup_state_t {
          * Total number of packets received out of order.                                                                          \
          */                                                                                                                        \
         uint64_t received_out_of_order;                                                                                            \
+        /**                                                                                                                        \
+         * Total number of packets sent on promoted paths.                                                                         \
+         */                                                                                                                        \
+        uint64_t sent_promoted_paths;                                                                                              \
+        /**                                                                                                                        \
+         * Total number of acked packets that were sent on promoted.                                                               \
+         */                                                                                                                        \
+        uint64_t ack_received_promoted_paths;                                                                                      \
     } num_packets;                                                                                                                 \
     struct {                                                                                                                       \
         /**                                                                                                                        \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -331,6 +331,10 @@ struct st_quicly_context_t {
      */
     uint64_t max_probe_packets;
     /**
+     * once path validation fails for the specified number of times, packets arriving on new tuples will be dropped
+     */
+    uint64_t max_path_validation_failures;
+    /**
      * expand client hello so that it does not fit into one datagram
      */
     unsigned expand_client_hello : 1;
@@ -494,6 +498,10 @@ struct st_quicly_conn_streamgroup_state_t {
          * number alternate paths validated                                                                                        \
          */                                                                                                                        \
         uint64_t validated;                                                                                                        \
+        /**                                                                                                                        \
+         * number of alternate paths that were created but failed to validate                                                      \
+         */                                                                                                                        \
+        uint64_t validation_failed;                                                                                                \
         /**                                                                                                                        \
          * number of migrations                                                                                                    \
          */                                                                                                                        \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -485,6 +485,20 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t stream_data_resent;                                                                                               \
     } num_bytes;                                                                                                                   \
+    struct {                                                                                                                       \
+        /**                                                                                                                        \
+         * number of alternate paths created                                                                                       \
+         */                                                                                                                        \
+        uint64_t created;                                                                                                          \
+        /**                                                                                                                        \
+         * number alternate paths validated                                                                                        \
+         */                                                                                                                        \
+        uint64_t validated;                                                                                                        \
+        /**                                                                                                                        \
+         * number of migrations                                                                                                    \
+         */                                                                                                                        \
+        uint64_t promoted;                                                                                                         \
+    } num_paths;                                                                                                                   \
     /**                                                                                                                            \
      * Total number of each frame being sent / received.                                                                           \
      */                                                                                                                            \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -511,6 +511,10 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t validation_failed;                                                                                                \
         /**                                                                                                                        \
+         * number of paths on which migration has been elicited (i.e., received non-probing packets)                               \
+         */                                                                                                                        \
+        uint64_t migration_elicited;                                                                                               \
+        /**                                                                                                                        \
          * number of migrations                                                                                                    \
          */                                                                                                                        \
         uint64_t promoted;                                                                                                         \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -518,6 +518,10 @@ struct st_quicly_conn_streamgroup_state_t {
          * number of migrations                                                                                                    \
          */                                                                                                                        \
         uint64_t promoted;                                                                                                         \
+        /**                                                                                                                        \
+         * number of alternate paths that were closed due to Connection ID being unavailable                                       \
+         */                                                                                                                        \
+        uint64_t closed_no_dcid;                                                                                                   \
     } num_paths;                                                                                                                   \
     /**                                                                                                                            \
      * Total number of each frame being sent / received.                                                                           \

--- a/include/quicly/remote_cid.h
+++ b/include/quicly/remote_cid.h
@@ -29,23 +29,39 @@ extern "C" {
 #endif
 
 /**
+ * state of `quicly_remote_cid_t`
+ */
+typedef enum en_quicly_remote_cid_state_t {
+    /**
+     * cid and stateless reset token have not been received for the sequence number
+     */
+    QUICLY_REMOTE_CID_UNAVAILABLE,
+    /**
+     * cid is in use
+     */
+    QUICLY_REMOTE_CID_IN_USE,
+    /**
+     * cid has been receive but has not been used yet
+     */
+    QUICLY_REMOTE_CID_AVAILABLE
+} quicly_remote_cid_state_t;
+
+/**
  * records a CID given by the remote peer
  */
 typedef struct st_quicly_remote_cid_t {
     /**
-     * indicates whether this record holds an active (given by remote peer and not retired) CID
+     * state
      */
-    int is_active;
+    quicly_remote_cid_state_t state;
     /**
-     * sequence number of the CID
-     *
-     * If is_active, this represents the sequence number associated with the CID.
-     * If !is_active, this represents a "reserved" slot, meaning that we are expecting to receive a NEW_CONNECTION_ID frame
-     * with this sequence number. This helps determine if a received frame is carrying a CID that is already retired.
+     * sequence number of the CID; if `state` is UNAVAILABLE, this is a reserved slot meaning that we are expecting to receive a
+     * NEW_CONNECTION_ID frame with this sequence number. This helps determine if a received frame is carrying a CID that is already
+     * retired.
      */
     uint64_t sequence;
     /**
-     * CID; only usable if `is_active` is true
+     * CID; available unless `state` is UNAVAILABLE
      */
     struct st_quicly_cid_t cid;
     /**
@@ -59,8 +75,9 @@ typedef struct st_quicly_remote_cid_t {
  */
 typedef struct st_quicly_remote_cid_set_t {
     /**
-     * we retain QUICLY_LOCAL_ACTIVE_CONNECTION_ID_LIMIT active connection IDs
-     * cids[0] holds the current (in use) CID which is used when emitting packets
+     * We retain QUICLY_LOCAL_ACTIVE_CONNECTION_ID_LIMIT active connection IDs. `cids[0]` used to retain the current DCID, but it is
+     * no longer the case. DCID of the non-probing path should now be obtained via `get_dcid(conn->paths[0])` where `paths[0]` is
+     * the non-probing path.
      */
     quicly_remote_cid_t cids[QUICLY_LOCAL_ACTIVE_CONNECTION_ID_LIMIT];
     /**
@@ -84,9 +101,8 @@ int quicly_remote_cid_register(quicly_remote_cid_set_t *set, uint64_t sequence, 
                                uint64_t unregistered_seqs[QUICLY_LOCAL_ACTIVE_CONNECTION_ID_LIMIT], size_t *num_unregistered_seqs);
 /**
  * unregisters specified CID from the store
- * returns 0 if success, 1 if failure
  */
-int quicly_remote_cid_unregister(quicly_remote_cid_set_t *set, uint64_t sequence);
+void quicly_remote_cid_unregister(quicly_remote_cid_set_t *set, uint64_t sequence);
 
 #ifdef __cplusplus
 }

--- a/include/quicly/sentmap.h
+++ b/include/quicly/sentmap.h
@@ -57,6 +57,10 @@ typedef struct st_quicly_sent_packet_t {
      */
     uint8_t frames_in_flight : 1;
     /**
+     * if sent on a promoted path
+     */
+    uint8_t promoted_path : 1;
+    /**
      * number of bytes in-flight for the packet, from the context of CC (becomes zero when deemed lost, but not when PTO fires)
      */
     uint16_t cc_bytes_in_flight;
@@ -252,7 +256,7 @@ int quicly_sentmap_prepare(quicly_sentmap_t *map, uint64_t packet_number, int64_
 /**
  * commits a write
  */
-static void quicly_sentmap_commit(quicly_sentmap_t *map, uint16_t bytes_in_flight);
+static void quicly_sentmap_commit(quicly_sentmap_t *map, uint16_t bytes_in_flight, int promoted_path);
 /**
  * Allocates a slot to contain a callback for a frame.  The function MUST be called after _prepare but before _commit.
  */
@@ -290,7 +294,7 @@ inline int quicly_sentmap_is_open(quicly_sentmap_t *map)
     return map->_pending_packet != NULL;
 }
 
-inline void quicly_sentmap_commit(quicly_sentmap_t *map, uint16_t bytes_in_flight)
+inline void quicly_sentmap_commit(quicly_sentmap_t *map, uint16_t bytes_in_flight, int promoted_path)
 {
     assert(quicly_sentmap_is_open(map));
 
@@ -300,6 +304,8 @@ inline void quicly_sentmap_commit(quicly_sentmap_t *map, uint16_t bytes_in_fligh
         map->bytes_in_flight += bytes_in_flight;
     }
     map->_pending_packet->data.packet.frames_in_flight = 1;
+    if (promoted_path)
+        map->_pending_packet->data.packet.promoted_path = 1;
     map->_pending_packet = NULL;
 
     ++map->num_packets;

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -30,6 +30,7 @@
 #define DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT 3
 #define DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER 400
 #define DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS 1000
+#define DEFAULT_MAX_PROBE_PACKETS 5
 
 /* profile that employs IETF specified values */
 const quicly_context_t quicly_spec_context = {NULL,                                                 /* tls */
@@ -49,6 +50,7 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                               0, /* ack_frequency */
                                               DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
                                               DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
+                                              DEFAULT_MAX_PROBE_PACKETS,
                                               0, /* enlarge_client_hello */
                                               NULL,
                                               NULL, /* on_stream_open */
@@ -79,6 +81,7 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                     0, /* ack_frequency */
                                                     DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
                                                     DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
+                                                    DEFAULT_MAX_PROBE_PACKETS,
                                                     0, /* enlarge_client_hello */
                                                     NULL,
                                                     NULL, /* on_stream_open */

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -31,6 +31,7 @@
 #define DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER 400
 #define DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS 1000
 #define DEFAULT_MAX_PROBE_PACKETS 5
+#define DEFAULT_MAX_PATH_VALIDATION_FAILURES 100
 
 /* profile that employs IETF specified values */
 const quicly_context_t quicly_spec_context = {NULL,                                                 /* tls */
@@ -51,6 +52,7 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                               DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
                                               DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
                                               DEFAULT_MAX_PROBE_PACKETS,
+                                              DEFAULT_MAX_PATH_VALIDATION_FAILURES,
                                               0, /* enlarge_client_hello */
                                               NULL,
                                               NULL, /* on_stream_open */
@@ -82,6 +84,7 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                     DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
                                                     DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
                                                     DEFAULT_MAX_PROBE_PACKETS,
+                                                    DEFAULT_MAX_PATH_VALIDATION_FAILURES,
                                                     0, /* enlarge_client_hello */
                                                     NULL,
                                                     NULL, /* on_stream_open */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -6781,8 +6781,10 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     if ((ret = handle_payload(conn, epoch, path_index, payload.base, payload.len, &offending_frame_type, &is_ack_only,
                               &is_probe_only)) != 0)
         goto Exit;
-    if (!is_probe_only)
+    if (!is_probe_only && conn->paths[path_index]->probe_only) {
+        ++conn->super.stats.num_paths.migration_elicited;
         conn->paths[path_index]->probe_only = 0;
+    }
     if (*space != NULL && conn->super.state < QUICLY_STATE_CLOSING) {
         if ((ret = record_receipt(*space, pn, is_ack_only, conn->stash.now, &conn->egress.send_ack_at,
                                   &conn->super.stats.num_packets.received_out_of_order)) != 0)

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1887,6 +1887,13 @@ static int promote_path(quicly_conn_t *conn, size_t path_index)
         conn->egress.cc.type->cc_init, &conn->egress.cc,
         quicly_cc_calc_initial_cwnd(conn->super.ctx->initcwnd_packets, conn->egress.max_udp_payload_size), conn->stash.now);
 
+    /* reset RTT estimate, adopting SRTT of the original path as initial RTT (TODO calculate RTT based on path challenge RT) */
+    quicly_rtt_init(&conn->egress.loss.rtt, &conn->super.ctx->loss,
+                    conn->egress.loss.rtt.smoothed < conn->super.ctx->loss.default_initial_rtt
+                        ? conn->egress.loss.rtt.smoothed
+                        : conn->super.ctx->loss.default_initial_rtt);
+
+    /* remember PN when the path was promoted */
     conn->egress.pn_path_start = conn->egress.packet_number;
 
     /* update path mapping */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4964,7 +4964,7 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
         }
     }
 
-    s->dcid = get_dcid(conn, 0);
+    s->dcid = get_dcid(conn, s->path_index);
 
     s->send_window = calc_send_window(conn, min_packets_to_send * conn->egress.max_udp_payload_size,
                                       calc_amplification_limit_allowance(conn), restrict_sending);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -6782,8 +6782,13 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
                               &is_probe_only)) != 0)
         goto Exit;
     if (!is_probe_only && conn->paths[path_index]->probe_only) {
-        ++conn->super.stats.num_paths.migration_elicited;
+        assert(path_index != 0);
         conn->paths[path_index]->probe_only = 0;
+        ++conn->super.stats.num_paths.migration_elicited;
+        QUICLY_ELICIT_PATH_MIGRATION(conn, conn->stash.now, path_index);
+        QUICLY_LOG_CONN(elicit_path_migration, conn, {
+            PTLS_LOG_ELEMENT_UNSIGNED(path_index, path_index);
+        });
     }
     if (*space != NULL && conn->super.state < QUICLY_STATE_CLOSING) {
         if ((ret = record_receipt(*space, pn, is_ack_only, conn->stash.now, &conn->egress.send_ack_at,

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3641,6 +3641,7 @@ static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, int
 
     ++conn->egress.packet_number;
     ++conn->super.stats.num_packets.sent;
+    ++conn->paths[s->path_index]->num_packets.sent;
     if (on_promoted_path)
         ++conn->super.stats.num_packets.sent_promoted_paths;
 
@@ -5390,7 +5391,6 @@ Exit:
                                    (s->num_datagrams == s->max_datagrams ||
                                     conn->egress.loss.sentmap.bytes_in_flight >= conn->egress.cc.cwnd ||
                                     pacer_can_send_at(conn) > conn->stash.now));
-        conn->paths[s->path_index]->num_packets.sent += 1;
         if (s->num_datagrams != 0)
             update_idle_timeout(conn, 0);
     }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5106,6 +5106,8 @@ int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *s
         s.path_index = 0;
         if ((ret = do_send(conn, &s)) != 0)
             goto Exit;
+    } else {
+        ret = 0;
     }
 
     assert_consistency(conn, 1);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4714,6 +4714,7 @@ static int send_path_challenge(quicly_conn_t *conn, quicly_send_context_t *s, in
         return ret;
 
     s->dst = quicly_encode_path_challenge_frame(s->dst, is_response, data);
+    s->target.full_size = 1; /* ensure that the path can transfer full-size packets */
 
     if (!is_response) {
         ++conn->super.stats.num_frames_sent.path_challenge;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5083,7 +5083,7 @@ int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *s
     if (conn->egress.send_probe_at <= conn->stash.now) {
         conn->egress.send_probe_at = INT64_MAX; /* `do_send` shortens this value */
         for (s.path_index = 1; s.path_index < PTLS_ELEMENTSOF(conn->paths); ++s.path_index) {
-            if (conn->paths[s.path_index] == NULL)
+            if (conn->paths[s.path_index] == NULL || conn->stash.now < conn->paths[s.path_index]->path_challenge.send_at)
                 continue;
             /* determine DCID to be used, if not yet been done; upon failure, this path (being secondary) is discarded */
             if (conn->paths[s.path_index]->dcid == UINT64_MAX && !setup_path_dcid(conn, s.path_index)) {

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5025,7 +5025,8 @@ int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *s
                                .max_datagrams = *num_datagrams,
                                .payload_buf = {.datagram = buf, .end = (uint8_t *)buf + bufsize},
                                .first_packet_number = conn->egress.packet_number};
-    size_t num_path_challenges_sent_upon_entry = conn->super.stats.num_frames_sent.path_challenge;
+    uint64_t num_path_probes_sent_upon_entry =
+        conn->super.stats.num_frames_sent.path_challenge + conn->super.stats.num_frames_sent.path_response;
     int ret;
 
     lock_now(conn, 0);
@@ -5122,7 +5123,8 @@ int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *s
 Exit:
     if (s.path_index == 0)
         clear_datagram_frame_payloads(conn);
-    if (num_path_challenges_sent_upon_entry != conn->super.stats.num_frames_sent.path_challenge) {
+    if (num_path_probes_sent_upon_entry !=
+        conn->super.stats.num_frames_sent.path_challenge + conn->super.stats.num_frames_sent.path_response) {
         /* if we've sent PATH_CHALLENGE, update send_probe_at */
         conn->egress.send_probe_at = INT64_MAX;
         for (size_t i = 0; i < PTLS_ELEMENTSOF(conn->paths); ++i) {

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -987,6 +987,7 @@ static void retire_connection_id(quicly_conn_t *conn, uint64_t sequence)
             path->dcid = UINT64_MAX;
     }
 
+    quicly_remote_cid_unregister(&conn->super.remote.cid_set, sequence);
     schedule_retire_connection_id_frame(conn, sequence);
 }
 
@@ -1788,6 +1789,8 @@ static void delete_path(quicly_conn_t *conn, int is_promote, size_t path_index)
     }
 
     /* deinstantiate */
+    if (path->dcid != UINT64_MAX && conn->super.remote.cid_set.cids[0].cid.len != 0)
+        retire_connection_id(conn, path->dcid);
     free(path);
 }
 
@@ -6832,8 +6835,6 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
         /* switch active path to current path, if current path is validated and not probe-only */
         if (path_index != 0 && conn->paths[path_index]->path_challenge.send_at == INT64_MAX &&
             !conn->paths[path_index]->probe_only) {
-            if (conn->super.remote.cid_set.cids[0].cid.len != 0)
-                retire_connection_id(conn, 0);
             delete_path(conn, 1 /* promote */, path_index);
             recalc_send_probe_at(conn);
         }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1913,6 +1913,9 @@ static int promote_path(quicly_conn_t *conn, size_t path_index)
                         ? conn->egress.loss.rtt.smoothed
                         : conn->super.ctx->loss.default_initial_rtt);
 
+    /* reset ratemeter */
+    quicly_ratemeter_init(&conn->egress.ratemeter);
+
     /* remember PN when the path was promoted */
     conn->egress.pn_path_start = conn->egress.packet_number;
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5217,6 +5217,7 @@ int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *s
             if (conn->paths[s.path_index]->dcid == UINT64_MAX && !setup_path_dcid(conn, s.path_index)) {
                 free_path(conn, 0, s.path_index);
                 s.recalc_send_probe_at = 1;
+                conn->super.stats.num_paths.closed_no_dcid += 1;
                 continue;
             }
             if ((ret = do_send(conn, &s)) != 0)

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -7182,19 +7182,21 @@ const quicly_stream_callbacks_t quicly_stream_noop_callbacks = {
 
 void quicly__debug_printf(quicly_conn_t *conn, const char *function, int line, const char *fmt, ...)
 {
-#if QUICLY_USE_DTRACE
-    char buf[1024];
-    va_list args;
+    if (QUICLY_DEBUG_MESSAGE_ENABLED() || ptls_log.is_active) {
+        char buf[1024];
+        va_list args;
 
-    if (!QUICLY_DEBUG_MESSAGE_ENABLED())
-        return;
+        va_start(args, fmt);
+        vsnprintf(buf, sizeof(buf), fmt, args);
+        va_end(args);
 
-    va_start(args, fmt);
-    vsnprintf(buf, sizeof(buf), fmt, args);
-    va_end(args);
-
-    QUICLY_DEBUG_MESSAGE(conn, function, line, buf);
-#endif
+        QUICLY_DEBUG_MESSAGE(conn, function, line, buf);
+        QUICLY_LOG_CONN(debug_message, conn, {
+            PTLS_LOG_ELEMENT_UNSAFESTR(function, function, strlen(function));
+            PTLS_LOG_ELEMENT_SIGNED(line, line);
+            PTLS_LOG_ELEMENT_UNSAFESTR(message, buf, strlen(buf));
+        });
+    }
 }
 
 const uint32_t quicly_supported_versions[] = {QUICLY_PROTOCOL_VERSION_1, QUICLY_PROTOCOL_VERSION_DRAFT29,

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -290,6 +290,10 @@ struct st_quicly_conn_t {
          */
         uint64_t next_pn_to_skip;
         /**
+         * smallest packet number being sent on any path other than the initial path
+         */
+        uint64_t pn_first_migration;
+        /**
          *
          */
         uint16_t max_udp_payload_size;
@@ -1772,6 +1776,8 @@ static void free_path(quicly_conn_t *conn, int is_promote, size_t path_index)
         path = conn->paths[0];
         conn->paths[0] = conn->paths[path_index];
         conn->paths[path_index] = NULL;
+        if (conn->egress.pn_first_migration == UINT64_MAX)
+            conn->egress.pn_first_migration = conn->egress.packet_number;
         conn->super.stats.num_paths.promoted += 1;
     } else {
         QUICLY_DELETE_PATH(conn, conn->stash.now, path_index);
@@ -2416,6 +2422,7 @@ static quicly_conn_t *create_connection(quicly_context_t *ctx, uint32_t protocol
                      &conn->super.remote.transport_params.max_ack_delay, &conn->super.remote.transport_params.ack_delay_exponent);
     conn->egress.next_pn_to_skip =
         calc_next_pn_to_skip(conn->super.ctx->tls, 0, initcwnd, conn->super.ctx->initial_egress_max_udp_payload_size);
+    conn->egress.pn_first_migration = UINT64_MAX;
     conn->egress.max_udp_payload_size = conn->super.ctx->initial_egress_max_udp_payload_size;
     init_max_streams(&conn->egress.max_streams.uni);
     init_max_streams(&conn->egress.max_streams.bidi);
@@ -5576,6 +5583,8 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
                 }
             }
             ++conn->super.stats.num_packets.ack_received;
+            if (pn_acked >= conn->egress.pn_first_migration)
+                ++conn->super.stats.num_packets.ack_received_post_migration;
             largest_newly_acked.pn = pn_acked;
             largest_newly_acked.sent_at = sent->sent_at;
             QUICLY_PROBE(PACKET_ACKED, conn, conn->stash.now, pn_acked, is_late_ack);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -6789,9 +6789,7 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
         conn->paths[path_index]->probe_only = 0;
         ++conn->super.stats.num_paths.migration_elicited;
         QUICLY_ELICIT_PATH_MIGRATION(conn, conn->stash.now, path_index);
-        QUICLY_LOG_CONN(elicit_path_migration, conn, {
-            PTLS_LOG_ELEMENT_UNSIGNED(path_index, path_index);
-        });
+        QUICLY_LOG_CONN(elicit_path_migration, conn, { PTLS_LOG_ELEMENT_UNSIGNED(path_index, path_index); });
     }
     if (*space != NULL && conn->super.state < QUICLY_STATE_CLOSING) {
         if ((ret = record_receipt(*space, pn, is_ack_only, conn->stash.now, &conn->egress.send_ack_at,

--- a/lib/remote_cid.c
+++ b/lib/remote_cid.c
@@ -26,7 +26,7 @@
 void quicly_remote_cid_init_set(quicly_remote_cid_set_t *set, ptls_iovec_t *initial_cid, void (*random_bytes)(void *, size_t))
 {
     set->cids[0] = (quicly_remote_cid_t){
-        .is_active = 1,
+        .state = QUICLY_REMOTE_CID_IN_USE,
         .sequence = 0,
     };
     if (initial_cid != NULL) {
@@ -39,27 +39,11 @@ void quicly_remote_cid_init_set(quicly_remote_cid_set_t *set, ptls_iovec_t *init
 
     for (size_t i = 1; i < PTLS_ELEMENTSOF(set->cids); i++)
         set->cids[i] = (quicly_remote_cid_t){
-            .is_active = 0,
+            .state = QUICLY_REMOTE_CID_UNAVAILABLE,
             .sequence = i,
         };
 
     set->_largest_sequence_expected = PTLS_ELEMENTSOF(set->cids) - 1;
-}
-
-/**
- * promote CID at idx_to_promote as the current CID for communication
- * i.e. swap cids[idx_to_promote] and cids[0]
- */
-static void promote_cid(quicly_remote_cid_set_t *set, size_t idx_to_promote)
-{
-    uint64_t seq_tmp = set->cids[0].sequence;
-
-    assert(idx_to_promote > 0);
-    assert(!set->cids[0].is_active);
-
-    set->cids[0] = set->cids[idx_to_promote];
-    set->cids[idx_to_promote].is_active = 0;
-    set->cids[idx_to_promote].sequence = seq_tmp;
 }
 
 static int do_register(quicly_remote_cid_set_t *set, uint64_t sequence, const uint8_t *cid, size_t cid_len,
@@ -71,7 +55,7 @@ static int do_register(quicly_remote_cid_set_t *set, uint64_t sequence, const ui
         return QUICLY_TRANSPORT_ERROR_CONNECTION_ID_LIMIT;
 
     for (size_t i = 0; i < PTLS_ELEMENTSOF(set->cids); i++) {
-        if (set->cids[i].is_active) {
+        if (set->cids[i].state != QUICLY_REMOTE_CID_UNAVAILABLE) {
             /* compare newly received CID against what we already have, to see if there is duplication/conflicts */
 
             /* If an endpoint receives a NEW_CONNECTION_ID frame that repeats a previously issued connection ID with
@@ -97,12 +81,8 @@ static int do_register(quicly_remote_cid_set_t *set, uint64_t sequence, const ui
             set->cids[i].sequence = sequence;
             quicly_set_cid(&set->cids[i].cid, ptls_iovec_init(cid, cid_len));
             memcpy(set->cids[i].stateless_reset_token, srt, QUICLY_STATELESS_RESET_TOKEN_LEN);
-            set->cids[i].is_active = 1;
+            set->cids[i].state = QUICLY_REMOTE_CID_AVAILABLE;
             was_stored = 1;
-            if (i > 0 && !set->cids[0].is_active) {
-                /* promote this CID for communication */
-                promote_cid(set, i);
-            }
         }
     }
 
@@ -113,64 +93,34 @@ static int do_register(quicly_remote_cid_set_t *set, uint64_t sequence, const ui
 
 static void do_unregister(quicly_remote_cid_set_t *set, size_t idx_to_unreg)
 {
-    assert(set->cids[idx_to_unreg].is_active);
+    assert(set->cids[idx_to_unreg].state != QUICLY_REMOTE_CID_UNAVAILABLE);
 
-    set->cids[idx_to_unreg].is_active = 0;
+    set->cids[idx_to_unreg].state = QUICLY_REMOTE_CID_UNAVAILABLE;
     set->cids[idx_to_unreg].sequence = ++set->_largest_sequence_expected;
 }
 
-int quicly_remote_cid_unregister(quicly_remote_cid_set_t *set, uint64_t sequence)
+void quicly_remote_cid_unregister(quicly_remote_cid_set_t *set, uint64_t sequence)
 {
-    uint64_t min_seq = UINT64_MAX;
-    size_t min_seq_idx = SIZE_MAX;
     for (size_t i = 0; i < PTLS_ELEMENTSOF(set->cids); i++) {
         if (sequence == set->cids[i].sequence) {
             do_unregister(set, i);
-            if (i != 0)
-                return 0; /* if not retiring idx=0 (current in-use CID), simply return */
-        }
-        if (set->cids[i].is_active && min_seq > set->cids[i].sequence) {
-            /* find a CID with minimum sequence number, while iterating over the array */
-            min_seq = set->cids[i].sequence;
-            min_seq_idx = i;
+            return;
         }
     }
-
-    if (!set->cids[0].is_active) {
-        /* we have retired the current CID (idx=0) */
-        if (min_seq_idx != SIZE_MAX)
-            promote_cid(set, min_seq_idx);
-        return 0;
-    } else {
-        /* we did not unregister any slot */
-        return 1;
-    }
+    assert(!"invalid CID sequence number");
 }
 
 static size_t unregister_prior_to(quicly_remote_cid_set_t *set, uint64_t seq_unreg_prior_to,
                                   uint64_t unregistered_seqs[QUICLY_LOCAL_ACTIVE_CONNECTION_ID_LIMIT])
 {
-    uint64_t min_seq = UINT64_MAX, min_seq_idx = UINT64_MAX;
     size_t num_unregistered = 0;
-    for (size_t i = 0; i < PTLS_ELEMENTSOF(set->cids); i++) {
-        if (set->cids[i].is_active) {
-            if (set->cids[i].sequence < seq_unreg_prior_to) {
-                unregistered_seqs[num_unregistered++] = set->cids[i].sequence;
-                do_unregister(set, i);
-                continue;
-            }
-            if (min_seq > set->cids[i].sequence) {
-                /* find a CID with minimum sequence number, while iterating over the array */
-                min_seq = set->cids[i].sequence;
-                min_seq_idx = i;
-            }
-        }
-    }
 
-    if (!set->cids[0].is_active) {
-        /* we have retired the current CID (idx=0) */
-        if (min_seq_idx != UINT64_MAX)
-            promote_cid(set, min_seq_idx);
+    for (size_t i = 0; i < PTLS_ELEMENTSOF(set->cids); i++) {
+        if (set->cids[i].state != QUICLY_REMOTE_CID_UNAVAILABLE && set->cids[i].sequence < seq_unreg_prior_to) {
+            unregistered_seqs[num_unregistered++] = set->cids[i].sequence;
+            do_unregister(set, i);
+            continue;
+        }
     }
 
     return num_unregistered;
@@ -189,11 +139,9 @@ int quicly_remote_cid_register(quicly_remote_cid_set_t *set, uint64_t sequence, 
      * retires active_connection_id_limit CIDs and then installs one new CID. */
     *num_unregistered_seqs = unregister_prior_to(set, retire_prior_to, unregistered_seqs);
 
-    /* Then, register given value. */
+    /* Then, register given value. If an error occurs, restore the backup and send the error. */
     if ((ret = do_register(set, sequence, cid, cid_len, srt)) != 0) {
-        /* restore the backup and send the error */
-        if (!set->cids[0].is_active)
-            *set = backup;
+        *set = backup;
         return ret;
     }
 

--- a/lib/remote_cid.c
+++ b/lib/remote_cid.c
@@ -180,7 +180,7 @@ int quicly_remote_cid_register(quicly_remote_cid_set_t *set, uint64_t sequence, 
                                const uint8_t srt[QUICLY_STATELESS_RESET_TOKEN_LEN], uint64_t retire_prior_to,
                                uint64_t unregistered_seqs[QUICLY_LOCAL_ACTIVE_CONNECTION_ID_LIMIT], size_t *num_unregistered_seqs)
 {
-    quicly_remote_cid_t backup_cid = set->cids[0]; // preserve one valid entry in cids[0] to handle protocol violation
+    quicly_remote_cid_set_t backup = *set; /* preserve current state so that it can be restored to notify protocol violation */
     int ret;
 
     assert(sequence >= retire_prior_to);
@@ -193,7 +193,7 @@ int quicly_remote_cid_register(quicly_remote_cid_set_t *set, uint64_t sequence, 
     if ((ret = do_register(set, sequence, cid, cid_len, srt)) != 0) {
         /* restore the backup and send the error */
         if (!set->cids[0].is_active)
-            set->cids[0] = backup_cid;
+            *set = backup;
         return ret;
     }
 

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -53,6 +53,7 @@ provider quicly {
     probe new_path(struct st_quicly_conn_t *conn, int64_t at, size_t path_index, const char *remote);
     probe delete_path(struct st_quicly_conn_t *conn, int64_t at, size_t path_index);
     probe promote_path(struct st_quicly_conn_t *conn, int64_t at, size_t path_index);
+    probe elicit_path_migration(struct st_quicly_conn_t *conn, int64_t at, size_t path_index);
 
     probe crypto_handshake(struct st_quicly_conn_t *conn, int64_t at, int ret);
     probe crypto_update_secret(struct st_quicly_conn_t *conn, int64_t at, int is_enc, uint8_t epoch, const char *label, const char *secret);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -45,6 +45,7 @@ provider quicly {
     probe send(struct st_quicly_conn_t *conn, int64_t at, int state, const char *dcid);
     probe receive(struct st_quicly_conn_t *conn, int64_t at, const char *dcid, const void *bytes, size_t bytes_len);
     probe version_switch(struct st_quicly_conn_t *conn, int64_t at, uint32_t new_version);
+    probe migrate_active_path(struct st_quicly_conn_t *conn, int64_t at);
     probe idle_timeout(struct st_quicly_conn_t *conn, int64_t at);
     probe handshake_timeout(struct st_quicly_conn_t *conn, int64_t at, int64_t elapsed, uint32_t rtt_smoothed);
     probe initial_handshake_packet_exceed(struct st_quicly_conn_t *conn, int64_t at, uint64_t num_packets);
@@ -125,6 +126,12 @@ provider quicly {
 
     probe stream_data_blocked_send(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t maximum);
     probe stream_data_blocked_receive(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t maximum);
+
+    probe path_challenge_send(struct st_quicly_conn_t *conn, int64_t at, const void *bytes, size_t bytes_len);
+    probe path_challenge_receive(struct st_quicly_conn_t *conn, int64_t at, const void *bytes, size_t bytes_len);
+
+    probe path_response_send(struct st_quicly_conn_t *conn, int64_t at, const void *bytes, size_t bytes_len);
+    probe path_response_receive(struct st_quicly_conn_t *conn, int64_t at, const void *bytes, size_t bytes_len);
 
     probe datagram_send(struct st_quicly_conn_t *conn, int64_t at, const void *payload, size_t payload_len);
     probe datagram_receive(struct st_quicly_conn_t *conn, int64_t at, const void *payload, size_t payload_len);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -50,8 +50,8 @@ provider quicly {
     probe initial_handshake_packet_exceed(struct st_quicly_conn_t *conn, int64_t at, uint64_t num_packets);
     probe stateless_reset_receive(struct st_quicly_conn_t *conn, int64_t at);
 
-    probe new_path(struct st_quicly_conn_t *conn, size_t path_index, const char *remote);
-    probe delete_path(struct st_quicly_conn_t *conn, size_t path_index);
+    probe new_path(struct st_quicly_conn_t *conn, int64_t at, size_t path_index, const char *remote);
+    probe delete_path(struct st_quicly_conn_t *conn, int64_t at, size_t path_index);
     probe promote_path(struct st_quicly_conn_t *conn, int64_t at, size_t path_index);
 
     probe crypto_handshake(struct st_quicly_conn_t *conn, int64_t at, int ret);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -45,11 +45,14 @@ provider quicly {
     probe send(struct st_quicly_conn_t *conn, int64_t at, int state, const char *dcid);
     probe receive(struct st_quicly_conn_t *conn, int64_t at, const char *dcid, const void *bytes, size_t bytes_len);
     probe version_switch(struct st_quicly_conn_t *conn, int64_t at, uint32_t new_version);
-    probe migrate_active_path(struct st_quicly_conn_t *conn, int64_t at);
     probe idle_timeout(struct st_quicly_conn_t *conn, int64_t at);
     probe handshake_timeout(struct st_quicly_conn_t *conn, int64_t at, int64_t elapsed, uint32_t rtt_smoothed);
     probe initial_handshake_packet_exceed(struct st_quicly_conn_t *conn, int64_t at, uint64_t num_packets);
     probe stateless_reset_receive(struct st_quicly_conn_t *conn, int64_t at);
+
+    probe new_path(struct st_quicly_conn_t *conn, size_t path_index, const char *remote);
+    probe delete_path(struct st_quicly_conn_t *conn, size_t path_index);
+    probe promote_path(struct st_quicly_conn_t *conn, int64_t at, size_t path_index);
 
     probe crypto_handshake(struct st_quicly_conn_t *conn, int64_t at, int ret);
     probe crypto_update_secret(struct st_quicly_conn_t *conn, int64_t at, int is_enc, uint8_t epoch, const char *label, const char *secret);

--- a/src/cli.c
+++ b/src/cli.c
@@ -506,7 +506,7 @@ static quicly_generate_resumption_token_t generate_resumption_token = {&on_gener
 static ssize_t receive_datagram(int fd, void *buf, quicly_address_t *dest, quicly_address_t *src, uint8_t *ecn)
 {
     struct iovec vec = {.iov_base = buf, .iov_len = ctx.transport_params.max_udp_payload_size};
-    char cmsgbuf[CMSG_SPACE(sizeof(struct in6_pktinfo) + sizeof(int) /* == max(V4_TOS, V6_TCLASS) */)] = {};
+    char cmsgbuf[CMSG_SPACE(sizeof(struct in6_pktinfo) /* == max(V4_TOS, V6_TCLASS) */) + CMSG_SPACE(1 /* TOS */)] = {};
     struct msghdr mess = {
         .msg_name = &src->sa,
         .msg_namelen = sizeof(*src),

--- a/src/cli.c
+++ b/src/cli.c
@@ -372,6 +372,7 @@ static void client_on_receive(quicly_stream_t *stream, size_t off, const void *s
         if (reqs[num_resp_received].path == NULL) {
             if (request_interval != 0) {
                 enqueue_requests_at = ctx.now->cb(ctx.now) + request_interval;
+                num_resp_received = 0;
             } else {
                 dump_stats(stderr, stream->conn);
                 quicly_close(stream->conn, 0, "");

--- a/src/cli.c
+++ b/src/cli.c
@@ -147,10 +147,11 @@ static void dump_stats(FILE *fp, quicly_conn_t *conn)
     fprintf(fp,
             "packets-received: %" PRIu64 ", packets-decryption-failed: %" PRIu64 ", packets-sent: %" PRIu64
             ", packets-lost: %" PRIu64 ", ack-received: %" PRIu64 ", late-acked: %" PRIu64 ", bytes-received: %" PRIu64
-            ", bytes-sent: %" PRIu64 ", srtt: %" PRIu32 "\n",
+            ", bytes-sent: %" PRIu64 ", paths-created %" PRIu64 ", paths-validated %" PRIu64 ", paths-promoted: %" PRIu64
+            ", srtt: %" PRIu32 "\n",
             stats.num_packets.received, stats.num_packets.decryption_failed, stats.num_packets.sent, stats.num_packets.lost,
             stats.num_packets.ack_received, stats.num_packets.late_acked, stats.num_bytes.received, stats.num_bytes.sent,
-            stats.rtt.smoothed);
+            stats.num_paths.created, stats.num_paths.validated, stats.num_paths.promoted, stats.rtt.smoothed);
 }
 
 static int validate_path(const char *path)

--- a/src/cli.c
+++ b/src/cli.c
@@ -765,7 +765,6 @@ static int run_client(int fd, struct sockaddr *sa, const char *host)
     int ret;
     quicly_conn_t *conn = NULL;
 
-    signal(SIGUSR1, on_client_signal);
     signal(SIGTERM, on_client_signal);
 
     memset(&local, 0, sizeof(local));
@@ -784,14 +783,6 @@ static int run_client(int fd, struct sockaddr *sa, const char *host)
         fd_set readfds;
         struct timeval *tv, tvbuf;
         do {
-            if (client_gotsig == SIGUSR1) {
-                client_gotsig = 0;
-                int newfd = new_socket(local.sa.sa_family);
-                if (newfd != -1) {
-                    close(fd);
-                    fd = newfd;
-                }
-            }
             int64_t timeout_at = conn != NULL ? quicly_get_first_timeout(conn) : INT64_MAX;
             if (enqueue_requests_at < timeout_at)
                 timeout_at = enqueue_requests_at;

--- a/src/cli.c
+++ b/src/cli.c
@@ -51,7 +51,7 @@
 #define MAX_BURST_PACKETS 10
 
 FILE *quicly_trace_fp = NULL;
-static unsigned verbosity = 0, udpbufsize = 0;
+static unsigned verbosity = 0;
 static int suppress_output = 0, send_datagram_frame = 0;
 static int64_t enqueue_requests_at = 0, request_interval = 0;
 
@@ -122,84 +122,6 @@ struct st_stream_data_t {
     quicly_streambuf_t streambuf;
     FILE *outfp;
 };
-
-static int new_socket(int af)
-{
-    int fd;
-
-    if ((fd = socket(af, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
-        perror("socket(2) failed");
-        return -1;
-    }
-    fcntl(fd, F_SETFL, O_NONBLOCK);
-    {
-        int on = 1;
-        if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) != 0) {
-            perror("setsockopt(SO_REUSEADDR) failed");
-            return -1;
-        }
-    }
-    if (udpbufsize != 0) {
-        unsigned arg = udpbufsize;
-        if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &arg, sizeof(arg)) != 0) {
-            perror("setsockopt(SO_RCVBUF) failed");
-            return -1;
-        }
-        arg = udpbufsize;
-        if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &arg, sizeof(arg)) != 0) {
-            perror("setsockopt(SO_RCVBUF) failed");
-            return -1;
-        }
-    }
-#if defined(IP_DONTFRAG)
-    {
-        int on = 1;
-        if (setsockopt(fd, IPPROTO_IP, IP_DONTFRAG, &on, sizeof(on)) != 0)
-            perror("Warning: setsockopt(IP_DONTFRAG) failed");
-    }
-#elif defined(IP_PMTUDISC_DO)
-    {
-        int opt = IP_PMTUDISC_DO;
-        if (setsockopt(fd, IPPROTO_IP, IP_MTU_DISCOVER, &opt, sizeof(opt)) != 0)
-            perror("Warning: setsockopt(IP_MTU_DISCOVER) failed");
-    }
-#endif
-    switch (af) {
-    case AF_INET: {
-#ifdef IP_PKTINFO
-        int on = 1;
-        if (setsockopt(fd, IPPROTO_IP, IP_PKTINFO, &on, sizeof(on)) != 0) {
-            perror("setsockopt(IP_PKTINFO) failed");
-            return -1;
-        }
-#elif defined(IP_RECVDSTADDR)
-        int on = 1;
-        if (setsockopt(fd, IPPROTO_IP, IP_RECVDSTADDR, &on, sizeof(on)) != 0) {
-            perror("setsockopt(IP_RECVDSTADDR) failed");
-            return -1;
-        }
-#endif
-    } break;
-    case AF_INET6: {
-        int on = 1;
-        if (setsockopt(fd, IPPROTO_IP, IPV6_RECVPKTINFO, &on, sizeof(on)) != 0) {
-            perror("setsockopt(IPV6_RECVPKTINNFO) failed");
-            return -1;
-        }
-    } break;
-    default:
-        break;
-    }
-#ifdef IP_RECVTOS
-    {
-        int on = 1;
-        if (setsockopt(fd, IPPROTO_IP, IP_RECVTOS, &on, sizeof(on)) != 0)
-            perror("Warning: setsockopt(IP_RECVTOS) failed");
-    }
-#endif
-
-    return fd;
-}
 
 static void on_stop_sending(quicly_stream_t *stream, int err);
 static void on_receive_reset(quicly_stream_t *stream, int err);
@@ -1340,6 +1262,7 @@ int main(int argc, char **argv)
     const char *cert_file = NULL, *raw_pubkey_file = NULL, *host, *port, *cid_key = NULL;
     struct sockaddr_storage sa;
     socklen_t salen;
+    unsigned udpbufsize = 0;
     int ch, opt_index, fd;
 
     ERR_load_crypto_strings();
@@ -1742,8 +1665,76 @@ int main(int argc, char **argv)
     if (resolve_address((void *)&sa, &salen, host, port, AF_INET, SOCK_DGRAM, IPPROTO_UDP) != 0)
         exit(1);
 
-    if ((fd = new_socket(sa.ss_family)) == -1)
+    if ((fd = socket(sa.ss_family, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
+        perror("socket(2) failed");
         return 1;
+    }
+    fcntl(fd, F_SETFL, O_NONBLOCK);
+    {
+        int on = 1;
+        if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) != 0) {
+            perror("setsockopt(SO_REUSEADDR) failed");
+            return 1;
+        }
+    }
+    if (udpbufsize != 0) {
+        unsigned arg = udpbufsize;
+        if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &arg, sizeof(arg)) != 0) {
+            perror("setsockopt(SO_RCVBUF) failed");
+            return 1;
+        }
+        arg = udpbufsize;
+        if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &arg, sizeof(arg)) != 0) {
+            perror("setsockopt(SO_RCVBUF) failed");
+            return 1;
+        }
+    }
+#if defined(IP_DONTFRAG)
+    {
+        int on = 1;
+        if (setsockopt(fd, IPPROTO_IP, IP_DONTFRAG, &on, sizeof(on)) != 0)
+            perror("Warning: setsockopt(IP_DONTFRAG) failed");
+    }
+#elif defined(IP_PMTUDISC_DO)
+    {
+        int opt = IP_PMTUDISC_DO;
+        if (setsockopt(fd, IPPROTO_IP, IP_MTU_DISCOVER, &opt, sizeof(opt)) != 0)
+            perror("Warning: setsockopt(IP_MTU_DISCOVER) failed");
+    }
+#endif
+#ifdef IP_RECVTOS
+    {
+        int on = 1;
+        if (setsockopt(fd, IPPROTO_IP, IP_RECVTOS, &on, sizeof(on)) != 0)
+            perror("Warning: setsockopt(IP_RECVTOS) failed");
+    }
+#endif
+    switch (sa.ss_family) {
+    case AF_INET: {
+#ifdef IP_PKTINFO
+        int on = 1;
+        if (setsockopt(fd, IPPROTO_IP, IP_PKTINFO, &on, sizeof(on)) != 0) {
+            perror("setsockopt(IP_PKTINFO) failed");
+            return 1;
+        }
+#elif defined(IP_RECVDSTADDR)
+        int on = 1;
+        if (setsockopt(fd, IPPROTO_IP, IP_RECVDSTADDR, &on, sizeof(on)) != 0) {
+            perror("setsockopt(IP_RECVDSTADDR) failed");
+            return 1;
+        }
+#endif
+    } break;
+    case AF_INET6: {
+        int on = 1;
+        if (setsockopt(fd, IPPROTO_IP, IPV6_RECVPKTINFO, &on, sizeof(on)) != 0) {
+            perror("setsockopt(IPV6_RECVPKTINNFO) failed");
+            return 1;
+        }
+    } break;
+    default:
+        break;
+    }
 
     return ctx.tls->certificates.count != 0 ? run_server(fd, (void *)&sa, salen) : run_client(fd, (void *)&sa, host);
 }

--- a/src/cli.c
+++ b/src/cli.c
@@ -750,7 +750,6 @@ static int run_client(int fd, struct sockaddr *sa, const char *host)
                 int newfd = new_socket(local.sa.sa_family);
                 if (newfd != -1) {
                     close(fd);
-                    fcntl(newfd, F_SETFL, O_NONBLOCK);
                     fd = newfd;
                 }
             }

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -382,6 +382,7 @@ subtest "path-migration" => sub {
         # kill the peers
         kill 'TERM', $pid;
         while (waitpid($pid, 0) != $pid) {}
+        sleep 0.5; # wait for server-side to close and emit stats
         my $server_output = $server_guard->finalize;
         # read the log
         my $log = slurp_file("$tempdir/events");

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -362,7 +362,7 @@ subtest "path-migration" => sub {
         die "fork failed:$!"
         unless defined $pid;
         if ($pid == 0) {
-            exec $cli, @client_opts, qw(-O -i 1000 127.0.0.1), $port;
+            exec $cli, @client_opts, qw(-O -i 1000 -p /10000 127.0.0.1), $port;
             die "exec $cli failed:$!";
         }
         # send two USR1 signals, each of them causing path migration between requests
@@ -372,7 +372,7 @@ subtest "path-migration" => sub {
         kill 'USR1', $pid;
         sleep 2;
         # kill the peers
-        kill 9, $pid;
+        kill 'TERM', $pid;
         while (waitpid($pid, 0) != $pid) {}
         undef $guard;
         # read the log

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -503,6 +503,8 @@ sub spawn_server {
 }
 
 package SpawnedProcess {
+    use POSIX ":sys_wait_h";
+
     sub new {
         my ($klass, $cmd, $listen_port) = @_;
 
@@ -526,7 +528,7 @@ package SpawnedProcess {
             if (`netstat -na` =~ /^udp.*\s(127\.0\.0\.1|0\.0\.0\.0|\*)[\.:]$listen_port\s/m) {
                 last;
             }
-            if (waitpid($self->{pid}, POSIX::WNOHANG) == $self->{pid}) {
+            if (waitpid($self->{pid}, WNOHANG) == $self->{pid}) {
                 die "failed to launch @{[$cmd->[0]]}:$?";
             }
             sleep 0.1;

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -348,29 +348,38 @@ subtest "raw-certificates-ec" => sub {
 };
 
 subtest "path-migration" => sub {
-    my $guard = spawn_server("-e", "$tempdir/events");
-    # spawn client that sends one request every second, recording events to file
-    my $pid = fork;
-    die "fork failed:$!"
+    my $doit = sub {
+        my @client_opts = @_;
+        my $guard = spawn_server("-e", "$tempdir/events");
+        # spawn client that sends one request every second, recording events to file
+        my $pid = fork;
+        die "fork failed:$!"
         unless defined $pid;
-    if ($pid == 0) {
-        exec $cli, qw(-O -i 1000 127.0.0.1), $port;
-        die "exec $cli failed:$!";
-    }
-    # send two USR1 signals, each of them causing path migration between requests
-    sleep .5;
-    kill 'USR1', $pid;
-    sleep 2;
-    kill 'USR1', $pid;
-    sleep 2;
-    # kill the peers
-    kill 9, $pid;
-    while (waitpid($pid, 0) != $pid) {}
-    undef $guard;
-    # read the log
-    my $log = slurp_file("$tempdir/events");
-    # check that the path has migrated twice
-    like $log, qr{"type":"promote_path".*\n.*"type":"promote_path"}s;
+        if ($pid == 0) {
+            exec $cli, @client_opts, qw(-O -i 1000 127.0.0.1), $port;
+            die "exec $cli failed:$!";
+        }
+        # send two USR1 signals, each of them causing path migration between requests
+        sleep .5;
+        kill 'USR1', $pid;
+        sleep 2;
+        kill 'USR1', $pid;
+        sleep 2;
+        # kill the peers
+        kill 9, $pid;
+        while (waitpid($pid, 0) != $pid) {}
+        undef $guard;
+        # read the log
+        my $log = slurp_file("$tempdir/events");
+        # check that the path has migrated twice
+        like $log, qr{"type":"promote_path".*\n.*"type":"promote_path"}s;
+    };
+    subtest "without-cid" => sub {
+        $doit->();
+    };
+    subtest "with-cid" => sub {
+        $doit->(qw(-B 01234567));
+    };
 };
 
 done_testing;

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -519,7 +519,7 @@ package SpawnedProcess {
     }
 
     sub DESTROY {
-        print shift->finalize();
+        goto \&finalize;
     }
 
     sub finalize {
@@ -539,6 +539,8 @@ package SpawnedProcess {
             readline $self->{logfh};
         };
         close $self->{logfh};
+
+        print STDERR $log;
 
         return $log;
     }

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -347,6 +347,31 @@ subtest "raw-certificates-ec" => sub {
     is $resp, "hello world\n";
 };
 
+subtest "path-migration" => sub {
+    my $guard = spawn_server("-e", "$tempdir/events");
+    # spawn client that sends one request every second, recording events to file
+    my $pid = fork;
+    die "fork failed:$!"
+        unless defined $pid;
+    if ($pid == 0) {
+        exec $cli, qw(-O -i 1000 127.0.0.1), $port;
+        die "exec $cli failed:$!";
+    }
+    # send two USR1 signals, each of them causing path migration between requests
+    sleep .5;
+    kill 'USR1', $pid;
+    sleep 2;
+    kill 'USR1', $pid;
+    sleep 2;
+    # kill the peers
+    kill 9, $pid;
+    while (waitpid($pid, 0) != $pid) {}
+    undef $guard;
+    # read the log
+    my $log = slurp_file("$tempdir/events");
+    # check that the path has migrated twice
+    like $log, qr{"type":"promote_path".*\n.*"type":"promote_path"}s;
+};
 
 done_testing;
 

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -359,7 +359,7 @@ subtest "path-migration" => sub {
         # spawn client that sends one request every second, recording events to file
         my $pid = fork;
         die "fork failed:$!"
-        unless defined $pid;
+            unless defined $pid;
         if ($pid == 0) {
             exec $cli, @client_opts, qw(-O -i 1000 -p /10000 127.0.0.1), $port;
             die "exec $cli failed:$!";

--- a/t/loss.c
+++ b/t/loss.c
@@ -60,11 +60,11 @@ static void test_time_detection(void)
 
     /* commit 3 packets (pn=0..2); check that loss timer is not active */
     ok(quicly_sentmap_prepare(&loss.sentmap, 0, now, QUICLY_EPOCH_INITIAL) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_sentmap_prepare(&loss.sentmap, 1, now, QUICLY_EPOCH_INITIAL) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_sentmap_prepare(&loss.sentmap, 2, now, QUICLY_EPOCH_INITIAL) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_loss_detect_loss(&loss, now, quicly_spec_context.transport_params.max_ack_delay, 0, on_loss_detected) == 0);
     ok(loss.loss_time == INT64_MAX);
 
@@ -104,13 +104,13 @@ static void test_pn_detection(void)
 
     /* commit 4 packets (pn=0..3); check that loss timer is not active */
     ok(quicly_sentmap_prepare(&loss.sentmap, 0, now, QUICLY_EPOCH_INITIAL) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_sentmap_prepare(&loss.sentmap, 1, now, QUICLY_EPOCH_INITIAL) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_sentmap_prepare(&loss.sentmap, 2, now, QUICLY_EPOCH_INITIAL) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_sentmap_prepare(&loss.sentmap, 3, now, QUICLY_EPOCH_INITIAL) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_loss_detect_loss(&loss, now, quicly_spec_context.transport_params.max_ack_delay, 0, on_loss_detected) == 0);
     ok(loss.loss_time == INT64_MAX);
 
@@ -145,9 +145,9 @@ static void test_slow_cert_verify(void)
 
     /* sent Handshake+1RTT packet */
     ok(quicly_sentmap_prepare(&loss.sentmap, 1, now, QUICLY_EPOCH_HANDSHAKE) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_sentmap_prepare(&loss.sentmap, 2, now, QUICLY_EPOCH_1RTT) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     last_retransmittable_sent_at = now;
     quicly_loss_update_alarm(&loss, now, last_retransmittable_sent_at, 1, 0, 1, 0, 1);
 
@@ -169,9 +169,9 @@ static void test_slow_cert_verify(void)
 
     /* therefore send probes */
     ok(quicly_sentmap_prepare(&loss.sentmap, 3, now, QUICLY_EPOCH_HANDSHAKE) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_sentmap_prepare(&loss.sentmap, 4, now, QUICLY_EPOCH_1RTT) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
 
     now += 10;
 

--- a/t/remote_cid.c
+++ b/t/remote_cid.c
@@ -57,13 +57,33 @@ void test_received_cid(void)
     uint64_t unregistered_seqs[QUICLY_LOCAL_ACTIVE_CONNECTION_ID_LIMIT];
     size_t num_unregistered;
 
+#define TEST_SET(...)                                                                                                              \
+    do {                                                                                                                           \
+        static const struct {                                                                                                      \
+            uint64_t seq;                                                                                                          \
+            quicly_remote_cid_state_t state;                                                                                       \
+        } expected[] = {__VA_ARGS__};                                                                                              \
+        PTLS_BUILD_ASSERT(PTLS_ELEMENTSOF(expected) == QUICLY_LOCAL_ACTIVE_CONNECTION_ID_LIMIT);                                   \
+        for (size_t i = 0; i < PTLS_ELEMENTSOF(expected); ++i) {                                                                   \
+            ok(set.cids[i].state == expected[i].state);                                                                            \
+            ok(set.cids[i].sequence == expected[i].seq);                                                                           \
+            if (expected[i].state != QUICLY_REMOTE_CID_UNAVAILABLE) {                                                              \
+                ok(set.cids[i].cid.len == CID_LEN);                                                                                \
+                ok(expected[i].seq == 0 /* cid is random for seq 0 */ ||                                                           \
+                   memcmp(set.cids[i].cid.cid, cids[expected[i].seq], CID_LEN) == 0);                                              \
+                ok(expected[i].seq == 0 /* so is srt */ ||                                                                         \
+                   memcmp(set.cids[i].stateless_reset_token, srts[expected[i].seq], QUICLY_STATELESS_RESET_TOKEN_LEN) == 0);       \
+            }                                                                                                                      \
+        }                                                                                                                          \
+    } while (0)
+
     quicly_remote_cid_init_set(&set, NULL, quic_ctx.tls->random_bytes);
     /* fill CIDs */
     for (int i = 1; i < 4; i++) {
         ok(quicly_remote_cid_register(&set, i, cids[i], CID_LEN, srts[i], 0, unregistered_seqs, &num_unregistered) == 0);
         ok(num_unregistered == 0);
     }
-    /* active CIDs = {*0, 1, 2, 3} (*0 is the current one) */
+    /* CIDs = {0, 1, 2, 3} */
 
     /* dup */
     ok(quicly_remote_cid_register(&set, 1, cids[1], CID_LEN, srts[1], 0, unregistered_seqs, &num_unregistered) == 0);
@@ -74,23 +94,18 @@ void test_received_cid(void)
     /* already full */
     ok(quicly_remote_cid_register(&set, 4, cids[4], CID_LEN, srts[4], 0, unregistered_seqs, &num_unregistered) ==
        QUICLY_TRANSPORT_ERROR_CONNECTION_ID_LIMIT);
-    ok(set.cids[0].is_active && "we have CID to send error");
+    TEST_SET({0, QUICLY_REMOTE_CID_IN_USE}, /* we have CID to send error */
+             {1, QUICLY_REMOTE_CID_AVAILABLE}, {2, QUICLY_REMOTE_CID_AVAILABLE}, {3, QUICLY_REMOTE_CID_AVAILABLE});
 
-    /* try to unregister something doesn't exist */
-    ok(quicly_remote_cid_unregister(&set, 255) != 0);
     /* retire seq=0 */
-    ok(quicly_remote_cid_unregister(&set, 0) == 0);
-    /* active CIDs = {*1, 2, 3} */
-    ok(set.cids[0].is_active);
-    ok(set.cids[0].sequence == 1);
-    ok(memcmp(set.cids[0].cid.cid, cids[1], CID_LEN) == 0);
-    ok(memcmp(set.cids[0].stateless_reset_token, srts[1], QUICLY_STATELESS_RESET_TOKEN_LEN) == 0);
-    /* try to unregister sequence which is already unregistered */
-    ok(quicly_remote_cid_unregister(&set, 0) != 0);
+    quicly_remote_cid_unregister(&set, 0);
+    /* CIDs = {(4), 1, 2, 3} */
+    TEST_SET({4, QUICLY_REMOTE_CID_UNAVAILABLE}, {1, QUICLY_REMOTE_CID_AVAILABLE}, {2, QUICLY_REMOTE_CID_AVAILABLE},
+             {3, QUICLY_REMOTE_CID_AVAILABLE});
     /* sequence number out of current acceptable window */
     ok(quicly_remote_cid_register(&set, 255, cids[4], CID_LEN, srts[4], 0, unregistered_seqs, &num_unregistered) ==
        QUICLY_TRANSPORT_ERROR_CONNECTION_ID_LIMIT);
-    ok(set.cids[0].is_active && "we have CID to send error");
+    ok(set.cids[1].state == QUICLY_REMOTE_CID_AVAILABLE && "we have CID to send error");
 
     /* ignore already retired CID */
     ok(quicly_remote_cid_register(&set, 0, cids[0], CID_LEN, srts[0], 0, unregistered_seqs, &num_unregistered) == 0);
@@ -99,57 +114,49 @@ void test_received_cid(void)
     /* register 5th CID */
     ok(quicly_remote_cid_register(&set, 4, cids[4], CID_LEN, srts[4], 0, unregistered_seqs, &num_unregistered) == 0);
     ok(num_unregistered == 0);
-    /* active CIDs = {*1, 2, 3, 4} */
+    /* active CIDs = {4, 1, 2, 3} */
+    TEST_SET({4, QUICLY_REMOTE_CID_AVAILABLE}, {1, QUICLY_REMOTE_CID_AVAILABLE}, {2, QUICLY_REMOTE_CID_AVAILABLE},
+             {3, QUICLY_REMOTE_CID_AVAILABLE});
 
     /* unregister seq=2 */
-    ok(quicly_remote_cid_unregister(&set, 2) == 0);
-    /* active CIDs = {*1, 3, 4} */
-    ok(set.cids[0].is_active);
-    ok(set.cids[0].sequence == 1);
+    quicly_remote_cid_unregister(&set, 2);
+    /* active CIDs = {4, 1, (5), 3} */
+    TEST_SET({4, QUICLY_REMOTE_CID_AVAILABLE}, {1, QUICLY_REMOTE_CID_AVAILABLE}, {5, QUICLY_REMOTE_CID_UNAVAILABLE},
+             {3, QUICLY_REMOTE_CID_AVAILABLE});
 
     /* register 5, unregister prior to 5 -- seq=1,3,4 should be unregistered at this moment */
     ok(quicly_remote_cid_register(&set, 5, cids[5], CID_LEN, srts[5], 5, unregistered_seqs, &num_unregistered) == 0);
-    /* active CIDs = {} */
     ok(num_unregistered == 3);
-    {
-        /* order in unregistered_seqs is not defined, so use a set to determine equivalence */
-        char expected[5] = {0, 1, 0, 1, 1}; /* expect seq=1,3,4 */
-        char seqset[5] = {0};
-        for (size_t i = 0; i < num_unregistered; i++) {
-            if (unregistered_seqs[i] < sizeof(seqset))
-                seqset[unregistered_seqs[i]] = 1;
-        }
-        ok(memcmp(seqset, expected, sizeof(seqset)) == 0);
-    }
-    /* active CIDs = {*5} */
-    ok(set.cids[0].is_active);
-    ok(set.cids[0].sequence == 5);
-    ok(memcmp(set.cids[0].cid.cid, cids[5], CID_LEN) == 0);
-    ok(memcmp(set.cids[0].stateless_reset_token, srts[5], QUICLY_STATELESS_RESET_TOKEN_LEN) == 0);
+    /* check unregistered_seqs */
+    ok(unregistered_seqs[0] == 4);
+    ok(unregistered_seqs[1] == 1);
+    ok(unregistered_seqs[2] == 3);
+    /* active CIDs = {(6), (7), 5, (8)} */
+    TEST_SET({6, QUICLY_REMOTE_CID_UNAVAILABLE}, {7, QUICLY_REMOTE_CID_UNAVAILABLE}, {5, QUICLY_REMOTE_CID_AVAILABLE},
+             {8, QUICLY_REMOTE_CID_UNAVAILABLE});
 
     /* install CID with out-of-order sequence */
     ok(quicly_remote_cid_register(&set, 8, cids[8], CID_LEN, srts[8], 5, unregistered_seqs, &num_unregistered) == 0);
     ok(num_unregistered == 0);
-    /* active CIDs = {*5, 8} */
+    /* active CIDs = {(6), (7), 5, 8} */
+    TEST_SET({6, QUICLY_REMOTE_CID_UNAVAILABLE}, {7, QUICLY_REMOTE_CID_UNAVAILABLE}, {5, QUICLY_REMOTE_CID_AVAILABLE},
+             {8, QUICLY_REMOTE_CID_AVAILABLE});
     ok(quicly_remote_cid_register(&set, 7, cids[7], CID_LEN, srts[7], 5, unregistered_seqs, &num_unregistered) == 0);
-    /* active CIDs = {*5, 7, 8} */
-    ok(set.cids[0].is_active);
-    ok(set.cids[0].sequence == 5);
+    /* active CIDs = {(6), 7, 5, 8} */
+    TEST_SET({6, QUICLY_REMOTE_CID_UNAVAILABLE}, {7, QUICLY_REMOTE_CID_AVAILABLE}, {5, QUICLY_REMOTE_CID_AVAILABLE},
+             {8, QUICLY_REMOTE_CID_AVAILABLE});
 
     /* unregister prior to 8 -- seq=5,7 should be unregistered at this moment */
     ok(quicly_remote_cid_register(&set, 8, cids[8], CID_LEN, srts[8], 8, unregistered_seqs, &num_unregistered) == 0);
     /* active CIDs = {*8} */
     ok(num_unregistered == 2);
-    {
-        /* order in unregistered_seqs is not defined, so use a set to determine equivalence */
-        char expected[8] = {0, 0, 0, 0, 0, 1, 0, 1}; /* expect seq=5,7 */
-        char seqset[8] = {0};
-        for (size_t i = 0; i < num_unregistered; i++) {
-            if (unregistered_seqs[i] < sizeof(seqset))
-                seqset[unregistered_seqs[i]] = 1;
-        }
-        ok(memcmp(seqset, expected, sizeof(seqset)) == 0);
-    }
-    ok(set.cids[0].is_active);
-    ok(set.cids[0].sequence == 8);
+    /* check unregistered_seqs */
+    ok(unregistered_seqs[0] == 7);
+    ok(unregistered_seqs[1] == 5);
+    /* active CIDs = {(6), (9), (10), 8} */
+    TEST_SET({6, QUICLY_REMOTE_CID_UNAVAILABLE}, {9, QUICLY_REMOTE_CID_UNAVAILABLE}, {10, QUICLY_REMOTE_CID_UNAVAILABLE},
+             {8, QUICLY_REMOTE_CID_AVAILABLE});
+
+    /* FIXME right above we receive NCID with retire_prior_to=8. Then, we should start accepting CIDs 8,9,10,11. But the code does
+     * not behave that way. */
 }

--- a/t/sentmap.c
+++ b/t/sentmap.c
@@ -59,7 +59,7 @@ static void test_basic(void)
             quicly_sentmap_prepare(&map, at * 5 + i, at, QUICLY_EPOCH_INITIAL);
             quicly_sentmap_allocate(&map, on_acked);
             quicly_sentmap_allocate(&map, on_acked);
-            quicly_sentmap_commit(&map, 1);
+            quicly_sentmap_commit(&map, 1, 0);
         }
     }
 
@@ -115,10 +115,10 @@ static void test_late_ack(void)
     /* commit pn 1, 2 */
     quicly_sentmap_prepare(&map, 1, 0, QUICLY_EPOCH_INITIAL);
     quicly_sentmap_allocate(&map, on_acked);
-    quicly_sentmap_commit(&map, 10);
+    quicly_sentmap_commit(&map, 10, 0);
     quicly_sentmap_prepare(&map, 2, 0, QUICLY_EPOCH_INITIAL);
     quicly_sentmap_allocate(&map, on_acked);
-    quicly_sentmap_commit(&map, 20);
+    quicly_sentmap_commit(&map, 20, 0);
     ok(map.bytes_in_flight == 30);
 
     /* mark pn 1 as lost */
@@ -159,10 +159,10 @@ static void test_pto(void)
     /* commit pn 1, 2 */
     quicly_sentmap_prepare(&map, 1, 0, QUICLY_EPOCH_INITIAL);
     quicly_sentmap_allocate(&map, on_acked);
-    quicly_sentmap_commit(&map, 10);
+    quicly_sentmap_commit(&map, 10, 0);
     quicly_sentmap_prepare(&map, 2, 0, QUICLY_EPOCH_INITIAL);
     quicly_sentmap_allocate(&map, on_acked);
-    quicly_sentmap_commit(&map, 20);
+    quicly_sentmap_commit(&map, 20, 0);
     ok(map.bytes_in_flight == 30);
 
     /* mark pn 1 for PTO */


### PR DESCRIPTION
Design:
* We issue 4 CIDs and therefore support 4 paths.
* `conn->paths[0]` is the path that will always exist, this path is always validation-complete once the handshake is complete and is the only path on which non-probing packets are sent.
* `paths[1]` to `paths[3]` are backup paths.
* When receiving a packet (regardless of it being probing or non-probing) from a new path, we pick the least-recently-used backup path that is not currently validating, and set its path to that of the new path, then start path validation.
* When receiving a packet on one of the backup paths, we consult if we have received non-probing packets on that backup path and if the path is validation-complete. If both conditions are met, this backup path is promoted to `path[0]`.

Notes:
* At the moment, loss detection and congestion controller are not reset when migrating. We will address the issue as part of adding support for multipath.

Config knobs:
* `max_probe_packets` - maximum number of probe packets to send before calling a path unreachable (default: 5)
* `max_path_validation_failures` - once path validation fails for the specified number of paths, packets arriving on new tuples will be dropped (default: 100)

Connection stats:
* `num_paths.created` - number of paths created
* `num_paths.validated` - number of paths that were validated
* `num_paths.validation_failed` - number of paths that failed to validate
* `num_paths.migration_elicited` - number of paths on which migration was elicited (i.e., non-probing packets were received)
* `num_paths.promoted` - number of paths that were promoted (for sending data)
* `num_paths.closed_no_dcid` - number of paths that were closed due to Connection ID being unavailable
* `num_packets.sent_promoted_paths` - number of packets sent on any promoted path
* `num_packets.ack_received_promoted_paths` - number of packets being acked among ones that were sent on any promoted path