### PR TITLE
fix asan crashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+    - name: setup
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28 # new default is 32 that causes libasan crashes
+
     - name: Run with Docker
       shell: 'script -q -e -c "bash -xe {0}"'
       run: |

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -455,7 +455,7 @@ sub spawn_process {
     }
     while (`netstat -na` !~ /^udp.*\s(127\.0\.0\.1|0\.0\.0\.0|\*)[\.:]$listen_port\s/m) {
         if (waitpid($pid, WNOHANG) == $pid) {
-            die "failed to launch @{[$cmd->[0]]}";
+            die "failed to launch @{[$cmd->[0]]}:$?";
         }
         sleep 0.1;
     }


### PR DESCRIPTION
Recent changes to Linux has started causing asan to crash with SEGV; see https://stackoverflow.com/questions/77672217/gcc-fsanitize-address-results-in-an-endless-loop-on-program-that-does-nothing/77994596#77994596.

Apparently, the changes have reached GitHub Actions, and our ASAN tests now failing.

This PR fixes the issue by adding the sysctl recommended in the stackoverflow Q&A linked above.