### PR TITLE
add missing u_* types for FreeBSD

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -21,6 +21,9 @@
  */
 #include <assert.h>
 #include <inttypes.h>
+#if defined(__FreeBSD__)
+#include <sys/types.h>
+#endif
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <pthread.h>

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -21,9 +21,7 @@
  */
 #include <assert.h>
 #include <inttypes.h>
-#if defined(__FreeBSD__)
 #include <sys/types.h>
-#endif
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <pthread.h>


### PR DESCRIPTION
This is patched downstream via https://cgit.freebsd.org/ports/tree/www/h2o-devel/files/patch-deps_quicly_lib_quicly.c to resolve errors similar to:

```
/usr/include/netinet/ip.h:53:2: error: unknown type name 'u_char'; did you mean 'char'?
```