### PR TITLE
support ECN

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -331,6 +331,10 @@ struct st_quicly_context_t {
      */
     unsigned expand_client_hello : 1;
     /**
+     * whether to use ECN on the send side; ECN is always on on the receive side
+     */
+    unsigned enable_ecn : 1;
+    /**
      *
      */
     quicly_cid_encryptor_t *cid_encryptor;
@@ -1039,6 +1043,10 @@ size_t quicly_send_retry(quicly_context_t *ctx, ptls_aead_context_t *token_encry
  */
 int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *src, struct iovec *datagrams, size_t *num_datagrams,
                 void *buf, size_t bufsize);
+/**
+ * returns ECN bits to be set for the packets built by the last invocation of `quicly_send`
+ */
+uint8_t quicly_send_get_ecn_bits(quicly_conn_t *conn);
 /**
  *
  */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -458,6 +458,10 @@ struct st_quicly_conn_streamgroup_state_t {
          * Total number of packets received out of order.                                                                          \
          */                                                                                                                        \
         uint64_t received_out_of_order;                                                                                            \
+        /**                                                                                                                        \
+         * connection-wide ACK-ECN counters for ECT(0), ECT(1), CE                                                                 \
+         */                                                                                                                        \
+        uint64_t ack_ecn_counts[3];                                                                                                \
     } num_packets;                                                                                                                 \
     struct {                                                                                                                       \
         /**                                                                                                                        \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -493,6 +493,16 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t stream_data_resent;                                                                                               \
     } num_bytes;                                                                                                                   \
+    struct {                                                                                                                       \
+        /**                                                                                                                        \
+         * number of paths that were ECN-capable                                                                                   \
+         */                                                                                                                        \
+        uint64_t ecn_validated;                                                                                                    \
+        /**                                                                                                                        \
+         * number of paths that were deemed as ECN black holes                                                                     \
+         */                                                                                                                        \
+        uint64_t ecn_failed;                                                                                                       \
+    } num_paths;                                                                                                                   \
     /**                                                                                                                            \
      * Total number of each frame being sent / received.                                                                           \
      */                                                                                                                            \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -459,9 +459,13 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t received_out_of_order;                                                                                            \
         /**                                                                                                                        \
-         * connection-wide ACK-ECN counters for ECT(0), ECT(1), CE                                                                 \
+         * connection-wide counters for ECT(0), ECT(1), CE                                                                         \
          */                                                                                                                        \
-        uint64_t ack_ecn_counts[3];                                                                                                \
+        uint64_t received_ecn_counts[3];                                                                                           \
+        /**                                                                                                                        \
+         * connection-wide ack-received counters for ECT(0), ECT(1), CE                                                            \
+         */                                                                                                                        \
+        uint64_t acked_ecn_counts[3];                                                                                              \
     } num_packets;                                                                                                                 \
     struct {                                                                                                                       \
         /**                                                                                                                        \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -819,6 +819,10 @@ typedef struct st_quicly_decoded_packet_t {
         uint64_t key_phase;
     } decrypted;
     /**
+     * ECN bits
+     */
+    uint8_t ecn : 2;
+    /**
      *
      */
     enum {

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -234,7 +234,7 @@ typedef struct st_quicly_stop_sending_frame_t {
 
 static int quicly_decode_stop_sending_frame(const uint8_t **src, const uint8_t *end, quicly_stop_sending_frame_t *frame);
 
-uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t *ranges, uint64_t ack_delay);
+uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t *ranges, uint64_t *ecn_counts, uint64_t ack_delay);
 
 typedef struct st_quicly_ack_frame_t {
     uint64_t largest_acknowledged;

--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -243,6 +243,7 @@ typedef struct st_quicly_ack_frame_t {
     uint64_t num_gaps;
     uint64_t ack_block_lengths[QUICLY_ACK_MAX_GAPS + 1];
     uint64_t gaps[QUICLY_ACK_MAX_GAPS];
+    uint64_t ecn_counts[3];
 } quicly_ack_frame_t;
 
 int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_frame_t *frame, int is_ack_ecn);

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -105,6 +105,8 @@ static void cubic_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t 
 static void cubic_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn,
                           int64_t now, uint32_t max_udp_payload_size)
 {
+    quicly_cc__update_ecn_episodes(cc, bytes, lost_pn);
+
     /* Nothing to do if loss is in recovery window. */
     if (lost_pn < cc->recovery_end)
         return;

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -95,6 +95,8 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
 static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn,
                          int64_t now, uint32_t max_udp_payload_size)
 {
+    quicly_cc__update_ecn_episodes(cc, bytes, lost_pn);
+
     /* Nothing to do if loss is in recovery window. */
     if (lost_pn < cc->recovery_end)
         return;

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -53,6 +53,8 @@ static void reno_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
 void quicly_cc_reno_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn,
                             int64_t now, uint32_t max_udp_payload_size)
 {
+    quicly_cc__update_ecn_episodes(cc, bytes, lost_pn);
+
     /* Nothing to do if loss is in recovery window. */
     if (lost_pn < cc->recovery_end)
         return;

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -50,6 +50,7 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                               DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
                                               DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
                                               0, /* enlarge_client_hello */
+                                              1, /* enable_ecn */
                                               NULL,
                                               NULL, /* on_stream_open */
                                               &quicly_default_stream_scheduler,
@@ -80,6 +81,7 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                     DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
                                                     DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
                                                     0, /* enlarge_client_hello */
+                                                    1, /* enable_ecn */
                                                     NULL,
                                                     NULL, /* on_stream_open */
                                                     &quicly_default_stream_scheduler,

--- a/lib/frame.c
+++ b/lib/frame.c
@@ -113,11 +113,14 @@ int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_
     }
 
     if (is_ack_ecn) {
-        /* just skip ECT(0), ECT(1), ECT-CE counters for the time being */
-        for (i = 0; i != 3; ++i)
-            if (quicly_decodev(src, end) == UINT64_MAX)
+        for (i = 0; i < PTLS_ELEMENTSOF(frame->ecn_counts); ++i)
+            if ((frame->ecn_counts[i] = quicly_decodev(src, end)) == UINT64_MAX)
                 goto Error;
+    } else {
+        for (i = 0; i < PTLS_ELEMENTSOF(frame->ecn_counts); ++i)
+            frame->ecn_counts[i] = 0;
     }
