### PR TITLE
jumpstart

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ SET(QUICLY_LIBRARY_FILES
 SET(UNITTEST_SOURCE_FILES
     deps/picotest/picotest.c
     t/frame.c
+    t/jumpstart.c
     t/local_cid.c
     t/loss.c
     t/lossy.c

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -327,6 +327,10 @@ struct st_quicly_context_t {
      */
     uint64_t max_initial_handshake_packets;
     /**
+     * jumpstart delivery rate to be used when there is no previous information
+     */
+    uint32_t default_jumpstart_cwnd_bytes;
+    /**
      * maximum CWND to be used by jumpstart
      */
     uint32_t max_jumpstart_cwnd_bytes;

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -531,7 +531,16 @@ struct st_quicly_conn_streamgroup_state_t {
     /**                                                                                                                            \
      * Total number of events where `initial_handshake_sent` exceeds limit.                                                        \
      */                                                                                                                            \
-    uint64_t num_initial_handshake_exceeded
+    uint64_t num_initial_handshake_exceeded;                                                                                       \
+    /**                                                                                                                            \
+     * jumpstart parameters and the CWND being adopted (see also quicly_cc_t::cwnd_exiting_jumpstart)                              \
+     */                                                                                                                            \
+    struct {                                                                                                                       \
+        uint64_t prev_rate;                                                                                                        \
+        uint32_t prev_rtt;                                                                                                         \
+        uint32_t new_rtt;                                                                                                          \
+        uint32_t cwnd;                                                                                                             \
+    } jumpstart;
 
 typedef struct st_quicly_stats_t {
     /**

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -544,7 +544,24 @@ struct st_quicly_conn_streamgroup_state_t {
         uint32_t prev_rtt;                                                                                                         \
         uint32_t new_rtt;                                                                                                          \
         uint32_t cwnd;                                                                                                             \
-    } jumpstart;
+    } jumpstart;                                                                                                                   \
+    /**                                                                                                                            \
+     * some contents of the last token sent                                                                                        \
+     */                                                                                                                            \
+    struct {                                                                                                                       \
+        /**                                                                                                                        \
+         * when sent, relative to the creation time of the connection                                                              \
+         */                                                                                                                        \
+        int64_t at;                                                                                                                \
+        /**                                                                                                                        \
+         * delivery rate                                                                                                           \
+         */                                                                                                                        \
+        uint64_t rate;                                                                                                             \
+        /**                                                                                                                        \
+         * rtt                                                                                                                     \
+         */                                                                                                                        \
+        uint32_t rtt;                                                                                                              \
+    } token_sent
 
 typedef struct st_quicly_stats_t {
     /**

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -329,7 +329,7 @@ struct st_quicly_context_t {
     /**
      * maximum CWND to be used by jumpstart
      */
-    uint32_t max_jumpstart_cwnd;
+    uint32_t max_jumpstart_cwnd_bytes;
     /**
      * expand client hello so that it does not fit into one datagram
      */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -866,6 +866,7 @@ struct st_quicly_address_token_plaintext_t {
     enum { QUICLY_ADDRESS_TOKEN_TYPE_RETRY, QUICLY_ADDRESS_TOKEN_TYPE_RESUMPTION } type;
     uint64_t issued_at;
     quicly_address_t local, remote;
+    unsigned address_mismatch : 1;
     union {
         struct {
             quicly_cid_t original_dcid;

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -327,6 +327,10 @@ struct st_quicly_context_t {
      */
     uint64_t max_initial_handshake_packets;
     /**
+     * maximum CWND to be used by jumpstart
+     */
+    uint32_t max_jumpstart_cwnd;
+    /**
      * expand client hello so that it does not fit into one datagram
      */
     unsigned expand_client_hello : 1;

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -330,12 +330,12 @@ struct st_quicly_context_t {
      * Jumpstart CWND to be used when there is no previous information. If set to zero, slow start is used. Note jumpstart is
      * possible only when the use_pacing flag is set.
      */
-    uint32_t default_jumpstart_cwnd_bytes;
+    uint32_t default_jumpstart_cwnd_packets;
     /**
      * Maximum jumpstart CWND to be used for connections with previous delivery rate information (i.e., resuming connections). If
      * set to zero, slow start is used.
      */
-    uint32_t max_jumpstart_cwnd_bytes;
+    uint32_t max_jumpstart_cwnd_packets;
     /**
      * expand client hello so that it does not fit into one datagram
      */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -327,11 +327,13 @@ struct st_quicly_context_t {
      */
     uint64_t max_initial_handshake_packets;
     /**
-     * jumpstart delivery rate to be used when there is no previous information
+     * Jumpstart CWND to be used when there is no previous information. If set to zero, slow start is used. Note jumpstart is
+     * possible only when the use_pacing flag is set.
      */
     uint32_t default_jumpstart_cwnd_bytes;
     /**
-     * maximum CWND to be used by jumpstart
+     * Maximum jumpstart CWND to be used for connections with previous delivery rate information (i.e., resuming connections). If
+     * set to zero, slow start is used.
      */
     uint32_t max_jumpstart_cwnd_bytes;
     /**

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -313,8 +313,6 @@ inline void quicly_cc_jumpstart_on_first_loss(quicly_cc_t *cc, uint64_t lost_pn,
         assert(cc->cwnd < cc->ssthresh);
         /* CWND is set to the amount of bytes ACKed during the jump start phase plus the value before jump start */
         cc->cwnd = cc->jumpstart.bytes_acked;
-        if (cc->cwnd < cc->cwnd_initial)
-            cc->cwnd = cc->cwnd_initial;
         if (cc->jumpstart.exit_pn == UINT64_MAX)
             cc->jumpstart.exit_pn = lost_pn;
         if (beta != NULL)

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -282,7 +282,7 @@ inline void quicly_cc_jumpstart_on_acked(quicly_cc_t *cc, int in_recovery, uint3
     if (in_recovery) {
         /* if a loss is observed due to jumpstart, CWND is adjusted so that it would become bytes that passed through to the client
          * during the jumpstart phase of exactly 1 RTT, when the last ACK for the jumpstart phase is received */
-        if (largest_acked < cc->jumpstart.exit_pn)
+        if (cc->jumpstart.enter_pn <= largest_acked && largest_acked < cc->jumpstart.exit_pn)
             cc->cwnd += bytes;
         return;
     }

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -38,7 +38,7 @@ extern "C" {
 #include "quicly/loss.h"
 
 #define QUICLY_MIN_CWND 2
-#define QUICLY_RENO_BETA 0.5
+#define QUICLY_RENO_BETA 0.7
 
 /**
  * Holds pointers to concrete congestion control implementation functions.

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -313,7 +313,8 @@ inline void quicly_cc_jumpstart_on_first_loss(quicly_cc_t *cc, uint64_t lost_pn,
             cc->cwnd = cc->cwnd_initial;
         if (cc->jumpstart.exit_pn == UINT64_MAX)
             cc->jumpstart.exit_pn = lost_pn;
-        *beta = 1; /* jumpstart makes accurate guess of CWND - there is no need to reduce CWND */
+        if (beta != NULL)
+            *beta = 1; /* jumpstart makes accurate guess of CWND - there is no need to reduce CWND */
     }
 }
 

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -241,7 +241,7 @@ static int quicly_cc_in_jumpstart(quicly_cc_t *cc);
 static void quicly_cc_jumpstart_enter(quicly_cc_t *cc, uint32_t jump_cwnd, uint64_t next_pn);
 static void quicly_cc_jumpstart_on_acked(quicly_cc_t *cc, int in_recovery, uint32_t bytes, uint64_t largest_acked,
                                          uint32_t inflight, uint64_t next_pn);
-static void quicly_cc_jumpstart_on_first_loss(quicly_cc_t *cc, uint64_t lost_pn, double *beta);
+static void quicly_cc_jumpstart_on_first_loss(quicly_cc_t *cc, uint64_t lost_pn);
 
 /* inline definitions */
 
@@ -286,17 +286,20 @@ inline void quicly_cc_jumpstart_enter(quicly_cc_t *cc, uint32_t jump_cwnd, uint6
 inline void quicly_cc_jumpstart_on_acked(quicly_cc_t *cc, int in_recovery, uint32_t bytes, uint64_t largest_acked,
                                          uint32_t inflight, uint64_t next_pn)
 {
+    int is_jumpstart_ack = cc->jumpstart.enter_pn <= largest_acked && largest_acked < cc->jumpstart.exit_pn;
+
+    /* remember the amount of bytes acked for the packets sent in jumpstart */
+    if (is_jumpstart_ack)
+        cc->jumpstart.bytes_acked += bytes;
+
     if (in_recovery) {
-        /* if a loss is observed due to jumpstart, CWND is adjusted so that it would become bytes that passed through to the client
-         * during the jumpstart phase of exactly 1 RTT, when the last ACK for the jumpstart phase is received */
-        if (cc->jumpstart.enter_pn <= largest_acked && largest_acked < cc->jumpstart.exit_pn)
-            cc->cwnd += bytes;
+        /* Propotional Rate Reduction: if a loss is observed due to jumpstart, CWND is adjusted so that it would become bytes that
+         * passed through to the client during the jumpstart phase of exactly 1 RTT, when the last ACK for the jumpstart phase is
+         * received */
+        if (is_jumpstart_ack && cc->cwnd < cc->jumpstart.bytes_acked)
+            cc->cwnd = cc->jumpstart.bytes_acked;
         return;
     }
-
-    /* remember the amount of bytes acked contiguously for the packets send in jumpstart */
-    if (cc->jumpstart.enter_pn <= largest_acked && largest_acked < cc->jumpstart.exit_pn)
-        cc->jumpstart.bytes_acked += bytes;
 
     /* when receiving the first ack for jumpstart, stop jumpstart and go back to slow start, adopting current inflight as cwnd */
     if (cc->jumpstart.exit_pn == UINT64_MAX && cc->jumpstart.enter_pn <= largest_acked) {
@@ -307,16 +310,16 @@ inline void quicly_cc_jumpstart_on_acked(quicly_cc_t *cc, int in_recovery, uint3
     }
 }
 
-inline void quicly_cc_jumpstart_on_first_loss(quicly_cc_t *cc, uint64_t lost_pn, double *beta)
+inline void quicly_cc_jumpstart_on_first_loss(quicly_cc_t *cc, uint64_t lost_pn)
 {
     if (cc->jumpstart.enter_pn != UINT64_MAX && lost_pn < cc->jumpstart.exit_pn) {
         assert(cc->cwnd < cc->ssthresh);
         /* CWND is set to the amount of bytes ACKed during the jump start phase plus the value before jump start */
         cc->cwnd = cc->jumpstart.bytes_acked;
+        if (cc->cwnd < cc->cwnd_initial)
+            cc->cwnd = cc->cwnd_initial;
         if (cc->jumpstart.exit_pn == UINT64_MAX)
             cc->jumpstart.exit_pn = lost_pn;
-        if (beta != NULL)
-            *beta = 1; /* jumpstart makes accurate guess of CWND - there is no need to reduce CWND */
     }
 }
 

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -94,13 +94,9 @@ typedef struct st_quicly_cc_t {
                  */
                 uint64_t exit_pn;
                 /**
-                 * original CWND
+                 * amount of bytes acked for packets sent in jumpstart
                  */
-                uint32_t orig_cwnd;
-                /**
-                 * cwnd at start of jumpstart
-                 */
-                uint32_t jump_cwnd;
+                uint32_t bytes_acked;
             } jumpstart;
         } reno;
         /**

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -148,6 +148,10 @@ typedef struct st_quicly_cc_t {
      */
     uint32_t cwnd_exiting_slow_start;
     /**
+     * the time at which we exitted slow start (or INT64_MAX)
+     */
+    int64_t exit_slow_start_at;
+    /**
      * Congestion window at the end of the unvalidated phase of jumpstart.
      */
     uint32_t cwnd_exiting_jumpstart;

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -90,9 +90,17 @@ typedef struct st_quicly_cc_t {
                  */
                 uint64_t enter_pn;
                 /**
+                 * packet number following the last packet in jumpstart
+                 */
+                uint64_t exit_pn;
+                /**
                  * original CWND
                  */
                 uint32_t orig_cwnd;
+                /**
+                 * cwnd at start of jumpstart
+                 */
+                uint32_t jump_cwnd;
             } jumpstart;
         } reno;
         /**

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -81,6 +81,19 @@ typedef struct st_quicly_cc_t {
              * Stash of acknowledged bytes, used during congestion avoidance.
              */
             uint32_t stash;
+            /**
+             *
+             */
+            struct {
+                /**
+                 * first packet number in jumpstart
+                 */
+                uint64_t enter_pn;
+                /**
+                 * original CWND
+                 */
+                uint32_t orig_cwnd;
+            } jumpstart;
         } reno;
         /**
          * State information for Pico.
@@ -180,6 +193,10 @@ struct st_quicly_cc_type_t {
      * Switches the underlying algorithm of `cc` to that of `cc_switch`, returning a boolean if the operation was successful.
      */
     int (*cc_switch)(quicly_cc_t *cc);
+    /**
+     *
+     */
+    void (*cc_jumpstart)(quicly_cc_t *cc, uint32_t cwnd, uint64_t next_pn);
 };
 
 /**

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -37,7 +37,7 @@ extern "C" {
 #include "quicly/loss.h"
 
 #define QUICLY_MIN_CWND 2
-#define QUICLY_RENO_BETA 0.7
+#define QUICLY_RENO_BETA 0.5
 
 /**
  * Holds pointers to concrete congestion control implementation functions.

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -125,7 +125,7 @@ typedef struct st_quicly_cc_t {
     /**
      * jumpstart state
      */
-    struct st_quicly_cc_jumpstart_t {
+    struct {
         /**
          * first packet number in jumpstart
          */
@@ -261,7 +261,9 @@ inline void quicly_cc__update_ecn_episodes(quicly_cc_t *cc, uint32_t lost_bytes,
 
 inline void quicly_cc_jumpstart_reset(quicly_cc_t *cc)
 {
-    cc->jumpstart = (struct st_quicly_cc_jumpstart_t){.enter_pn = UINT64_MAX, .exit_pn = UINT64_MAX};
+    cc->jumpstart.enter_pn = UINT64_MAX;
+    cc->jumpstart.exit_pn = UINT64_MAX;
+    cc->jumpstart.bytes_acked = 0;
 }
 
 inline void quicly_cc_jumpstart_enter(quicly_cc_t *cc, uint32_t jump_cwnd, uint64_t next_pn)

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -147,6 +147,10 @@ typedef struct st_quicly_cc_t {
      */
     uint32_t cwnd_exiting_slow_start;
     /**
+     * Congestion window at the end of the unvalidated phase of jumpstart.
+     */
+    uint32_t cwnd_exiting_jumpstart;
+    /**
      * Minimum congestion window during the connection.
      */
     uint32_t cwnd_minimum;

--- a/include/quicly/sendstate.h
+++ b/include/quicly/sendstate.h
@@ -59,6 +59,7 @@ void quicly_sendstate_init_closed(quicly_sendstate_t *state);
 void quicly_sendstate_dispose(quicly_sendstate_t *state);
 static int quicly_sendstate_transfer_complete(quicly_sendstate_t *state);
 static int quicly_sendstate_is_open(quicly_sendstate_t *state);
+static int quicly_sendstate_is_fully_inflight(quicly_sendstate_t *state);
 int quicly_sendstate_activate(quicly_sendstate_t *state);
 int quicly_sendstate_shutdown(quicly_sendstate_t *state, uint64_t final_size);
 void quicly_sendstate_reset(quicly_sendstate_t *state);
@@ -75,6 +76,11 @@ inline int quicly_sendstate_transfer_complete(quicly_sendstate_t *state)
 inline int quicly_sendstate_is_open(quicly_sendstate_t *state)
 {
     return state->final_size == UINT64_MAX;
+}
+
+inline int quicly_sendstate_is_fully_inflight(quicly_sendstate_t *state)
+{
+    return state->size_inflight == state->final_size;
 }
 
 #ifdef __cplusplus

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -121,7 +121,7 @@ static void cubic_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
 
     /* if detected loss before receiving all acks for jumpstart, restore original CWND */
     if (cc->ssthresh == UINT32_MAX)
-        quicly_cc_jumpstart_on_first_loss(cc, lost_pn, NULL /* do we want to adopt beta == 1 as other CCs do? */);
+        quicly_cc_jumpstart_on_first_loss(cc, lost_pn);
 
     ++cc->num_loss_episodes;
     if (cc->cwnd_exiting_slow_start == 0) {

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -143,7 +143,7 @@ static void cubic_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
     update_cubic_k(cc, max_udp_payload_size);
 
     /* RFC 8312, Section 4.5; Multiplicative Decrease */
-    cc->cwnd *= QUICLY_CUBIC_BETA;
+    cc->cwnd *= cc->ssthresh == UINT32_MAX ? 0.5 : QUICLY_CUBIC_BETA; /* without HyStart++, we overshoot by 2x in slowstart */
     if (cc->cwnd < QUICLY_MIN_CWND * max_udp_payload_size)
         cc->cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
     cc->ssthresh = cc->cwnd;

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -123,8 +123,10 @@ static void cubic_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
         quicly_cc_jumpstart_on_first_loss(cc, lost_pn, NULL /* do we want to adopt beta == 1 as other CCs do? */);
 
     ++cc->num_loss_episodes;
-    if (cc->cwnd_exiting_slow_start == 0)
+    if (cc->cwnd_exiting_slow_start == 0) {
         cc->cwnd_exiting_slow_start = cc->cwnd;
+        cc->exit_slow_start_at = now;
+    }
 
     cc->state.cubic.avoidance_start = now;
     cc->state.cubic.w_max = cc->cwnd;
@@ -175,6 +177,7 @@ static void cubic_reset(quicly_cc_t *cc, uint32_t initcwnd)
     cc->type = &quicly_cc_type_cubic;
     cc->cwnd = cc->cwnd_initial = cc->cwnd_maximum = initcwnd;
     cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
+    cc->exit_slow_start_at = INT64_MAX;
     cc->pacer_multiplier = QUICLY_PACER_CALC_MULTIPLIER(2);
 
     quicly_cc_jumpstart_reset(cc);

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -66,9 +66,13 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
 {
     assert(inflight >= bytes);
 
-    /* Do not increase congestion window while in recovery. */
-    if (largest_acked < cc->recovery_end)
+    /* Do not increase congestion window while in recovery (but jumpstart may do something different). */
+    if (largest_acked < cc->recovery_end) {
+        quicly_cc_jumpstart_on_acked(cc, 1, bytes, largest_acked, inflight, next_pn);
         return;
+    }
+
+    quicly_cc_jumpstart_on_acked(cc, 0, bytes, largest_acked, inflight, next_pn);
 
     cc->state.pico.stash += bytes;
 
@@ -96,6 +100,10 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
 static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn,
                          int64_t now, uint32_t max_udp_payload_size)
 {
+    /* when exiting slow start, use inverse of exponential growth ratio, as loss is detected 1 RTT later, at which point CWND has
+     * overshot as much as the growth ratio */
+    double beta = cc->ssthresh == UINT32_MAX ? 0.5 : QUICLY_RENO_BETA;
+
     quicly_cc__update_ecn_episodes(cc, bytes, lost_pn);
 
     /* Nothing to do if loss is in recovery window. */
@@ -106,6 +114,10 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
     /* switch pacer to congestion avoidance mode the moment loss is observed */
     cc->pacer_multiplier = QUICLY_PACER_CALC_MULTIPLIER(1.2);
 
+    /* if detected loss before receiving all acks for jumpstart, restore original CWND */
+    if (cc->ssthresh == UINT32_MAX)
+        quicly_cc_jumpstart_on_first_loss(cc, lost_pn, &beta);
+
     ++cc->num_loss_episodes;
     if (cc->cwnd_exiting_slow_start == 0)
         cc->cwnd_exiting_slow_start = cc->cwnd;
@@ -114,7 +126,7 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
     cc->state.pico.bytes_per_mtu_increase = calc_bytes_per_mtu_increase(cc->cwnd, loss->rtt.smoothed, max_udp_payload_size);
 
     /* Reduce congestion window. */
-    cc->cwnd *= QUICLY_RENO_BETA;
+    cc->cwnd *= beta;
     if (cc->cwnd < QUICLY_MIN_CWND * max_udp_payload_size)
         cc->cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
     cc->ssthresh = cc->cwnd;
@@ -151,6 +163,8 @@ static void pico_reset(quicly_cc_t *cc, uint32_t initcwnd)
         .pacer_multiplier = QUICLY_PACER_CALC_MULTIPLIER(2),
     };
     pico_init_pico_state(cc, 0);
+
+    quicly_cc_jumpstart_reset(cc);
 }
 
 static int pico_on_switch(quicly_cc_t *cc)
@@ -180,6 +194,7 @@ static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd
     pico_reset(cc, initcwnd);
 }
 
-quicly_cc_type_t quicly_cc_type_pico = {
-    "pico", &quicly_cc_pico_init, pico_on_acked, pico_on_lost, pico_on_persistent_congestion, pico_on_sent, pico_on_switch};
+quicly_cc_type_t quicly_cc_type_pico = {"pico",         &quicly_cc_pico_init,          pico_on_acked,
+                                        pico_on_lost,   pico_on_persistent_congestion, pico_on_sent,
+                                        pico_on_switch, quicly_cc_jumpstart_enter};
 quicly_init_cc_t quicly_cc_pico_init = {pico_init};

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -116,7 +116,7 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
 
     /* if detected loss before receiving all acks for jumpstart, restore original CWND */
     if (cc->ssthresh == UINT32_MAX)
-        quicly_cc_jumpstart_on_first_loss(cc, lost_pn, &beta);
+        quicly_cc_jumpstart_on_first_loss(cc, lost_pn);
 
     ++cc->num_loss_episodes;
     if (cc->cwnd_exiting_slow_start == 0) {

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -103,10 +103,6 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
 static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn,
                          int64_t now, uint32_t max_udp_payload_size)
 {
-    /* when exiting slow start, use inverse of exponential growth ratio, as loss is detected 1 RTT later, at which point CWND has
-     * overshot as much as the growth ratio */
-    double beta = cc->ssthresh == UINT32_MAX ? 0.5 : QUICLY_RENO_BETA;
-
     quicly_cc__update_ecn_episodes(cc, bytes, lost_pn);
 
     /* Nothing to do if loss is in recovery window. */
@@ -128,7 +124,7 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
     cc->state.pico.bytes_per_mtu_increase = calc_bytes_per_mtu_increase(cc->cwnd, loss->rtt.smoothed, max_udp_payload_size);
 
     /* Reduce congestion window. */
-    cc->cwnd *= beta;
+    cc->cwnd *=  cc->ssthresh == UINT32_MAX ? 0.5 : QUICLY_RENO_BETA; /* without HyStart++, we overshoot by 2x in slowstart */
     if (cc->cwnd < QUICLY_MIN_CWND * max_udp_payload_size)
         cc->cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
     cc->ssthresh = cc->cwnd;

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -119,8 +119,10 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
         quicly_cc_jumpstart_on_first_loss(cc, lost_pn, &beta);
 
     ++cc->num_loss_episodes;
-    if (cc->cwnd_exiting_slow_start == 0)
+    if (cc->cwnd_exiting_slow_start == 0) {
         cc->cwnd_exiting_slow_start = cc->cwnd;
+        cc->exit_slow_start_at = now;
+    }
 
     /* Calculate increase rate. */
     cc->state.pico.bytes_per_mtu_increase = calc_bytes_per_mtu_increase(cc->cwnd, loss->rtt.smoothed, max_udp_payload_size);
@@ -159,6 +161,7 @@ static void pico_reset(quicly_cc_t *cc, uint32_t initcwnd)
         .cwnd_initial = initcwnd,
         .cwnd_maximum = initcwnd,
         .cwnd_minimum = UINT32_MAX,
+        .exit_slow_start_at = INT64_MAX,
         .ssthresh = UINT32_MAX,
         .pacer_multiplier = QUICLY_PACER_CALC_MULTIPLIER(2),
     };

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -46,6 +46,7 @@ static void reno_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
     if (cc->pacer_multiplier == QUICLY_PACER_CALC_MULTIPLIER(1) && cc->state.reno.jumpstart.enter_pn <= largest_acked) {
         assert(cc->cwnd < cc->ssthresh);
         cc->cwnd = inflight;
+        cc->cwnd_exiting_jumpstart = cc->cwnd;
         cc->state.reno.jumpstart.exit_pn = next_pn;
         cc->pacer_multiplier = QUICLY_PACER_CALC_MULTIPLIER(2); /* revert to pacing of slow start */
     }

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -62,10 +62,6 @@ static void reno_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
 void quicly_cc_reno_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn,
                             int64_t now, uint32_t max_udp_payload_size)
 {
-    /* when exiting slow start, use inverse of exponential growth ratio, as loss is detected 1 RTT later, at which point CWND has
-     * overshot as much as the growth ratio */
-    double beta = cc->ssthresh == UINT32_MAX ? 0.5 : QUICLY_RENO_BETA;
-
     quicly_cc__update_ecn_episodes(cc, bytes, lost_pn);
 
     /* Nothing to do if loss is in recovery window. */
@@ -84,7 +80,7 @@ void quicly_cc_reno_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t
     }
 
     /* Reduce congestion window. */
-    cc->cwnd *= beta;
+    cc->cwnd *= cc->ssthresh == UINT32_MAX ? 0.5 : QUICLY_RENO_BETA; /* without HyStart++, we overshoot by 2x in slowstart */
     if (cc->cwnd < QUICLY_MIN_CWND * max_udp_payload_size)
         cc->cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
     cc->ssthresh = cc->cwnd;

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -75,7 +75,7 @@ void quicly_cc_reno_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t
 
     /* if detected loss before receiving all acks for jumpstart, restore original CWND */
     if (cc->ssthresh == UINT32_MAX)
-        quicly_cc_jumpstart_on_first_loss(cc, lost_pn, &beta);
+        quicly_cc_jumpstart_on_first_loss(cc, lost_pn);
 
     ++cc->num_loss_episodes;
     if (cc->cwnd_exiting_slow_start == 0) {

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -162,5 +162,6 @@ uint32_t quicly_cc_calc_initial_cwnd(uint32_t max_packets, uint16_t max_udp_payl
     if (max_udp_payload_size > mtu_max)
         max_udp_payload_size = mtu_max;
 
-    return max_packets * max_udp_payload_size;
+    uint64_t cwnd_bytes = (uint64_t)max_packets * max_udp_payload_size;
+    return cwnd_bytes <= UINT32_MAX ? (uint32_t)cwnd_bytes : UINT32_MAX;
 }

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -75,8 +75,10 @@ void quicly_cc_reno_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t
         quicly_cc_jumpstart_on_first_loss(cc, lost_pn, &beta);
 
     ++cc->num_loss_episodes;
-    if (cc->cwnd_exiting_slow_start == 0)
+    if (cc->cwnd_exiting_slow_start == 0) {
         cc->cwnd_exiting_slow_start = cc->cwnd;
+        cc->exit_slow_start_at = now;
+    }
 
     /* Reduce congestion window. */
     cc->cwnd *= beta;
@@ -103,6 +105,7 @@ static void reno_reset(quicly_cc_t *cc, uint32_t initcwnd)
     memset(cc, 0, sizeof(quicly_cc_t));
     cc->type = &quicly_cc_type_reno;
     cc->cwnd = cc->cwnd_initial = cc->cwnd_maximum = initcwnd;
+    cc->exit_slow_start_at = INT64_MAX;
     cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
     cc->pacer_multiplier = QUICLY_PACER_CALC_MULTIPLIER(2);
 

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -83,9 +83,11 @@ void quicly_cc_reno_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t
     /* if detected loss before receiving all acks for jumpstart, restore original CWND */
     if (cc->ssthresh == UINT32_MAX && lost_pn < cc->state.reno.jumpstart.exit_pn) {
         assert(cc->cwnd < cc->ssthresh);
-        /* CWND is set to the amount of bytes ACKed during the jump start phase plus the value before jump start. As we multiply by
-         * beta below, we compensate for that by dividing by beta here. */
-        cc->cwnd = cc->state.reno.jumpstart.bytes_acked / QUICLY_RENO_BETA;
+        /* CWND is set to the amount of bytes ACKed during the jump start phase plus the value before jump start */
+        cc->cwnd = cc->state.reno.jumpstart.bytes_acked;
+        if (cc->cwnd < cc->cwnd_initial)
+            cc->cwnd = cc->cwnd_initial;
+        cc->cwnd /= QUICLY_RENO_BETA; /* compensate for the multiplification below */
     }
 
     ++cc->num_loss_episodes;

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -58,7 +58,9 @@ static void reno_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
 void quicly_cc_reno_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn,
                             int64_t now, uint32_t max_udp_payload_size)
 {
-    double beta = QUICLY_RENO_BETA;
+    /* when exiting slow start, use inverse of exponential growth ratio, as loss is detected 1 RTT later, at which point CWND has
+     * overshot as much as the growth ratio */
+    double beta = cc->ssthresh == UINT32_MAX ? 0.5 : QUICLY_RENO_BETA;
 
     quicly_cc__update_ecn_episodes(cc, bytes, lost_pn);
 

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -49,6 +49,7 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                               0, /* ack_frequency */
                                               DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
                                               DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
+                                              0, /* max_jumpstart_cwnd */
                                               0, /* enlarge_client_hello */
                                               1, /* enable_ecn */
                                               0, /* use_pacing */
@@ -81,6 +82,7 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                     0, /* ack_frequency */
                                                     DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
                                                     DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
+                                                    0, /* max_jumpstart_cwnd */
                                                     0, /* enlarge_client_hello */
                                                     1, /* enable_ecn */
                                                     0, /* use_pacing */

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -49,7 +49,8 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                               0, /* ack_frequency */
                                               DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
                                               DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
-                                              0, /* max_jumpstart_cwnd */
+                                              0, /* default_jumpstart_cwnd_bytes */
+                                              0, /* max_jumpstart_cwnd_bytes */
                                               0, /* enlarge_client_hello */
                                               1, /* enable_ecn */
                                               0, /* use_pacing */
@@ -82,7 +83,8 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                     0, /* ack_frequency */
                                                     DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
                                                     DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
-                                                    0, /* max_jumpstart_cwnd */
+                                                    0, /* default_jumpstart_cwnd_bytes */
+                                                    0, /* max_jumpstart_cwnd_bytes */
                                                     0, /* enlarge_client_hello */
                                                     1, /* enable_ecn */
                                                     0, /* use_pacing */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5017,24 +5017,27 @@ Exit:
          * size of the pacer (10 packets) */
         if (conn->egress.try_jumpstart && conn->egress.loss.rtt.minimum != UINT32_MAX) {
             conn->egress.try_jumpstart = 0;
-            uint32_t jumpstart_cwnd = 0;
-            conn->super.stats.jumpstart.new_rtt = conn->egress.loss.rtt.minimum;
-            if (conn->super.ctx->max_jumpstart_cwnd_packets != 0 && conn->super.stats.jumpstart.prev_rate != 0 &&
-                conn->super.stats.jumpstart.prev_rtt != 0) {
-                /* Careful Resume */
-                jumpstart_cwnd = derive_jumpstart_cwnd(conn->super.ctx, conn->super.stats.jumpstart.new_rtt,
-                                                       conn->super.stats.jumpstart.prev_rate, conn->super.stats.jumpstart.prev_rtt);
-            } else if (conn->super.ctx->default_jumpstart_cwnd_packets != 0) {
-                /* jumpstart without previous information */
-                jumpstart_cwnd = quicly_cc_calc_initial_cwnd(conn->super.ctx->default_jumpstart_cwnd_packets,
-                                                             conn->super.ctx->transport_params.max_udp_payload_size);
-            }
-            /* Jumpstart if the amount that can be sent in 1 RTT would be higher than without. Comparison target is CWND + inflight,
-             * as that is the amount that can be sent at most. Note the flow rate can become smaller due to packets paced across
-             * the entire RTT during jumpstart. */
-            if (jumpstart_cwnd >= conn->egress.cc.cwnd + orig_bytes_inflight) {
-                conn->super.stats.jumpstart.cwnd = (uint32_t)jumpstart_cwnd;
-                conn->egress.cc.type->cc_jumpstart(&conn->egress.cc, jumpstart_cwnd, conn->egress.packet_number);
+            if (conn->egress.cc.num_loss_episodes == 0) {
+                uint32_t jumpstart_cwnd = 0;
+                conn->super.stats.jumpstart.new_rtt = conn->egress.loss.rtt.minimum;
+                if (conn->super.ctx->max_jumpstart_cwnd_packets != 0 && conn->super.stats.jumpstart.prev_rate != 0 &&
+                    conn->super.stats.jumpstart.prev_rtt != 0) {
+                    /* Careful Resume */
+                    jumpstart_cwnd =
+                        derive_jumpstart_cwnd(conn->super.ctx, conn->super.stats.jumpstart.new_rtt,
+                                              conn->super.stats.jumpstart.prev_rate, conn->super.stats.jumpstart.prev_rtt);
+                } else if (conn->super.ctx->default_jumpstart_cwnd_packets != 0) {
+                    /* jumpstart without previous information */
+                    jumpstart_cwnd = quicly_cc_calc_initial_cwnd(conn->super.ctx->default_jumpstart_cwnd_packets,
+                                                                 conn->super.ctx->transport_params.max_udp_payload_size);
+                }
+                /* Jumpstart if the amount that can be sent in 1 RTT would be higher than without. Comparison target is CWND +
+                 * inflight, as that is the amount that can be sent at most. Note the flow rate can become smaller due to packets
+                 * paced across the entire RTT during jumpstart. */
+                if (jumpstart_cwnd >= conn->egress.cc.cwnd + orig_bytes_inflight) {
+                    conn->super.stats.jumpstart.cwnd = (uint32_t)jumpstart_cwnd;
+                    conn->egress.cc.type->cc_jumpstart(&conn->egress.cc, jumpstart_cwnd, conn->egress.packet_number);
+                }
             }
         }
     }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4245,10 +4245,10 @@ static size_t encode_resumption_info(quicly_conn_t *conn, uint8_t *dst, size_t c
 
     ptls_buffer_init(&buf, dst, capacity);
 
-#define PUSH_ENTRY(id, block) \
-    do { \
-        ptls_buffer_push_quicint(&buf, (id)); \
-        ptls_buffer_push_block(&buf, -1, block); \
+#define PUSH_ENTRY(id, block)                                                                                                      \
+    do {                                                                                                                           \
+        ptls_buffer_push_quicint(&buf, (id));                                                                                      \
+        ptls_buffer_push_block(&buf, -1, block);                                                                                   \
     } while (0)
 
     /* emit delivery rate for Careful Resume */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -6505,6 +6505,9 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
                 goto Exit;
             setup_next_send(conn);
             conn->super.remote.address_validation.validated = 1;
+            if (conn->super.ctx->max_jumpstart_cwnd != 0 && conn->egress.cc.type->cc_jumpstart != NULL)
+                conn->egress.cc.type->cc_jumpstart(&conn->egress.cc, conn->super.ctx->max_jumpstart_cwnd,
+                                                   conn->egress.packet_number);
         }
         break;
     default:

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4275,7 +4275,7 @@ static int send_resumption_token(quicly_conn_t *conn, quicly_send_context_t *s)
 {
     { /* fill conn->super.stats.token_sent the information we are sending now */
         quicly_rate_t rate;
-        conn->super.stats.token_sent.at = conn->stash.now;
+        conn->super.stats.token_sent.at = conn->stash.now - conn->created_at;
         if (conn->egress.loss.rtt.minimum != 0 && (quicly_ratemeter_report(&conn->egress.ratemeter, &rate), rate.smoothed != 0)) {
             conn->super.stats.token_sent.rate = rate.smoothed;
             conn->super.stats.token_sent.rtt = conn->egress.loss.rtt.minimum;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5034,7 +5034,7 @@ Exit:
                 /* Jumpstart if the amount that can be sent in 1 RTT would be higher than without. Comparison target is CWND +
                  * inflight, as that is the amount that can be sent at most. Note the flow rate can become smaller due to packets
                  * paced across the entire RTT during jumpstart. */
-                if (jumpstart_cwnd >= conn->egress.cc.cwnd + orig_bytes_inflight) {
+                if (jumpstart_cwnd > conn->egress.cc.cwnd + orig_bytes_inflight) {
                     conn->super.stats.jumpstart.cwnd = (uint32_t)jumpstart_cwnd;
                     conn->egress.cc.type->cc_jumpstart(&conn->egress.cc, jumpstart_cwnd, conn->egress.packet_number);
                 }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5029,9 +5029,10 @@ Exit:
                 jumpstart_cwnd = quicly_cc_calc_initial_cwnd(conn->super.ctx->default_jumpstart_cwnd_packets,
                                                              conn->super.ctx->transport_params.max_udp_payload_size);
             }
-            /* Jumpstart if the flow rate would be higher. Comparison target is CWND + inflight bytes in 1/2 RTT, as that is the
-             * amount that can be sent at most, with pacer controlling the send rate. */
-            if (jumpstart_cwnd >= (conn->egress.cc.cwnd + orig_bytes_inflight) * 2) {
+            /* Jumpstart if the amount that can be sent in 1 RTT would be higher than without. Comparison target is CWND + inflight,
+             * as that is the amount that can be sent at most. Note the flow rate can become smaller due to packets paced across
+             * the entire RTT during jumpstart. */
+            if (jumpstart_cwnd >= conn->egress.cc.cwnd + orig_bytes_inflight) {
                 conn->super.stats.jumpstart.cwnd = (uint32_t)jumpstart_cwnd;
                 conn->egress.cc.type->cc_jumpstart(&conn->egress.cc, jumpstart_cwnd, conn->egress.packet_number);
             }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5147,6 +5147,8 @@ size_t quicly_send_stateless_reset(quicly_context_t *ctx, const void *src_cid, v
 
 int quicly_send_resumption_token(quicly_conn_t *conn)
 {
+    assert(!quicly_is_client(conn));
+
     if (conn->super.state <= QUICLY_STATE_CONNECTED) {
         ++conn->egress.new_token.generation;
         conn->egress.pending_flows |= QUICLY_PENDING_FLOW_NEW_TOKEN_BIT;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4993,10 +4993,11 @@ Exit:
         if (conn->egress.try_jumpstart && conn->egress.loss.rtt.minimum != UINT32_MAX) {
             conn->egress.try_jumpstart = 0;
             uint32_t jumpstart_cwnd = 0;
+            conn->super.stats.jumpstart.new_rtt = conn->egress.loss.rtt.minimum;
             if (conn->super.ctx->max_jumpstart_cwnd_bytes != 0 && conn->super.stats.jumpstart.prev_rate != 0 &&
                 conn->super.stats.jumpstart.prev_rtt != 0) {
                 /* Careful Resume */
-                jumpstart_cwnd = derive_jumpstart_cwnd(conn->super.ctx, conn->egress.loss.rtt.minimum,
+                jumpstart_cwnd = derive_jumpstart_cwnd(conn->super.ctx, conn->super.stats.jumpstart.new_rtt,
                                                        conn->super.stats.jumpstart.prev_rate, conn->super.stats.jumpstart.prev_rtt);
             } else if (conn->super.ctx->default_jumpstart_cwnd_bytes != 0) {
                 /* jumpstart without previous information */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4257,12 +4257,12 @@ static size_t encode_resumption_info(quicly_conn_t *conn, uint8_t *dst, size_t c
     } while (0)
 
     /* emit delivery rate for Careful Resume */
-    PUSH_ENTRY(QUICLY_RESUMPTION_ENTRY_TYPE_CAREFUL_RESUME, {
-        quicly_rate_t rate;
-        quicly_ratemeter_report(&conn->egress.ratemeter, &rate);
-        ptls_buffer_push_quicint(&buf, rate.smoothed);
-        ptls_buffer_push_quicint(&buf, conn->egress.loss.rtt.minimum);
-    });
+    if (conn->super.stats.token_sent.rate != 0 && conn->super.stats.token_sent.rtt != 0) {
+        PUSH_ENTRY(QUICLY_RESUMPTION_ENTRY_TYPE_CAREFUL_RESUME, {
+            ptls_buffer_push_quicint(&buf, conn->super.stats.token_sent.rate);
+            ptls_buffer_push_quicint(&buf, conn->super.stats.token_sent.rtt);
+        });
+    }
 
 #undef PUSH_ENTRY
 
@@ -4273,6 +4273,18 @@ Exit:
 
 static int send_resumption_token(quicly_conn_t *conn, quicly_send_context_t *s)
 {
+    { /* fill conn->super.stats.token_sent the information we are sending now */
+        quicly_rate_t rate;
+        conn->super.stats.token_sent.at = conn->stash.now;
+        if (conn->egress.loss.rtt.minimum != 0 && (quicly_ratemeter_report(&conn->egress.ratemeter, &rate), rate.smoothed != 0)) {
+            conn->super.stats.token_sent.rate = rate.smoothed;
+            conn->super.stats.token_sent.rtt = conn->egress.loss.rtt.minimum;
+        } else {
+            conn->super.stats.token_sent.rate = 0;
+            conn->super.stats.token_sent.rtt = 0;
+        }
+    }
+
     quicly_address_token_plaintext_t token;
     ptls_buffer_t tokenbuf;
     uint8_t tokenbuf_small[128];

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -6382,7 +6382,7 @@ int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *
         case QUICLY_ADDRESS_TOKEN_TYPE_RESUMPTION:
             if (decode_resumption_info(address_token->resumption.bytes, address_token->resumption.len,
                                        &(*conn)->super.stats.jumpstart.prev_rate, &(*conn)->super.stats.jumpstart.prev_rtt) != 0) {
-                (*conn)->super.stats.jumpstart.prev_rtt = 0;
+                (*conn)->super.stats.jumpstart.prev_rate = 0;
                 (*conn)->super.stats.jumpstart.prev_rtt = 0;
             }
             break;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1302,6 +1302,11 @@ int quicly_get_stats(quicly_conn_t *conn, quicly_stats_t *stats)
     stats->rtt = conn->egress.loss.rtt;
     stats->loss_thresholds = conn->egress.loss.thresholds;
     stats->cc = conn->egress.cc;
+    /* convert `exit_slow_start_at` to time spent since the connection was created */
+    if (stats->cc.exit_slow_start_at != INT64_MAX) {
+        assert(stats->cc.exit_slow_start_at >= conn->created_at);
+        stats->cc.exit_slow_start_at -= conn->created_at;
+    }
     quicly_ratemeter_report(&conn->egress.ratemeter, &stats->delivery_rate);
     stats->num_sentmap_packets_largest = conn->egress.loss.sentmap.num_packets_largest;
     stats->handshake_confirmed_msec = conn->super.stats.handshake_confirmed_msec;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4186,8 +4186,8 @@ static uint32_t derive_jumpstart_cwnd(quicly_context_t *ctx, uint32_t new_rtt, u
         cwnd = cwnd * new_rtt / prev_rtt;
 
     /* cap to the configured value */
-    if (cwnd > ctx->max_jumpstart_cwnd)
-        cwnd = ctx->max_jumpstart_cwnd;
+    if (cwnd > ctx->max_jumpstart_cwnd_bytes)
+        cwnd = ctx->max_jumpstart_cwnd_bytes;
 
     return (uint32_t)cwnd;
 }
@@ -6617,7 +6617,7 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
             setup_next_send(conn);
             conn->super.remote.address_validation.validated = 1;
             /* jumpstart if possible */
-            if (conn->super.ctx->max_jumpstart_cwnd != 0 && conn->egress.cc.type->cc_jumpstart != NULL &&
+            if (conn->super.ctx->max_jumpstart_cwnd_bytes != 0 && conn->egress.cc.type->cc_jumpstart != NULL &&
                 conn->super.ctx->use_pacing && conn->super.stats.jumpstart.prev_rate != 0 &&
                 conn->super.stats.jumpstart.prev_rtt != 0) {
                 /* For the purpose of calculating jumpstart CWND, we use minRTT if available. There could be cases where we do not

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4941,6 +4941,12 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
                     goto Exit;
                 conn->egress.pending_flows &= ~QUICLY_PENDING_FLOW_OTHERS_BIT;
             }
+            /* stream operations might have requested emission of NEW_TOKEN at the tail; if so, try to bundle it */
+            if ((conn->egress.pending_flows & QUICLY_PENDING_FLOW_NEW_TOKEN_BIT) != 0) {
+                assert(conn->application->one_rtt_writable);
+                if ((ret = send_resumption_token(conn, s)) != 0)
+                    goto Exit;
+            }
         }
     }
 

--- a/quicly.xcodeproj/project.pbxproj
+++ b/quicly.xcodeproj/project.pbxproj
@@ -36,13 +36,14 @@
 		0829879026E03D4D0053638F /* rate.c in Sources */ = {isa = PBXBuildFile; fileRef = 0829878D26E03D4D0053638F /* rate.c */; };
 		0829879226E0A9DF0053638F /* rate.c in Sources */ = {isa = PBXBuildFile; fileRef = 0829879126E0A9DF0053638F /* rate.c */; };
 		085125F828F51BA20074C124 /* quicly-probes.d in Sources */ = {isa = PBXBuildFile; fileRef = E95EBCCD227EC13F0022C32D /* quicly-probes.d */; };
+		085AB4D726427E9C00DF5209 /* pacer.h in Headers */ = {isa = PBXBuildFile; fileRef = 085AB4D626427E9C00DF5209 /* pacer.h */; };
+		085AB4D9264283D600DF5209 /* pacer.c in Sources */ = {isa = PBXBuildFile; fileRef = 085AB4D8264283D600DF5209 /* pacer.c */; };
 		086001CB273271E80043886F /* rate.c in Sources */ = {isa = PBXBuildFile; fileRef = 0829878D26E03D4D0053638F /* rate.c */; };
+		089738FB2B9FF2E1000569EB /* jumpstart.c in Sources */ = {isa = PBXBuildFile; fileRef = 089738FA2B9FF2E1000569EB /* jumpstart.c */; };
 		08B3297A29407097009D6766 /* hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = 08B3297929407096009D6766 /* hpke.c */; };
 		08B3297B29407097009D6766 /* hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = 08B3297929407096009D6766 /* hpke.c */; };
 		08B3297C29407097009D6766 /* hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = 08B3297929407096009D6766 /* hpke.c */; };
 		08B3297D29407097009D6766 /* hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = 08B3297929407096009D6766 /* hpke.c */; };
-		085AB4D726427E9C00DF5209 /* pacer.h in Headers */ = {isa = PBXBuildFile; fileRef = 085AB4D626427E9C00DF5209 /* pacer.h */; };
-		085AB4D9264283D600DF5209 /* pacer.c in Sources */ = {isa = PBXBuildFile; fileRef = 085AB4D8264283D600DF5209 /* pacer.c */; };
 		E904233D24AED0410072C5B7 /* loss.c in Sources */ = {isa = PBXBuildFile; fileRef = E904233C24AED0410072C5B7 /* loss.c */; };
 		E904233E24AED0410072C5B7 /* loss.c in Sources */ = {isa = PBXBuildFile; fileRef = E904233C24AED0410072C5B7 /* loss.c */; };
 		E904233F24AED0410072C5B7 /* loss.c in Sources */ = {isa = PBXBuildFile; fileRef = E904233C24AED0410072C5B7 /* loss.c */; };
@@ -193,9 +194,10 @@
 		0829878D26E03D4D0053638F /* rate.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rate.c; sourceTree = "<group>"; };
 		0829879126E0A9DF0053638F /* rate.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rate.c; sourceTree = "<group>"; };
 		085125F728EFC0480074C124 /* cplusplus.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = cplusplus.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
-		08B3297929407096009D6766 /* hpke.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hpke.c; sourceTree = "<group>"; };
 		085AB4D626427E9C00DF5209 /* pacer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pacer.h; sourceTree = "<group>"; };
 		085AB4D8264283D600DF5209 /* pacer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pacer.c; sourceTree = "<group>"; };
+		089738FA2B9FF2E1000569EB /* jumpstart.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = jumpstart.c; sourceTree = "<group>"; };
+		08B3297929407096009D6766 /* hpke.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hpke.c; sourceTree = "<group>"; };
 		E904233C24AED0410072C5B7 /* loss.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = loss.c; sourceTree = "<group>"; };
 		E904234024AEFB980072C5B7 /* loss.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = loss.c; sourceTree = "<group>"; };
 		E9056C071F56965300E2B96C /* linklist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = linklist.h; sourceTree = "<group>"; };
@@ -478,6 +480,7 @@
 				085125F728EFC0480074C124 /* cplusplus.t */,
 				E98884C221E3F23A0060F010 /* e2e.t */,
 				E99F8C281F4EAEF800C26B3D /* frame.c */,
+				089738FA2B9FF2E1000569EB /* jumpstart.c */,
 				E9736533246FD3DA0039AA49 /* local_cid.c */,
 				E904234024AEFB980072C5B7 /* loss.c */,
 				E920D22F1F49EE0B00799777 /* lossy.c */,
@@ -884,6 +887,7 @@
 				E9D31DD1232DEDB400ACD5EC /* quicly-probes.d in Sources */,
 				E9736530246FD3B50039AA49 /* local_cid.c in Sources */,
 				E920D22C1F49533800799777 /* sentmap.c in Sources */,
+				089738FB2B9FF2E1000569EB /* jumpstart.c in Sources */,
 				E920D2301F49EE0B00799777 /* lossy.c in Sources */,
 				E99B75E71F5CF96900CF503E /* maxsender.c in Sources */,
 				E9F6A42F1F41375B0083F0B2 /* sendstate.c in Sources */,

--- a/src/cli.c
+++ b/src/cli.c
@@ -1201,6 +1201,7 @@ int main(int argc, char **argv)
     static const struct option longopts[] = {{"ech-key", required_argument, NULL, 0},
                                              {"ech-configs", required_argument, NULL, 0},
                                              {"disable-ecn", no_argument, NULL, 0},
+                                             {"default-jumpstart", required_argument, NULL, 0},
                                              {"max-jumpstart", required_argument, NULL, 0},
                                              {NULL}};
     while ((ch = getopt_long(argc, argv, "a:b:B:c:C:Dd:k:Ee:f:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvw:W:x:X:y:h", longopts,
@@ -1213,6 +1214,11 @@ int main(int argc, char **argv)
                 ech_setup_configs(optarg);
             } else if (strcmp(longopts[opt_index].name, "disable-ecn") == 0) {
                 ctx.enable_ecn = 0;
+            } else if (strcmp(longopts[opt_index].name, "default-jumpstart") == 0) {
+                if (sscanf(optarg, "%" SCNu32, &ctx.default_jumpstart_cwnd_bytes) != 1) {
+                    fprintf(stderr, "failed to parse default jumpstart size: %s\n", optarg);
+                    exit(1);
+                }
             } else if (strcmp(longopts[opt_index].name, "max-jumpstart") == 0) {
                 if (sscanf(optarg, "%" SCNu32, &ctx.max_jumpstart_cwnd_bytes) != 1) {
                     fprintf(stderr, "failed to parse max jumpstart size: %s\n", optarg);

--- a/src/cli.c
+++ b/src/cli.c
@@ -1126,7 +1126,7 @@ static void usage(const char *cmd)
            "                            fraction of CWND (default: 0)\n"
            "  -G                        enable UDP generic segmentation offload\n"
            "  -i interval               interval to reissue requests (in milliseconds)\n"
-           "  --jumpstart-default <wnd> jumpstart CWND size for new connections, in bytes\n"
+           "  --jumpstart-default <wnd> jumpstart CWND size for new connections, in packets\n"
            "  --jumpstart-max <wnd>     maximum jumpstart CWND size for resuming connections\n"
            "  -I timeout                idle timeout (in milliseconds; default: 600,000)\n"
            "  -K num-packets            perform key update every num-packets packets\n"
@@ -1228,12 +1228,12 @@ int main(int argc, char **argv)
             } else if (strcmp(longopts[opt_index].name, "disregard-app-limited") == 0) {
                 ctx.cc_recognize_app_limited = 0;
             } else if (strcmp(longopts[opt_index].name, "jumpstart-default") == 0) {
-                if (sscanf(optarg, "%" SCNu32, &ctx.default_jumpstart_cwnd_bytes) != 1) {
+                if (sscanf(optarg, "%" SCNu32, &ctx.default_jumpstart_cwnd_packets) != 1) {
                     fprintf(stderr, "failed to parse default jumpstart size: %s\n", optarg);
                     exit(1);
                 }
             } else if (strcmp(longopts[opt_index].name, "jumpstart-max") == 0) {
-                if (sscanf(optarg, "%" SCNu32, &ctx.max_jumpstart_cwnd_bytes) != 1) {
+                if (sscanf(optarg, "%" SCNu32, &ctx.max_jumpstart_cwnd_packets) != 1) {
                     fprintf(stderr, "failed to parse max jumpstart size: %s\n", optarg);
                     exit(1);
                 }

--- a/src/cli.c
+++ b/src/cli.c
@@ -663,8 +663,9 @@ static int run_client(int fd, struct sockaddr *sa, const char *host)
                         send_datagram_frame = 0;
                     }
                     if (quicly_num_streams(conn) == 0) {
-                        if (request_interval != 0 && enqueue_requests_at == INT64_MAX) {
-                            enqueue_requests_at = ctx.now->cb(ctx.now) + request_interval;
+                        if (request_interval != 0) {
+                            if (enqueue_requests_at == INT64_MAX)
+                                enqueue_requests_at = ctx.now->cb(ctx.now) + request_interval;
                         } else {
                             static int close_called;
                             if (!close_called) {

--- a/src/cli.c
+++ b/src/cli.c
@@ -149,14 +149,16 @@ static void dump_stats(FILE *fp, quicly_conn_t *conn)
             ", ack-ecn-ce: %" PRIu64 ", late-acked: %" PRIu64 ", bytes-received: %" PRIu64 ", bytes-sent: %" PRIu64
             ", srtt: %" PRIu32 ", num-loss-episodes: %" PRIu32 ", num-ecn-loss-episodes: %" PRIu32 ", delivery-rate: %" PRIu64
             ", cwnd: %" PRIu32 ", cwnd-exiting-slow-start: %" PRIu32 ", slow-start-exit-at: %" PRId64 ", jumpstart-cwnd: %" PRIu32
-            ", jumpstart-exit: %" PRIu32 "\n",
+            ", jumpstart-exit: %" PRIu32 ", jumpstart-prev-rate: %" PRIu64 ", jumpstart-prev-rtt: %" PRIu32
+            ", token-sent-rate: %" PRIu64 ", token-sent-rtt: %" PRIu32 "\n",
             stats.num_packets.received, stats.num_packets.received_ecn_counts[0], stats.num_packets.received_ecn_counts[1],
             stats.num_packets.received_ecn_counts[2], stats.num_packets.decryption_failed, stats.num_packets.sent,
             stats.num_packets.lost, stats.num_packets.ack_received, stats.num_packets.acked_ecn_counts[0],
             stats.num_packets.acked_ecn_counts[1], stats.num_packets.acked_ecn_counts[2], stats.num_packets.late_acked,
             stats.num_bytes.received, stats.num_bytes.sent, stats.rtt.smoothed, stats.cc.num_loss_episodes,
             stats.cc.num_ecn_loss_episodes, stats.delivery_rate.smoothed, stats.cc.cwnd, stats.cc.cwnd_exiting_slow_start,
-            stats.cc.exit_slow_start_at, stats.jumpstart.cwnd, stats.cc.cwnd_exiting_jumpstart);
+            stats.cc.exit_slow_start_at, stats.jumpstart.cwnd, stats.cc.cwnd_exiting_jumpstart, stats.jumpstart.prev_rate,
+            stats.jumpstart.prev_rtt, stats.token_sent.rate, stats.token_sent.rtt);
 }
 
 static int validate_path(const char *path)

--- a/src/cli.c
+++ b/src/cli.c
@@ -147,13 +147,14 @@ static void dump_stats(FILE *fp, quicly_conn_t *conn)
             ", received-ecn-ce: %" PRIu64 ", packets-decryption-failed: %" PRIu64 ", packets-sent: %" PRIu64
             ", packets-lost: %" PRIu64 ", ack-received: %" PRIu64 ", ack-ecn-ect0: %" PRIu64 ", ack-ecn-ect1: %" PRIu64
             ", ack-ecn-ce: %" PRIu64 ", late-acked: %" PRIu64 ", bytes-received: %" PRIu64 ", bytes-sent: %" PRIu64
-            ", srtt: %" PRIu32 ", num-loss-episodes: %" PRIu32 ", num-ecn-loss-episodes: %" PRIu32 "\n",
+            ", srtt: %" PRIu32 ", num-loss-episodes: %" PRIu32 ", num-ecn-loss-episodes: %" PRIu32 ", jumpstart-cwnd: %" PRIu32
+            ", jumpstart-exit: %" PRIu32 "\n",
             stats.num_packets.received, stats.num_packets.received_ecn_counts[0], stats.num_packets.received_ecn_counts[1],
             stats.num_packets.received_ecn_counts[2], stats.num_packets.decryption_failed, stats.num_packets.sent,
             stats.num_packets.lost, stats.num_packets.ack_received, stats.num_packets.acked_ecn_counts[0],
             stats.num_packets.acked_ecn_counts[1], stats.num_packets.acked_ecn_counts[2], stats.num_packets.late_acked,
             stats.num_bytes.received, stats.num_bytes.sent, stats.rtt.smoothed, stats.cc.num_loss_episodes,
-            stats.cc.num_ecn_loss_episodes);
+            stats.cc.num_ecn_loss_episodes, stats.jumpstart.cwnd, stats.cc.cwnd_exiting_jumpstart);
 }
 
 static int validate_path(const char *path)

--- a/src/cli.c
+++ b/src/cli.c
@@ -1124,6 +1124,8 @@ static void usage(const char *cmd)
            "                            fraction of CWND (default: 0)\n"
            "  -G                        enable UDP generic segmentation offload\n"
            "  -i interval               interval to reissue requests (in milliseconds)\n"
+           "  --jumpstart-default <wnd> jumpstart CWND size for new connections, in bytes\n"
+           "  --jumpstart-max <wnd>     maximum jumpstart CWND size for resuming connections\n"
            "  -I timeout                idle timeout (in milliseconds; default: 600,000)\n"
            "  -K num-packets            perform key update every num-packets packets\n"
            "  -l log-file               file to log traffic secrets\n"
@@ -1207,8 +1209,8 @@ int main(int argc, char **argv)
     static const struct option longopts[] = {{"ech-key", required_argument, NULL, 0},
                                              {"ech-configs", required_argument, NULL, 0},
                                              {"disable-ecn", no_argument, NULL, 0},
-                                             {"default-jumpstart", required_argument, NULL, 0},
-                                             {"max-jumpstart", required_argument, NULL, 0},
+                                             {"jumpstart-default", required_argument, NULL, 0},
+                                             {"jumpstart-max", required_argument, NULL, 0},
                                              {NULL}};
     while ((ch = getopt_long(argc, argv, "a:b:B:c:C:Dd:k:Ee:f:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvw:W:x:X:y:h", longopts,
                              &opt_index)) != -1) {
@@ -1220,12 +1222,12 @@ int main(int argc, char **argv)
                 ech_setup_configs(optarg);
             } else if (strcmp(longopts[opt_index].name, "disable-ecn") == 0) {
                 ctx.enable_ecn = 0;
-            } else if (strcmp(longopts[opt_index].name, "default-jumpstart") == 0) {
+            } else if (strcmp(longopts[opt_index].name, "jumpstart-default") == 0) {
                 if (sscanf(optarg, "%" SCNu32, &ctx.default_jumpstart_cwnd_bytes) != 1) {
                     fprintf(stderr, "failed to parse default jumpstart size: %s\n", optarg);
                     exit(1);
                 }
-            } else if (strcmp(longopts[opt_index].name, "max-jumpstart") == 0) {
+            } else if (strcmp(longopts[opt_index].name, "jumpstart-max") == 0) {
                 if (sscanf(optarg, "%" SCNu32, &ctx.max_jumpstart_cwnd_bytes) != 1) {
                     fprintf(stderr, "failed to parse max jumpstart size: %s\n", optarg);
                     exit(1);

--- a/src/cli.c
+++ b/src/cli.c
@@ -1214,7 +1214,7 @@ int main(int argc, char **argv)
             } else if (strcmp(longopts[opt_index].name, "disable-ecn") == 0) {
                 ctx.enable_ecn = 0;
             } else if (strcmp(longopts[opt_index].name, "max-jumpstart") == 0) {
-                if (sscanf(optarg, "%" SCNu32, &ctx.max_jumpstart_cwnd) != 1) {
+                if (sscanf(optarg, "%" SCNu32, &ctx.max_jumpstart_cwnd_bytes) != 1) {
                     fprintf(stderr, "failed to parse max jumpstart size: %s\n", optarg);
                     exit(1);
                 }

--- a/src/cli.c
+++ b/src/cli.c
@@ -147,14 +147,16 @@ static void dump_stats(FILE *fp, quicly_conn_t *conn)
             ", received-ecn-ce: %" PRIu64 ", packets-decryption-failed: %" PRIu64 ", packets-sent: %" PRIu64
             ", packets-lost: %" PRIu64 ", ack-received: %" PRIu64 ", ack-ecn-ect0: %" PRIu64 ", ack-ecn-ect1: %" PRIu64
             ", ack-ecn-ce: %" PRIu64 ", late-acked: %" PRIu64 ", bytes-received: %" PRIu64 ", bytes-sent: %" PRIu64
-            ", srtt: %" PRIu32 ", num-loss-episodes: %" PRIu32 ", num-ecn-loss-episodes: %" PRIu32 ", jumpstart-cwnd: %" PRIu32
+            ", srtt: %" PRIu32 ", num-loss-episodes: %" PRIu32 ", num-ecn-loss-episodes: %" PRIu32 ", delivery-rate: %" PRIu64
+            ", cwnd: %" PRIu32 ", cwnd-exiting-slow-start: %" PRIu32 ", slow-start-exit-at: %" PRId64 ", jumpstart-cwnd: %" PRIu32
             ", jumpstart-exit: %" PRIu32 "\n",
             stats.num_packets.received, stats.num_packets.received_ecn_counts[0], stats.num_packets.received_ecn_counts[1],
             stats.num_packets.received_ecn_counts[2], stats.num_packets.decryption_failed, stats.num_packets.sent,
             stats.num_packets.lost, stats.num_packets.ack_received, stats.num_packets.acked_ecn_counts[0],
             stats.num_packets.acked_ecn_counts[1], stats.num_packets.acked_ecn_counts[2], stats.num_packets.late_acked,
             stats.num_bytes.received, stats.num_bytes.sent, stats.rtt.smoothed, stats.cc.num_loss_episodes,
-            stats.cc.num_ecn_loss_episodes, stats.jumpstart.cwnd, stats.cc.cwnd_exiting_jumpstart);
+            stats.cc.num_ecn_loss_episodes, stats.delivery_rate.smoothed, stats.cc.cwnd, stats.cc.cwnd_exiting_slow_start,
+            stats.cc.exit_slow_start_at, stats.jumpstart.cwnd, stats.cc.cwnd_exiting_jumpstart);
 }
 
 static int validate_path(const char *path)

--- a/src/cli.c
+++ b/src/cli.c
@@ -1166,6 +1166,7 @@ int main(int argc, char **argv)
     static const struct option longopts[] = {{"ech-key", required_argument, NULL, 0},
                                              {"ech-configs", required_argument, NULL, 0},
                                              {"disable-ecn", no_argument, NULL, 0},
+                                             {"max-jumpstart", required_argument, NULL, 0},
                                              {NULL}};
     while ((ch = getopt_long(argc, argv, "a:b:B:c:C:Dd:k:Ee:f:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvw:W:x:X:y:h", longopts,
                              &opt_index)) != -1) {
@@ -1177,6 +1178,11 @@ int main(int argc, char **argv)
                 ech_setup_configs(optarg);
             } else if (strcmp(longopts[opt_index].name, "disable-ecn") == 0) {
                 ctx.enable_ecn = 0;
+            } else if (strcmp(longopts[opt_index].name, "max-jumpstart") == 0) {
+                if (sscanf(optarg, "%" SCNu32, &ctx.max_jumpstart_cwnd) != 1) {
+                    fprintf(stderr, "failed to parse max jumpstart size: %s\n", optarg);
+                    exit(1);
+                }
             } else {
                 assert(!"unexpected longname");
             }

--- a/t/jumpstart.c
+++ b/t/jumpstart.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2017-2024 Fastly, Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "test.h"
+
+struct test_jumpstart_action {
+    enum { TEST_JUMPSTART_ACTION_END, TEST_JUMPSTART_ACTION_SEND, TEST_JUMPSTART_ACTION_ACKED, TEST_JUMPSTART_ACTION_LOST } action;
+    int64_t now;
+    uint32_t packets;
+};
+
+static void test_jumpstart_pattern(quicly_init_cc_t *init, const struct test_jumpstart_action *actions, uint32_t final_cwnd)
+{
+    static const uint32_t mtu = 1200;
+    quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
+    quicly_cc_t cc;
+    int64_t now = 1;
+    uint32_t inflight = 0;
+    uint64_t next_pn = 0, packets_acked = 0;
+    size_t ackcnt = 0;
+
+    init->cb(init, &cc, 10 * mtu, now);
+    ok(cc.cwnd == 10 * mtu);
+    ok(cc.num_loss_episodes == 0);
+
+    for (const struct test_jumpstart_action *action = actions; action->action != TEST_JUMPSTART_ACTION_END; ++action) {
+        switch (action->action) {
+        case TEST_JUMPSTART_ACTION_SEND:
+            cc.type->cc_on_sent(&cc, &loss, action->packets * mtu, action->now);
+            inflight += action->packets * mtu;
+            next_pn += action->packets;
+            break;
+        case TEST_JUMPSTART_ACTION_ACKED:
+            cc.type->cc_on_acked(&cc, &loss, action->packets * mtu, packets_acked + action->packets - 1, action->packets * mtu, 1,
+                                 next_pn, action->now, mtu);
+            inflight -= action->packets * mtu;
+            packets_acked += action->packets;
+            ++ackcnt;
+            /* enter jumpstart upon receiving the first ack */
+            if (ackcnt == 1 && cc.num_loss_episodes == 0) {
+                cc.type->cc_jumpstart(&cc, 20 * mtu, next_pn);
+                ok(cc.cwnd == 20 * mtu);
+            }
+            break;
+        case TEST_JUMPSTART_ACTION_LOST:
+            cc.type->cc_on_lost(&cc, &loss, action->packets * mtu, packets_acked + action->packets - 1, next_pn, action->now, mtu);
+            inflight -= action->packets * mtu;
+            packets_acked += action->packets;
+            ok(!quicly_cc_in_jumpstart(&cc));
+            ok(cc.ssthresh < UINT32_MAX);
+            break;
+        default:
+            assert(!"FIXME");
+        }
+    }
+
+    ok(!quicly_cc_in_jumpstart(&cc));
+    ok(cc.cwnd == final_cwnd * mtu);
+}
+
+static void do_test_jumpstart(quicly_init_cc_t *init)
+{
+    /* if all packets sent in the unvalidated phase are acked, final CWND is 2x jumpstart cwnd */
+    subtest("simple", test_jumpstart_pattern, init,
+            (struct test_jumpstart_action[]){
+                {TEST_JUMPSTART_ACTION_SEND, 1000, 2},   /* send 2 packets */
+                {TEST_JUMPSTART_ACTION_ACKED, 1100, 2},  /* 2 packet acked, entering jumpstart */
+                {TEST_JUMPSTART_ACTION_SEND, 1100, 20},  /* use full jumpstart window */
+                {TEST_JUMPSTART_ACTION_ACKED, 1200, 20}, /* receive acks for all packets send in jumpstart */
+                {TEST_JUMPSTART_ACTION_END},
+            },
+            40);
+
+    /* if a packet is lost in the reconnaisance phase, jumpstart is not entered */
+    subtest("loss-inreconnaisance", test_jumpstart_pattern, init,
+            (struct test_jumpstart_action[]){
+                {TEST_JUMPSTART_ACTION_SEND, 1000, 2},  /* send 2 packets */
+                {TEST_JUMPSTART_ACTION_LOST, 1100, 1},  /* 1st packet lost */
+                {TEST_JUMPSTART_ACTION_ACKED, 1100, 1}, /* 2nd packet acked */
+                {TEST_JUMPSTART_ACTION_END},
+            },
+            5);
+
+    /* if 25% of packets sent in the unvalidated phase are lost, final CWND is 75% the jumpstart cwnd */
+    subtest("proportional rate reduction", test_jumpstart_pattern, init,
+            (struct test_jumpstart_action[]){
+                {TEST_JUMPSTART_ACTION_SEND, 1000, 2},  /* send 2 packets */
+                {TEST_JUMPSTART_ACTION_ACKED, 1100, 2}, /* 2 packet acked, entering jumpstart */
+                {TEST_JUMPSTART_ACTION_SEND, 1100, 20}, /* use full jumpstart window */
+                {TEST_JUMPSTART_ACTION_ACKED, 1200, 8},
+                {TEST_JUMPSTART_ACTION_LOST, 1200, 2},
+                {TEST_JUMPSTART_ACTION_ACKED, 1200, 7},
+                {TEST_JUMPSTART_ACTION_LOST, 1200, 3},
+                {TEST_JUMPSTART_ACTION_END},
+            },
+            15);
+
+    /* regardless of how much we lose, we never go down below 1/2 IW */
+    subtest("lower bound", test_jumpstart_pattern, init,
+            (struct test_jumpstart_action[]){
+                {TEST_JUMPSTART_ACTION_SEND, 1000, 2},  /* send 2 packets */
+                {TEST_JUMPSTART_ACTION_ACKED, 1100, 2}, /* 2 packet acked, entering jumpstart */
+                {TEST_JUMPSTART_ACTION_SEND, 1100, 20}, /* use full jumpstart window */
+                {TEST_JUMPSTART_ACTION_ACKED, 1200, 1},
+                {TEST_JUMPSTART_ACTION_LOST, 1200, 9},
+                {TEST_JUMPSTART_ACTION_ACKED, 1200, 2},
+                {TEST_JUMPSTART_ACTION_LOST, 1200, 8},
+                {TEST_JUMPSTART_ACTION_END},
+            },
+            5);
+}
+
+void test_jumpstart(void)
+{
+    subtest("reno", do_test_jumpstart, &quicly_cc_reno_init);
+    subtest("pico", do_test_jumpstart, &quicly_cc_pico_init);
+    subtest("cubic", do_test_jumpstart, &quicly_cc_cubic_init);
+}

--- a/t/test.c
+++ b/t/test.c
@@ -723,8 +723,7 @@ void test_ecn_index_from_bits(void)
     ok(get_ecn_index_from_bits(3) == 2);
 }
 
-/* at the moment only derivation is tested */
-static void test_jumpstart(void)
+static void test_jumpstart_cwnd(void)
 {
     quicly_context_t unbounded_max = {
         .max_jumpstart_cwnd_packets = UINT32_MAX,
@@ -818,6 +817,7 @@ int main(int argc, char **argv)
     subtest("test-nondecryptable-initial", test_nondecryptable_initial);
     subtest("set_cc", test_set_cc);
     subtest("ecn-index-from-bits", test_ecn_index_from_bits);
+    subtest("jumpstart-cwnd", test_jumpstart_cwnd);
     subtest("jumpstart", test_jumpstart);
 
     return done_testing();

--- a/t/test.c
+++ b/t/test.c
@@ -723,6 +723,18 @@ void test_ecn_index_from_bits(void)
     ok(get_ecn_index_from_bits(3) == 2);
 }
 
+/* at the moment only derivation is tested */
+static void test_jumpstart(void)
+{
+    quicly_context_t unbounded_max = {.max_jumpstart_cwnd_bytes = UINT32_MAX};
+    ok(derive_jumpstart_cwnd(&unbounded_max, 250, 1000000, 250) == 250000);
+    ok(derive_jumpstart_cwnd(&unbounded_max, 250, 1000000, 400) == 250000); /* if RTT increases, CWND stays same */
+    ok(derive_jumpstart_cwnd(&unbounded_max, 250, 1000000, 125) == 125000); /* if RTT decreses, CWND is reduced proportionally */
+
+    quicly_context_t bounded_max = {.max_jumpstart_cwnd_bytes = 80000};
+    ok(derive_jumpstart_cwnd(&bounded_max, 250, 1000000, 250) == 80000);
+}
+
 int main(int argc, char **argv)
 {
     static ptls_iovec_t cert;
@@ -800,6 +812,7 @@ int main(int argc, char **argv)
     subtest("test-nondecryptable-initial", test_nondecryptable_initial);
     subtest("set_cc", test_set_cc);
     subtest("ecn-index-from-bits", test_ecn_index_from_bits);
+    subtest("jumpstart", test_jumpstart);
 
     return done_testing();
 }

--- a/t/test.c
+++ b/t/test.c
@@ -726,12 +726,18 @@ void test_ecn_index_from_bits(void)
 /* at the moment only derivation is tested */
 static void test_jumpstart(void)
 {
-    quicly_context_t unbounded_max = {.max_jumpstart_cwnd_bytes = UINT32_MAX};
+    quicly_context_t unbounded_max = {
+        .max_jumpstart_cwnd_packets = UINT32_MAX,
+        .transport_params.max_udp_payload_size = 1200,
+    };
     ok(derive_jumpstart_cwnd(&unbounded_max, 250, 1000000, 250) == 250000);
     ok(derive_jumpstart_cwnd(&unbounded_max, 250, 1000000, 400) == 250000); /* if RTT increases, CWND stays same */
     ok(derive_jumpstart_cwnd(&unbounded_max, 250, 1000000, 125) == 125000); /* if RTT decreses, CWND is reduced proportionally */
 
-    quicly_context_t bounded_max = {.max_jumpstart_cwnd_bytes = 80000};
+    quicly_context_t bounded_max = {
+        .max_jumpstart_cwnd_packets = 64,
+        .transport_params.max_udp_payload_size = 1250,
+    };
     ok(derive_jumpstart_cwnd(&bounded_max, 250, 1000000, 250) == 80000);
 }
 

--- a/t/test.h
+++ b/t/test.h
@@ -61,5 +61,6 @@ void test_stream_concurrency(void);
 void test_received_cid(void);
 void test_local_cid(void);
 void test_retire_cid(void);
+void test_jumpstart(void);
 
 #endif


### PR DESCRIPTION
Builds on top of #452, and therefore this PR currently points to #452 as the base branch.

This PR implements [Careful Resume WG draft-04](https://datatracker.ietf.org/doc/html/draft-ietf-tsvwg-careful-resume-04) with following differences:
* Uses smoothed delivery rate (https://datatracker.ietf.org/doc/html/draft-ietf-tsvwg-careful-resume-04) and compares idle RTTs of the previous and new connection. That gives up better accuracy compared to using CWND and SRTT (a pair known to overshoot up to 2x at the end of slow start or undershoot by 1/2 immediately after a loss in congestion avoidance phase).
* When resuming, sends at the estimated bandwidth for full idle RTT. The draft states that endpoints should send at the estimated bandwidth for half the idle RTT. Justifications are that we have better accuracy (as stated above), and that there is no firm ground for the argument that half the idle RTT is better for fairness, considering that RTT of competing connections are going to be different.
* We count the number of bytes being acked among the packets sent in the jumpstart (i.e., unvalidated) phase, and if a loss is observed for any of the packets sent in that phase, CWND is adjusted to the number of bytes being acked. When the last packet sent in the unvalidated phase is acked (or deemed lost), CWND becomes equal to the pipe width.
* We do not have HyStart++ implemented.
* Separate knob (`quicly_context_t::default_jumpstart_cwnd_bytes`) is provided to set the CWND to be used when there is no previous information. This is useful for testing, et. al.
* We enter jumpstart (unvalidated phase) when we have more data to send than the pacer can send immediatly (i.e., 10 packets).

The PR adds following metrics to `quicly_context_t`:
* `max_jumpstart_cwnd_bytes` - cap for the CWND size used for jumpstart when previous information is available.
* `default_jumpstart_cwnd_bytes` jumpstart CWND to be used when no previous information is available; see above.

The PR adds following metrics to `quicly_stats_t`:
* `jumpstart.prev_rate` - delivery rate of the previous session
* `jumpstart.prev_rtt` - min RTT of the previous session
* `jumpstart.new_rtt`- min RTT of the new session
* `jumpstart.cwnd` - jumpstart CWND being adopted
* `cc.exit_slow_start_at` - contains milliseconds between creation of the connection and exit of slow start; alongside the existing parameter `cc.cwnd_exiting_slow_start`, this value would help us test the efficiency of jumpstart
* `cc.cwnd_exiting_jumpstart` - this value represents overestimation of the new RTT; if new RTT was overestimated, the value is going to be smaller than `jumpstart.cwnd`, as CWND is adjusted to the amount of bytes being acked previously, when exiting CWND (this is the moment when an the first ack is received for the packets sent in the unvalidated phase).