### PR TITLE
fix hot loops introduced by #554

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5553,7 +5553,8 @@ int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *s
      * more than one path at a time) */
     if (conn->egress.send_probe_at <= conn->stash.now) {
         for (s.path_index = 1; s.path_index < PTLS_ELEMENTSOF(conn->paths); ++s.path_index) {
-            if (conn->paths[s.path_index] == NULL || conn->stash.now < conn->paths[s.path_index]->path_challenge.send_at)
+            if (conn->paths[s.path_index] == NULL || !(conn->stash.now >= conn->paths[s.path_index]->path_challenge.send_at ||
+                                                       conn->paths[s.path_index]->path_response.send_))
                 continue;
             if (conn->paths[s.path_index]->path_challenge.num_sent > conn->super.ctx->max_probe_packets) {
                 delete_path(conn, s.path_index);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -6232,6 +6232,7 @@ static int handle_path_response_frame(quicly_conn_t *conn, struct st_quicly_hand
     if (ptls_mem_equal(path->path_challenge.data, frame.data, QUICLY_PATH_CHALLENGE_DATA_LEN)) {
         /* Path validation succeeded, stop sending PATH_CHALLENGEs. Active path might become changed in `quicly_receive`. */
         path->path_challenge.send_at = INT64_MAX;
+        recalc_send_probe_at(conn);
         conn->super.stats.num_paths.validated += 1;
     }
 


### PR DESCRIPTION
`quicly_send` has to make some progress when `quicly_get_first_timeout` says `quicly_send` has to be called.