+
     return 0;
 Error:
     return QUICLY_TRANSPORT_ERROR_FRAME_ENCODING;

--- a/lib/frame.c
+++ b/lib/frame.c
@@ -31,7 +31,7 @@ uint8_t *quicly_encode_path_challenge_frame(uint8_t *dst, int is_response, const
     return dst;
 }
 
-uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t *ranges, uint64_t ack_delay)
+uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t *ranges, uint64_t *ecn_counts, uint64_t ack_delay)
 {
 #define WRITE_BLOCK(start, end)                                                                                                    \
     do {                                                                                                                           \
@@ -42,12 +42,14 @@ uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t
         dst = quicly_encodev(dst, _end - _start - 1);                                                                              \
     } while (0)
 
+    /* emit ACK_ECN frame if any of the three ECN counts are non-zero */
+    uint8_t frame_type = (ecn_counts[0] | ecn_counts[1] | ecn_counts[2]) != 0 ? QUICLY_FRAME_TYPE_ACK_ECN : QUICLY_FRAME_TYPE_ACK;
     size_t range_index = ranges->num_ranges - 1;
 
     assert(ranges->num_ranges != 0);
 
     /* number of bytes being emitted without space check are 1 + 8 + 8 + 1 bytes (as defined in QUICLY_ACK_FRAME_CAPACITY) */
-    *dst++ = QUICLY_FRAME_TYPE_ACK;
+    *dst++ = frame_type;
     dst = quicly_encodev(dst, ranges->ranges[range_index].end - 1); /* largest acknowledged */
     dst = quicly_encodev(dst, ack_delay);                           /* ack delay */
     PTLS_BUILD_ASSERT(QUICLY_MAX_ACK_BLOCKS - 1 <= 63);
@@ -58,6 +60,17 @@ uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t
         if (range_index-- == 0)
             break;
         WRITE_BLOCK(ranges->ranges[range_index].end, ranges->ranges[range_index + 1].start);
+    }
+
+    if (frame_type == QUICLY_FRAME_TYPE_ACK_ECN) {
+        uint8_t buf[24], *p = buf;
+        for (size_t i = 0; i < 3; ++i)
+            p = quicly_encodev(p, ecn_counts[i]);
+        size_t len = p - buf;
+        if (dst_end - dst < len)
+            return NULL;
+        memcpy(dst, buf, len);
+        dst += len;
     }
 
     return dst;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1464,7 +1464,7 @@ static int record_receipt(struct st_quicly_pn_space_t *space, uint64_t pn, uint8
     if (space->ack_queue.ranges[space->ack_queue.num_ranges - 1].end == pn + 1)
         space->largest_pn_received_at = now;
 
-    /* ecn */
+    /* increment ecn counters */
     switch (ecn) {
     case 0: /* NOT-ECT */
         break;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -632,7 +632,15 @@ static size_t get_ecn_index_from_bits(uint8_t bits)
 
 static void update_ecn_state(quicly_conn_t *conn, enum en_quicly_ecn_state new_state)
 {
+    assert(new_state == QUICLY_ECN_ON || new_state == QUICLY_ECN_OFF);
+
     conn->egress.ecn.state = new_state;
+    if (new_state == QUICLY_ECN_ON) {
+        ++conn->super.stats.num_paths.ecn_validated;
+    } else {
+        ++conn->super.stats.num_paths.ecn_failed;
+    }
+
     QUICLY_PROBE(ECN_VALIDATION, conn, conn->stash.now, (int)new_state);
     QUICLY_LOG_CONN(ecn_validation, conn, { PTLS_LOG_ELEMENT_SIGNED(state, (int)new_state); });
 }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -621,12 +621,13 @@ static int64_t get_sentmap_expiration_time(quicly_conn_t *conn)
     return quicly_loss_get_sentmap_expiration_time(&conn->egress.loss, conn->super.remote.transport_params.max_ack_delay);
 }
 
+/**
+ * converts ECN bits to index in the order of ACK-ECN field (i.e., ECT(0) -> 0, ECT(1) -> 1, CE -> 2)
+ */
 static size_t get_ecn_index_from_bits(uint8_t bits)
 {
     assert(1 <= bits && bits <= 3);
-    bits -= 1;
-    bits = bits < 2 ? (bits ^ 1) : bits;
-    return bits;
+    return (18 >> bits) & 3;
 }
 
 static void update_ecn_state(quicly_conn_t *conn, enum en_quicly_ecn_state new_state)

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -621,6 +621,14 @@ static int64_t get_sentmap_expiration_time(quicly_conn_t *conn)
     return quicly_loss_get_sentmap_expiration_time(&conn->egress.loss, conn->super.remote.transport_params.max_ack_delay);
 }
 
