### PR TITLE
Improve detection of CC-limited state

### DIFF
--- a/t/loss.c
+++ b/t/loss.c
@@ -60,11 +60,11 @@ static void test_time_detection(void)
 
     /* commit 3 packets (pn=0..2); check that loss timer is not active */
     ok(quicly_sentmap_prepare(&loss.sentmap, 0, now, QUICLY_EPOCH_INITIAL) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_sentmap_prepare(&loss.sentmap, 1, now, QUICLY_EPOCH_INITIAL) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_sentmap_prepare(&loss.sentmap, 2, now, QUICLY_EPOCH_INITIAL) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_loss_detect_loss(&loss, now, quicly_spec_context.transport_params.max_ack_delay, 0, on_loss_detected) == 0);
     ok(loss.loss_time == INT64_MAX);
 
@@ -104,13 +104,13 @@ static void test_pn_detection(void)
 
     /* commit 4 packets (pn=0..3); check that loss timer is not active */
     ok(quicly_sentmap_prepare(&loss.sentmap, 0, now, QUICLY_EPOCH_INITIAL) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_sentmap_prepare(&loss.sentmap, 1, now, QUICLY_EPOCH_INITIAL) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_sentmap_prepare(&loss.sentmap, 2, now, QUICLY_EPOCH_INITIAL) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_sentmap_prepare(&loss.sentmap, 3, now, QUICLY_EPOCH_INITIAL) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_loss_detect_loss(&loss, now, quicly_spec_context.transport_params.max_ack_delay, 0, on_loss_detected) == 0);
     ok(loss.loss_time == INT64_MAX);
 
@@ -145,9 +145,9 @@ static void test_slow_cert_verify(void)
 
     /* sent Handshake+1RTT packet */
     ok(quicly_sentmap_prepare(&loss.sentmap, 1, now, QUICLY_EPOCH_HANDSHAKE) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_sentmap_prepare(&loss.sentmap, 2, now, QUICLY_EPOCH_1RTT) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     last_retransmittable_sent_at = now;
     quicly_loss_update_alarm(&loss, now, last_retransmittable_sent_at, 1, 0, 1, 0, 1);
 
@@ -169,9 +169,9 @@ static void test_slow_cert_verify(void)
 
     /* therefore send probes */
     ok(quicly_sentmap_prepare(&loss.sentmap, 3, now, QUICLY_EPOCH_HANDSHAKE) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
     ok(quicly_sentmap_prepare(&loss.sentmap, 4, now, QUICLY_EPOCH_1RTT) == 0);
-    quicly_sentmap_commit(&loss.sentmap, 10);
+    quicly_sentmap_commit(&loss.sentmap, 10, 0);
 
     now += 10;
 

--- a/t/sentmap.c
+++ b/t/sentmap.c
@@ -59,7 +59,7 @@ static void test_basic(void)
             quicly_sentmap_prepare(&map, at * 5 + i, at, QUICLY_EPOCH_INITIAL);
             quicly_sentmap_allocate(&map, on_acked);
             quicly_sentmap_allocate(&map, on_acked);
-            quicly_sentmap_commit(&map, 1);
+            quicly_sentmap_commit(&map, 1, 0);
         }
     }
 
@@ -115,10 +115,10 @@ static void test_late_ack(void)
     /* commit pn 1, 2 */
     quicly_sentmap_prepare(&map, 1, 0, QUICLY_EPOCH_INITIAL);
     quicly_sentmap_allocate(&map, on_acked);
-    quicly_sentmap_commit(&map, 10);
+    quicly_sentmap_commit(&map, 10, 0);
     quicly_sentmap_prepare(&map, 2, 0, QUICLY_EPOCH_INITIAL);
     quicly_sentmap_allocate(&map, on_acked);
-    quicly_sentmap_commit(&map, 20);
+    quicly_sentmap_commit(&map, 20, 0);
     ok(map.bytes_in_flight == 30);
 
     /* mark pn 1 as lost */
@@ -159,10 +159,10 @@ static void test_pto(void)
     /* commit pn 1, 2 */
     quicly_sentmap_prepare(&map, 1, 0, QUICLY_EPOCH_INITIAL);
     quicly_sentmap_allocate(&map, on_acked);
-    quicly_sentmap_commit(&map, 10);
+    quicly_sentmap_commit(&map, 10, 0);
     quicly_sentmap_prepare(&map, 2, 0, QUICLY_EPOCH_INITIAL);
     quicly_sentmap_allocate(&map, on_acked);
-    quicly_sentmap_commit(&map, 20);
+    quicly_sentmap_commit(&map, 20, 0);
     ok(map.bytes_in_flight == 30);
 
     /* mark pn 1 for PTO */


### PR DESCRIPTION
At the moment, a flow is considered CC limited (i.e., CWND in increased) when an acknowledgment is received and if either the CWND or the pacer restricts the flow from sending more.

The problem with this approach is that once all data is sent, newly received acks do not increase CWND, even if those acks were sent while the sender was sending at full speed. To paraphrase, if an idle connection goes into CC-limited for X round-trips then becomes idle again, only packets sent during X - 1 round-trips cause the increase of CWND.

During slow start, this behavior might lead to slower CWND growth than what is ideal.

This PR changes the approach: a flow is considered CC-limited if the packet was sent while `inflight >= 1/2 * CWND` or acked under the same condition. 1/2 of CWND is adopted for fairness with RFC 7661, and also provides correct increase; i.e., if an idle connection goes into CC-limited for X round-trips then becomes idle again, all packets sent during that X round-trips will be considered as CC-limited.