### PR TITLE
[delivery rate estimator] fix handling of dupack

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5340,8 +5340,9 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
     QUICLY_PROBE(ACK_DELAY_RECEIVED, conn, conn->stash.now, frame.ack_delay);
     QUICLY_LOG_CONN(ack_delay_received, conn, { PTLS_LOG_ELEMENT_UNSIGNED(ack_delay, frame.ack_delay); });
 
-    quicly_ratemeter_on_ack(&conn->egress.ratemeter, conn->stash.now, conn->super.stats.num_bytes.ack_received,
-                            largest_newly_acked.pn);
+    if (largest_newly_acked.pn != UINT64_MAX)
+        quicly_ratemeter_on_ack(&conn->egress.ratemeter, conn->stash.now, conn->super.stats.num_bytes.ack_received,
+                                largest_newly_acked.pn);
 
     /* Update loss detection engine on ack. The function uses ack_delay only when the largest_newly_acked is also the largest acked
      * so far. So, it does not matter if the ack_delay being passed in does not apply to the largest_newly_acked. */


### PR DESCRIPTION
When dupack is received, `quicly_ratemeter_on_ack` is called with pn=UINT64_MAX. That causes incorrect closure of the cc-limited phase, leading to drops of samples.