### PR TITLE
fix entering hot loop if app opens a stream before the handshake is complete (amends #551)

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -3097,8 +3097,14 @@ int64_t quicly_get_first_timeout(quicly_conn_t *conn)
     uint64_t amp_window = calc_amplification_limit_allowance(conn);
 
     if (calc_send_window(conn, 0, amp_window, 0) > 0) {
-        if (conn->egress.pending_flows != 0)
-            return 0;
+        if (conn->egress.pending_flows != 0) {
+            /* crypto streams (as indicated by lower 4 bits) can be sent whenever CWND is available; other flows need application
+             * packet number space */
+            if (conn->application != NULL && conn->application->cipher.egress.key.header_protection != NULL)
+                return 0;
+            if ((conn->egress.pending_flows & 0xf) != 0)
+                return 0;
+        }
         if (quicly_linklist_is_linked(&conn->egress.pending_streams.control))
             return 0;
         if (scheduler_can_send(conn))


### PR DESCRIPTION
H2O opens the HTTP/3 control stream when the connection is created. As that happens before the peer grants any stream credit, QUICLY_PENDING_FLOW_OTHERS_BITgets set, and that leads to `quicly_get_first_timeout` return zero whenever there is space in CWND.

But because write keys for the application packet number space is unavailable, `quicly_send` cannot make progress.

Hence the hot loop.

This PR fixes `quicly_get_first_timeout`. The function no longer returns `0` (indicating now) when the write keys for the application packet number space is available.

Amends #551.