### PR TITLE
prevent hot loop when 0rtt is rejected

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1428,7 +1428,7 @@ static int scheduler_can_send(quicly_conn_t *conn)
     }
 
     /* scheduler would never have data to send, until application keys become available */
-    if (conn->application == NULL)
+    if (conn->application == NULL || conn->application->cipher.egress.key.aead == NULL)
         return 0;
 
     int conn_is_saturated = !(conn->egress.max_data.sent < conn->egress.max_data.permitted);


### PR DESCRIPTION
At the moment, `scheduler_can_send` returns `1` if 0-RTT is rejected and there is some application data to be sent.

This results in a hot loop in the applications, as `quicly_get_first_timeout` would request invocation of `quicly_send` at an earliest moment. Each time `quicly_send` is called, zero packets will be emitted, but `quicly_get_first_timeout` will continue requesting immediate invocation.