### PR TITLE
[ipv6] fix address token validation failures

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -6842,7 +6842,7 @@ int quicly_decrypt_address_token(ptls_aead_context_t *aead, quicly_address_token
                 portaddr = &plaintext->remote.sin.sin_port;
                 break;
             case 16: /* ipv6 */
-                plaintext->remote.sin6.sin6_family = AF_INET6;
+                plaintext->remote.sin6 = (struct sockaddr_in6){.sin6_family = AF_INET6};
                 memcpy(&plaintext->remote.sin6.sin6_addr, src, 16);
                 portaddr = &plaintext->remote.sin6.sin6_port;
                 break;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -6744,6 +6744,7 @@ int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead
                 break;
             case AF_INET6:
                 ptls_buffer_pushv(buf, &plaintext->remote.sin6.sin6_addr, 16);
+                ptls_buffer_push32(buf, plaintext->remote.sin6.sin6_scope_id);
                 port = ntohs(plaintext->remote.sin6.sin6_port);
                 break;
             default:
@@ -6841,9 +6842,11 @@ int quicly_decrypt_address_token(ptls_aead_context_t *aead, quicly_address_token
                 memcpy(&plaintext->remote.sin.sin_addr.s_addr, src, 4);
                 portaddr = &plaintext->remote.sin.sin_port;
                 break;
-            case 16: /* ipv6 */
+            case 20: /* ipv6 */
                 plaintext->remote.sin6 = (struct sockaddr_in6){.sin6_family = AF_INET6};
                 memcpy(&plaintext->remote.sin6.sin6_addr, src, 16);
+                if ((ret = ptls_decode32(&plaintext->remote.sin6.sin6_scope_id, &src, end)) != 0)
+                    goto Exit;
                 portaddr = &plaintext->remote.sin6.sin6_port;
                 break;
             default:

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5696,7 +5696,6 @@ static int compare_socket_address(struct sockaddr *x, struct sockaddr *y)
         if (r != 0)
             return r;
         CMP(ntohs(xin6->sin6_port), ntohs(yin6->sin6_port));
-        CMP(xin6->sin6_flowinfo, yin6->sin6_flowinfo);
         CMP(xin6->sin6_scope_id, yin6->sin6_scope_id);
     } else if (x->sa_family == AF_UNSPEC) {
         return 1;


### PR DESCRIPTION
This lead to failed connection attempts when a Retry is used, or address validation enforced even when valid address tokens were provided by the clients.

Specifically,
* We were not initializing the flowinfo and scope_id fields of the internal structure to which we decode address tokens. This lead to address validation failures, as these fields would contain bogus values and comparing them to what `recvmsg` provides would fail.
* When comparing IPv6 addresses, flowinfo should be skipped. Remove the comparison.
* Address tokens did not include scope_id, even though it should, as they are essential to disambiguate link-local addresses of different interfaces. The token format is changed to include scope_id.