### PR TITLE
[cli] add option for encrypting packet images

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -271,6 +271,19 @@ typedef struct st_quicly_transport_parameters_t {
     uint16_t max_datagram_frame_size;
 } quicly_transport_parameters_t;
 
+typedef struct st_quicly_salt_t {
+    uint8_t initial[20];
+    struct {
+        uint8_t key[PTLS_AES128_KEY_SIZE];
+        uint8_t iv[PTLS_AESGCM_IV_SIZE];
+    } retry;
+} quicly_salt_t;
+
+typedef struct st_quicly_cipher_context_t {
+    ptls_aead_context_t *aead;
+    ptls_cipher_context_t *header_protection;
+} quicly_cipher_context_t;
+
 struct st_quicly_context_t {
     /**
      * tls context to use
@@ -1161,6 +1174,16 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
  */
 int quicly_is_destination(quicly_conn_t *conn, struct sockaddr *dest_addr, struct sockaddr *src_addr,
                           quicly_decoded_packet_t *decoded);
+/**
+ * returns salts given version
+ */
+const quicly_salt_t *quicly_get_salt(uint32_t protocol_version);
+/**
+ * initializes the cipher contexts given cid and salt
+ * @param conn maybe NULL when called by quicly_accept; if so, the default crypto engine will be used
+ */
+int quicly_setup_initial_encryption(ptls_cipher_suite_t *cs, quicly_cipher_context_t *ingress, quicly_cipher_context_t *egress,
+                                    ptls_iovec_t cid, int is_client, ptls_iovec_t salt, quicly_conn_t *conn);
 /**
  *
  */

--- a/t/test.c
+++ b/t/test.c
@@ -305,9 +305,9 @@ static void test_vector(void)
     ok(off == sizeof(datagram));
 
     /* decrypt */
-    const struct st_ptls_salt_t *salt = get_salt(QUICLY_PROTOCOL_VERSION_DRAFT29);
-    ret = setup_initial_encryption(&ptls_openssl_aes128gcmsha256, &ingress, &egress, packet.cid.dest.encrypted, 0,
-                                   ptls_iovec_init(salt->initial, sizeof(salt->initial)), NULL);
+    const quicly_salt_t *salt = quicly_get_salt(QUICLY_PROTOCOL_VERSION_DRAFT29);
+    ret = quicly_setup_initial_encryption(&ptls_openssl_aes128gcmsha256, &ingress, &egress, packet.cid.dest.encrypted, 0,
+                                          ptls_iovec_init(salt->initial, sizeof(salt->initial)), NULL);
     ok(ret == 0);
     ok(decrypt_packet(ingress.header_protection, aead_decrypt_fixed_key, ingress.aead, &next_expected_pn, &packet, &pn, &payload) ==
        0);


### PR DESCRIPTION
When crafting QUIC packets for testing, the hardest part is encrypting them. This PR adds `--encrypt-packet` option for the purpose.