### PR TITLE
record number of packets sent / received per each QUIC packet type

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -486,9 +486,29 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t late_acked;                                                                                                       \
         /**                                                                                                                        \
-         * Total number of Initial and Handshake packets sent.                                                                     \
+         * Total number of Initial packets received.                                                                               \
          */                                                                                                                        \
-        uint64_t initial_handshake_sent;                                                                                           \
+        uint64_t initial_received;                                                                                                 \
+        /**                                                                                                                        \
+         * Total number of 0-RTT packets received.                                                                                 \
+         */                                                                                                                        \
+        uint64_t zero_rtt_received;                                                                                                \
+        /**                                                                                                                        \
+         * Total number of Handshake packets received.                                                                             \
+         */                                                                                                                        \
+        uint64_t handshake_received;                                                                                               \
+        /**                                                                                                                        \
+         * Total number of Initial packets sent.                                                                                   \
+         */                                                                                                                        \
+        uint64_t initial_sent;                                                                                                     \
+        /**                                                                                                                        \
+         * Total number of 0-RTT packets sent.                                                                                     \
+         */                                                                                                                        \
+        uint64_t zero_rtt_sent;                                                                                                    \
+        /**                                                                                                                        \
+         * Total number of Handshake packets sent.                                                                                 \
+         */                                                                                                                        \
+        uint64_t handshake_sent;                                                                                                   \
         /**                                                                                                                        \
          * Total number of packets received out of order.                                                                          \
          */                                                                                                                        \

--- a/src/cli.c
+++ b/src/cli.c
@@ -147,8 +147,10 @@ static void dump_stats(FILE *fp, quicly_conn_t *conn)
 
     quicly_get_stats(conn, &stats);
     fprintf(fp,
-            "packets-received: %" PRIu64 ", received-ecn-ect0: %" PRIu64 ", received-ecn-ect1: %" PRIu64
+            "packets-received: %" PRIu64 ", initial-packets-received: %" PRIu64 ", 0rtt-packets-received: %" PRIu64
+            ", handshake-packets-received: %" PRIu64 ", received-ecn-ect0: %" PRIu64 ", received-ecn-ect1: %" PRIu64
             ", received-ecn-ce: %" PRIu64 ", packets-decryption-failed: %" PRIu64 ", packets-sent: %" PRIu64
+            ", initial-packets-sent: %" PRIu64 ", 0rtt-packets-sent: %" PRIu64 ", handshake-packets-sent: %" PRIu64
             ", packets-lost: %" PRIu64 ", ack-received: %" PRIu64 ", ack-ecn-ect0: %" PRIu64 ", ack-ecn-ect1: %" PRIu64
             ", ack-ecn-ce: %" PRIu64 ", late-acked: %" PRIu64 ", bytes-received: %" PRIu64 ", bytes-sent: %" PRIu64
             ", paths-created %" PRIu64 ", paths-validated %" PRIu64 ", paths-promoted: %" PRIu64 ", srtt: %" PRIu32
@@ -156,15 +158,17 @@ static void dump_stats(FILE *fp, quicly_conn_t *conn)
             ", cwnd-exiting-slow-start: %" PRIu32 ", slow-start-exit-at: %" PRId64 ", jumpstart-cwnd: %" PRIu32
             ", jumpstart-exit: %" PRIu32 ", jumpstart-prev-rate: %" PRIu64 ", jumpstart-prev-rtt: %" PRIu32
             ", token-sent-rate: %" PRIu64 ", token-sent-rtt: %" PRIu32 "\n",
-            stats.num_packets.received, stats.num_packets.received_ecn_counts[0], stats.num_packets.received_ecn_counts[1],
-            stats.num_packets.received_ecn_counts[2], stats.num_packets.decryption_failed, stats.num_packets.sent,
-            stats.num_packets.lost, stats.num_packets.ack_received, stats.num_packets.acked_ecn_counts[0],
-            stats.num_packets.acked_ecn_counts[1], stats.num_packets.acked_ecn_counts[2], stats.num_packets.late_acked,
-            stats.num_bytes.received, stats.num_bytes.sent, stats.num_paths.created, stats.num_paths.validated,
-            stats.num_paths.promoted, stats.rtt.smoothed, stats.cc.num_loss_episodes, stats.cc.num_ecn_loss_episodes,
-            stats.delivery_rate.smoothed, stats.cc.cwnd, stats.cc.cwnd_exiting_slow_start, stats.cc.exit_slow_start_at,
-            stats.jumpstart.cwnd, stats.cc.cwnd_exiting_jumpstart, stats.jumpstart.prev_rate, stats.jumpstart.prev_rtt,
-            stats.token_sent.rate, stats.token_sent.rtt);
+            stats.num_packets.received, stats.num_packets.initial_received, stats.num_packets.zero_rtt_received,
+            stats.num_packets.handshake_received, stats.num_packets.received_ecn_counts[0],
+            stats.num_packets.received_ecn_counts[1], stats.num_packets.received_ecn_counts[2], stats.num_packets.decryption_failed,
+            stats.num_packets.sent, stats.num_packets.initial_sent, stats.num_packets.zero_rtt_sent,
+            stats.num_packets.handshake_sent, stats.num_packets.lost, stats.num_packets.ack_received,
+            stats.num_packets.acked_ecn_counts[0], stats.num_packets.acked_ecn_counts[1], stats.num_packets.acked_ecn_counts[2],
+            stats.num_packets.late_acked, stats.num_bytes.received, stats.num_bytes.sent, stats.num_paths.created,
+            stats.num_paths.validated, stats.num_paths.promoted, stats.rtt.smoothed, stats.cc.num_loss_episodes,
+            stats.cc.num_ecn_loss_episodes, stats.delivery_rate.smoothed, stats.cc.cwnd, stats.cc.cwnd_exiting_slow_start,
+            stats.cc.exit_slow_start_at, stats.jumpstart.cwnd, stats.cc.cwnd_exiting_jumpstart, stats.jumpstart.prev_rate,
+            stats.jumpstart.prev_rtt, stats.token_sent.rate, stats.token_sent.rtt);
 }
 
 static int validate_path(const char *path)


### PR DESCRIPTION
Number of 1-RTT packets sent / received is not recorded, but can be calculated by subtracting the numbers of other packet types from the total.