### PR TITLE
[cli] split packet encrypt mode to key calculation and encryption

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -1179,6 +1179,11 @@ int quicly_is_destination(quicly_conn_t *conn, struct sockaddr *dest_addr, struc
  */
 const quicly_salt_t *quicly_get_salt(uint32_t protocol_version);
 /**
+ *
+ */
+int quicly_calc_initial_keys(ptls_cipher_suite_t *cs, uint8_t *ingress, uint8_t *egress, ptls_iovec_t cid, int is_client,
+                             ptls_iovec_t salt);
+/**
  * initializes the cipher contexts given cid and salt
  * @param conn maybe NULL when called by quicly_accept; if so, the default crypto engine will be used
  */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -279,11 +279,6 @@ typedef struct st_quicly_salt_t {
     } retry;
 } quicly_salt_t;
 
-typedef struct st_quicly_cipher_context_t {
-    ptls_aead_context_t *aead;
-    ptls_cipher_context_t *header_protection;
-} quicly_cipher_context_t;
-
 struct st_quicly_context_t {
     /**
      * tls context to use
@@ -1183,12 +1178,6 @@ const quicly_salt_t *quicly_get_salt(uint32_t protocol_version);
  */
 int quicly_calc_initial_keys(ptls_cipher_suite_t *cs, uint8_t *ingress, uint8_t *egress, ptls_iovec_t cid, int is_client,
                              ptls_iovec_t salt);
-/**
- * initializes the cipher contexts given cid and salt
- * @param conn maybe NULL when called by quicly_accept; if so, the default crypto engine will be used
- */
-int quicly_setup_initial_encryption(ptls_cipher_suite_t *cs, quicly_cipher_context_t *ingress, quicly_cipher_context_t *egress,
-                                    ptls_iovec_t cid, int is_client, ptls_iovec_t salt, quicly_conn_t *conn);
 /**
  *
  */

--- a/src/cli.c
+++ b/src/cli.c
@@ -1244,7 +1244,7 @@ static void usage(const char *cmd)
            "\n"
            "Miscellaneous Options:\n"
            "  -h                        print this help\n"
-           "  --print-initial-secret    print Initial client traffic secret given DCID\n"
+           "  --calc-initial-secret     calculate Initial client traffic secret given DCID\n"
            "  --encrypt-packet secret   given a packet without encryption applied, emits a\n"
            "                            packet encrypted using given traffic key\n"
            "\n",
@@ -1279,7 +1279,7 @@ static size_t decode_hexstring(uint8_t *dst, size_t capacity, const char *src)
     return dst_off;
 }
 
-static int cmd_print_initial_secret(const char *dcid_hex)
+static int cmd_calc_initial_secret(const char *dcid_hex)
 {
     uint8_t dcid[QUICLY_MAX_CID_LEN_V1], secret[PTLS_MAX_DIGEST_SIZE];
     size_t dcid_len;
@@ -1413,7 +1413,7 @@ int main(int argc, char **argv)
                                              {"disregard-app-limited", no_argument, NULL, 0},
                                              {"jumpstart-default", required_argument, NULL, 0},
                                              {"jumpstart-max", required_argument, NULL, 0},
-                                             {"print-initial-secret", required_argument, NULL, 0},
+                                             {"calc-initial-secret", required_argument, NULL, 0},
                                              {"encrypt-packet", required_argument, NULL, 0},
                                              {NULL}};
     while ((ch = getopt_long(argc, argv, "a:b:B:c:C:Dd:k:Ee:f:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvw:W:x:X:y:h", longopts,
@@ -1438,8 +1438,8 @@ int main(int argc, char **argv)
                     fprintf(stderr, "failed to parse max jumpstart size: %s\n", optarg);
                     exit(1);
                 }
-            } else if (strcmp(longopts[opt_index].name, "print-initial-secret") == 0) {
-                return cmd_print_initial_secret(optarg);
+            } else if (strcmp(longopts[opt_index].name, "calc-initial-secret") == 0) {
+                return cmd_calc_initial_secret(optarg);
             } else if (strcmp(longopts[opt_index].name, "encrypt-packet") == 0) {
                 return cmd_encrypt_packet(optarg);
             } else {

--- a/t/test.c
+++ b/t/test.c
@@ -306,8 +306,8 @@ static void test_vector(void)
 
     /* decrypt */
     const quicly_salt_t *salt = quicly_get_salt(QUICLY_PROTOCOL_VERSION_DRAFT29);
-    ret = quicly_setup_initial_encryption(&ptls_openssl_aes128gcmsha256, &ingress, &egress, packet.cid.dest.encrypted, 0,
-                                          ptls_iovec_init(salt->initial, sizeof(salt->initial)), NULL);
+    ret = setup_initial_encryption(&ptls_openssl_aes128gcmsha256, &ingress, &egress, packet.cid.dest.encrypted, 0,
+                                   ptls_iovec_init(salt->initial, sizeof(salt->initial)), NULL);
     ok(ret == 0);
     ok(decrypt_packet(ingress.header_protection, aead_decrypt_fixed_key, ingress.aead, &next_expected_pn, &packet, &pn, &payload) ==
        0);


### PR DESCRIPTION
#584 added `--encrypt-packet` option that encrypts a Initial packet using the DCID. This option helps building arbitrary packets but cannot be used for building Initial packets sent in response, as the initial DCID chosen by the client is replaced by the server chosen server CID.

This PR addresses this inflexibility, by splitting the traffic key calculation and packet encryption into two distinct options.

Users can now calculate the keys using the `--calc-initial-secret` option to obtain the initial traffic secrets (by supplying DCID as an argument), then use that key to encrypt Initial packets with the `--encrypt-packet` option, regardless of from whom or when that Initial is sent.

For the time being, only Initial packets can be encrypted using the `--encrypt-packet` option. However, with the new design, it would be trivial to enhance the command to support encryption _and decryption_ of _all types of packets_. FWIW, the traffic keys generated at later stages can be obtained and logged as events (see `-e`).