### PR TITLE
[examples-echo] immediate means now, not 1 second later

### DIFF
--- a/examples/echo.c
+++ b/examples/echo.c
@@ -215,7 +215,7 @@ static int run_loop(int fd, quicly_conn_t *client)
                 tv.tv_sec = delta / 1000;
                 tv.tv_usec = (delta % 1000) * 1000;
             } else {
-                tv.tv_sec = 1000;
+                tv.tv_sec = 0;
                 tv.tv_usec = 0;
             }
             FD_ZERO(&readfds);


### PR DESCRIPTION
When a connection is requesting it's callback to be called immediately (i.e., value returned by `quicly_get_first_timeout` no greater than "now"), `select` should be called with zero timeout.

However, at the moment, we are introducing one second delay.