+static size_t get_ecn_index_from_bits(uint8_t bits)
+{
+    assert(1 <= bits && bits <= 3);
+    bits -= 1;
+    bits = bits < 2 ? (bits ^ 1) : bits;
+    return bits;
+}
+
 static void update_ecn_state(quicly_conn_t *conn, enum en_quicly_ecn_state new_state)
 {
     conn->egress.ecn.state = new_state;
@@ -1465,22 +1473,8 @@ static int record_receipt(struct st_quicly_pn_space_t *space, uint64_t pn, uint8
         space->largest_pn_received_at = now;
 
     /* increment ecn counters */
-    switch (ecn) {
-    case 0: /* NOT-ECT */
-        break;
-    case 1: /* ECT(1) */
-        space->ecn_counts[1] += 1;
-        break;
-    case 2: /* ECT(0) */
-        space->ecn_counts[0] += 1;
-        break;
-    case 3: /* CE */
-        space->ecn_counts[2] += 1;
-        break;
-    default:
-        assert(!"unexpected ecn flag");
-        break;
-    }
+    if (ecn != 0)
+        space->ecn_counts[get_ecn_index_from_bits(ecn)] += 1;
 
     /* if the received packet is ack-eliciting, update / schedule transmission of ACK */
     if (!is_ack_only) {
@@ -5362,16 +5356,16 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
         /* update counters */
         for (size_t i = 0; i < PTLS_ELEMENTSOF(frame.ecn_counts); ++i) {
             if (frame.ecn_counts[i] > conn->egress.ecn.counts[state->epoch][i]) {
-                conn->super.stats.num_packets.ack_ecn_counts[i] += frame.ecn_counts[i] - conn->egress.ecn.counts[state->epoch][i];
+                conn->super.stats.num_packets.acked_ecn_counts[i] += frame.ecn_counts[i] - conn->egress.ecn.counts[state->epoch][i];
                 conn->egress.ecn.counts[state->epoch][i] = frame.ecn_counts[i];
             }
         }
 
         /* report congestion */
         if (report_congestion) {
-            QUICLY_PROBE(ECN_CONGESTION, conn, conn->stash.now, conn->super.stats.num_packets.ack_ecn_counts[2]);
+            QUICLY_PROBE(ECN_CONGESTION, conn, conn->stash.now, conn->super.stats.num_packets.acked_ecn_counts[2]);
             QUICLY_LOG_CONN(ecn_congestion, conn,
-                            { PTLS_LOG_ELEMENT_UNSIGNED(ce_count, conn->super.stats.num_packets.ack_ecn_counts[2]); });
+                            { PTLS_LOG_ELEMENT_UNSIGNED(ce_count, conn->super.stats.num_packets.acked_ecn_counts[2]); });
             notify_congestion_to_cc(conn, 0, largest_newly_acked.pn);
         }
     }
@@ -6199,6 +6193,8 @@ int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *
 
     /* handle the input; we ignore is_ack_only, we consult if there's any output from TLS in response to CH anyways */
     (*conn)->super.stats.num_packets.received += 1;
+    if (packet->ecn != 0)
+        (*conn)->super.stats.num_packets.received_ecn_counts[get_ecn_index_from_bits(packet->ecn)] += 1;
     (*conn)->super.stats.num_bytes.received += packet->datagram_size;
     if ((ret = handle_payload(*conn, QUICLY_EPOCH_INITIAL, payload.base, payload.len, &offending_frame_type, &is_ack_only)) != 0)
         goto Exit;
@@ -6414,6 +6410,8 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     if (conn->super.state == QUICLY_STATE_FIRSTFLIGHT)
         conn->super.state = QUICLY_STATE_CONNECTED;
     conn->super.stats.num_packets.received += 1;
+    if (packet->ecn != 0)
+        conn->super.stats.num_packets.received_ecn_counts[get_ecn_index_from_bits(packet->ecn)] += 1;
 
     /* state updates, that are triggered by the receipt of a packet */
     switch (epoch) {

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3979,6 +3979,8 @@ static void on_loss_detected(quicly_loss_t *loss, const quicly_sent_packet_t *lo
 {
     quicly_conn_t *conn = (void *)((char *)loss - offsetof(quicly_conn_t, egress.loss));
 
+    assert(lost_packet->cc_bytes_in_flight != 0);
+
     ++conn->super.stats.num_packets.lost;
     if (is_time_threshold)
         ++conn->super.stats.num_packets.lost_time_threshold;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5360,7 +5360,7 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
         /* update counters */
         for (size_t i = 0; i < PTLS_ELEMENTSOF(frame.ecn_counts); ++i) {
             if (frame.ecn_counts[i] > conn->egress.ecn.counts[state->epoch][i]) {
-                conn->super.stats.num_packets.ack_ecn_counts[i] = frame.ecn_counts[i] - conn->egress.ecn.counts[state->epoch][i];
+                conn->super.stats.num_packets.ack_ecn_counts[i] += frame.ecn_counts[i] - conn->egress.ecn.counts[state->epoch][i];
                 conn->egress.ecn.counts[state->epoch][i] = frame.ecn_counts[i];
             }
         }

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -126,6 +126,9 @@ provider quicly {
     probe stream_data_blocked_send(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t maximum);
     probe stream_data_blocked_receive(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t maximum);
 
+    probe ecn_validation(struct st_quicly_conn_t *conn, int64_t at, int ecn_state);
+    probe ecn_congestion(struct st_quicly_conn_t *conn, int64_t at, uint64_t ce_count);
+
     probe datagram_send(struct st_quicly_conn_t *conn, int64_t at, const void *payload, size_t payload_len);
     probe datagram_receive(struct st_quicly_conn_t *conn, int64_t at, const void *payload, size_t payload_len);
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -465,7 +465,7 @@ static ssize_t receive_datagram(int fd, void *buf, quicly_address_t *src, uint8_
 
 static void set_ecn(struct msghdr *mess, int ecn)
 {
-    if (ecn != 0)
+    if (ecn == 0)
         return;
 
     struct cmsghdr *cmsg = (struct cmsghdr *)((char *)mess->msg_control + mess->msg_controllen);

--- a/src/cli.c
+++ b/src/cli.c
@@ -451,7 +451,7 @@ static ssize_t receive_datagram(int fd, void *buf, quicly_address_t *src, uint8_
                 IP_TOS
 #endif
                 ) {
-                assert(cmsg->cmsg_len == 1);
+                assert((char *)CMSG_DATA(cmsg) - (char *)cmsg + 1 == cmsg->cmsg_len);
                 *ecn = *(uint8_t *)CMSG_DATA(cmsg) & IPTOS_ECN_MASK;
             }
 #endif

--- a/src/cli.c
+++ b/src/cli.c
@@ -143,10 +143,12 @@ static void dump_stats(FILE *fp, quicly_conn_t *conn)
     quicly_get_stats(conn, &stats);
     fprintf(fp,
             "packets-received: %" PRIu64 ", packets-decryption-failed: %" PRIu64 ", packets-sent: %" PRIu64
-            ", packets-lost: %" PRIu64 ", ack-received: %" PRIu64 ", late-acked: %" PRIu64 ", bytes-received: %" PRIu64
-            ", bytes-sent: %" PRIu64 ", srtt: %" PRIu32 "\n",
+            ", packets-lost: %" PRIu64 ", ack-received: %" PRIu64 ", ack-ecn-ect0: %" PRIu64 ", ack-ecn-ect1: %" PRIu64
+            ", ack-ecn-ce: %" PRIu64 ", late-acked: %" PRIu64 ", bytes-received: %" PRIu64 ", bytes-sent: %" PRIu64
+            ", srtt: %" PRIu32 "\n",
             stats.num_packets.received, stats.num_packets.decryption_failed, stats.num_packets.sent, stats.num_packets.lost,
-            stats.num_packets.ack_received, stats.num_packets.late_acked, stats.num_bytes.received, stats.num_bytes.sent,
+            stats.num_packets.ack_received, stats.num_packets.ack_ecn_counts[0], stats.num_packets.ack_ecn_counts[1],
+            stats.num_packets.ack_ecn_counts[2], stats.num_packets.late_acked, stats.num_bytes.received, stats.num_bytes.sent,
             stats.rtt.smoothed);
 }
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -145,11 +145,11 @@ static void dump_stats(FILE *fp, quicly_conn_t *conn)
             "packets-received: %" PRIu64 ", packets-decryption-failed: %" PRIu64 ", packets-sent: %" PRIu64
             ", packets-lost: %" PRIu64 ", ack-received: %" PRIu64 ", ack-ecn-ect0: %" PRIu64 ", ack-ecn-ect1: %" PRIu64
             ", ack-ecn-ce: %" PRIu64 ", late-acked: %" PRIu64 ", bytes-received: %" PRIu64 ", bytes-sent: %" PRIu64
-            ", srtt: %" PRIu32 "\n",
+            ", srtt: %" PRIu32 ", num-loss-episodes: %" PRIu32 ", num-ecn-loss-episodes: %" PRIu32 "\n",
             stats.num_packets.received, stats.num_packets.decryption_failed, stats.num_packets.sent, stats.num_packets.lost,
             stats.num_packets.ack_received, stats.num_packets.ack_ecn_counts[0], stats.num_packets.ack_ecn_counts[1],
             stats.num_packets.ack_ecn_counts[2], stats.num_packets.late_acked, stats.num_bytes.received, stats.num_bytes.sent,
-            stats.rtt.smoothed);
+            stats.rtt.smoothed, stats.cc.num_loss_episodes, stats.cc.num_ecn_loss_episodes);
 }
 
 static int validate_path(const char *path)

--- a/src/cli.c
+++ b/src/cli.c
@@ -142,14 +142,17 @@ static void dump_stats(FILE *fp, quicly_conn_t *conn)
 
     quicly_get_stats(conn, &stats);
     fprintf(fp,
-            "packets-received: %" PRIu64 ", packets-decryption-failed: %" PRIu64 ", packets-sent: %" PRIu64
+            "packets-received: %" PRIu64 ", received-ecn-ect0: %" PRIu64 ", received-ecn-ect1: %" PRIu64
+            ", received-ecn-ce: %" PRIu64 ", packets-decryption-failed: %" PRIu64 ", packets-sent: %" PRIu64
             ", packets-lost: %" PRIu64 ", ack-received: %" PRIu64 ", ack-ecn-ect0: %" PRIu64 ", ack-ecn-ect1: %" PRIu64
             ", ack-ecn-ce: %" PRIu64 ", late-acked: %" PRIu64 ", bytes-received: %" PRIu64 ", bytes-sent: %" PRIu64
             ", srtt: %" PRIu32 ", num-loss-episodes: %" PRIu32 ", num-ecn-loss-episodes: %" PRIu32 "\n",
-            stats.num_packets.received, stats.num_packets.decryption_failed, stats.num_packets.sent, stats.num_packets.lost,
-            stats.num_packets.ack_received, stats.num_packets.ack_ecn_counts[0], stats.num_packets.ack_ecn_counts[1],
-            stats.num_packets.ack_ecn_counts[2], stats.num_packets.late_acked, stats.num_bytes.received, stats.num_bytes.sent,
-            stats.rtt.smoothed, stats.cc.num_loss_episodes, stats.cc.num_ecn_loss_episodes);
+            stats.num_packets.received, stats.num_packets.received_ecn_counts[0], stats.num_packets.received_ecn_counts[1],
+            stats.num_packets.received_ecn_counts[2], stats.num_packets.decryption_failed, stats.num_packets.sent,
+            stats.num_packets.lost, stats.num_packets.ack_received, stats.num_packets.acked_ecn_counts[0],
+            stats.num_packets.acked_ecn_counts[1], stats.num_packets.acked_ecn_counts[2], stats.num_packets.late_acked,
+            stats.num_bytes.received, stats.num_bytes.sent, stats.rtt.smoothed, stats.cc.num_loss_episodes,
+            stats.cc.num_ecn_loss_episodes);
 }
 
 static int validate_path(const char *path)

--- a/t/test.c
+++ b/t/test.c
@@ -520,15 +520,15 @@ static void do_test_record_receipt(size_t epoch)
 
     if (epoch == QUICLY_EPOCH_1RTT) {
         /* 2nd packet triggers an ack */
-        ok(record_receipt(space, pn++, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
+        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now + QUICLY_DELAYED_ACK_TIMEOUT);
         now += 1;
-        ok(record_receipt(space, pn++, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
+        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now);
         now += 1;
     } else {
         /* every packet triggers an ack */
-        ok(record_receipt(space, pn++, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
+        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now);
         now += 1;
     }
@@ -538,23 +538,23 @@ static void do_test_record_receipt(size_t epoch)
     send_ack_at = INT64_MAX;
 
     /* ack-only packets do not elicit an ack */
-    ok(record_receipt(space, pn++, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
+    ok(record_receipt(space, pn++, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == INT64_MAX);
     now += 1;
-    ok(record_receipt(space, pn++, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
+    ok(record_receipt(space, pn++, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == INT64_MAX);
     now += 1;
     pn++; /* gap */
-    ok(record_receipt(space, pn++, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
+    ok(record_receipt(space, pn++, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == INT64_MAX);
     now += 1;
-    ok(record_receipt(space, pn++, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
+    ok(record_receipt(space, pn++, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == INT64_MAX);
     now += 1;
 
     /* gap triggers an ack */
     pn += 1; /* gap */
-    ok(record_receipt(space, pn++, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
+    ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == now);
     now += 1;
 
@@ -566,10 +566,10 @@ static void do_test_record_receipt(size_t epoch)
     if (epoch == QUICLY_EPOCH_1RTT) {
         space->ignore_order = 1;
         pn++; /* gap */
-        ok(record_receipt(space, pn++, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
+        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now + QUICLY_DELAYED_ACK_TIMEOUT);
         now += 1;
-        ok(record_receipt(space, pn++, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
+        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now);
         now += 1;
     }

--- a/t/test.c
+++ b/t/test.c
@@ -716,6 +716,13 @@ static void test_set_cc(void)
     ok(strcmp(stats.cc.type->name, "reno") == 0);
 }
 
+void test_ecn_index_from_bits(void)
+{
+    ok(get_ecn_index_from_bits(1) == 1);
+    ok(get_ecn_index_from_bits(2) == 0);
+    ok(get_ecn_index_from_bits(3) == 2);
+}
+
 int main(int argc, char **argv)
 {
     static ptls_iovec_t cert;
@@ -791,6 +798,7 @@ int main(int argc, char **argv)
     subtest("lossy", test_lossy);
     subtest("test-nondecryptable-initial", test_nondecryptable_initial);
     subtest("set_cc", test_set_cc);
+    subtest("ecn-index-from-bits", test_ecn_index_from_bits);
 
     return done_testing();
 }


### PR DESCRIPTION
This PR incorporates the following changes.

__Generate ACK-ECN frames as a receiver__

When quicly is provided received packets with accompanying ECN bits, it generates ACK frames with ECN counts.

Support for ECN is in fact [a requirement of RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000#name-reporting-ecn-counts), we have just been lazy.

Note that it is up to applications using quicly to provide the ECN bits, as it is those applications that read the packets from the operating system. src/cli.c has been updated to do that.

This feature is always on and cannot be turned off.

__Use ECN as a sender__

A new function called `quicly_send_get_ecn_bits` is being provided for obtaining the ECN bits to be set for outgoing packets. This function is to be called immediately after `quicly_send` to obtain the ECN bits to be associated to the packets being obtained from `quicly_send`.

Note that unless the new `quicly_context_t::enable_ecn` bit is set, `quicly_send_get_ecn_bits` will return zero (indicating non-use of ECT), so the observable behavior will not change.

`quicly_context_t::enable_ecn` is on by default. src/cli.c has a `--disable-ecn` option for turning it off.

When ECN is on, at the beginning of the connection, all the packets emitted be marked as ECT(0). If none of the packets are acked during the first 3 SRTT, the path is considered to be a ECN black hole and we resort to non-ECN mode. This is last resort and will have performance penalties, therefore we do not even reset the CC when the path is deemed as a black hole.

__Report ECN-related stats__

Following counters are added to `quicly_stats_t`, a per-connection stat:
* number of packets being received with ECN-ECT(0), ECT-ECN(1), ECT-CE
* number of packets being acked with ECN-ECT(0), ECT-ECN(1), ECT-CE
* number of paths that were ECN validated or failed
* number of loss episodes that were purly due to ECN (i.e., no packet loss). We already report the number of loss episodes, the hope is that these metrics can be used to observe and compare the smoothness of a CC.