### PR TITLE
FreeBSD compatibility

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -511,6 +511,8 @@ static void set_srcaddr(struct msghdr *mess, quicly_address_t *addr)
         memcpy(CMSG_DATA(cmsg), &info, sizeof(info));
         mess->msg_controllen += CMSG_SPACE(sizeof(info));
 #elif defined(IP_SENDSRCADDR)
+        /* TODO FreeBSD: skip setting IP_SENDSRCADDR if the socket is not bound to INADDR_ANY, as doing so results in sendmsg
+         * generating an error */
         cmsg->cmsg_level = IPPROTO_IP;
         cmsg->cmsg_type = IP_SENDSRCADDR;
         cmsg->cmsg_len = CMSG_LEN(sizeof(addr->sin.sin_addr));

--- a/src/cli.c
+++ b/src/cli.c
@@ -534,7 +534,7 @@ static void set_srcaddr(struct msghdr *mess, quicly_address_t *addr)
     }
 }
 
-static void set_ecn(struct msghdr *mess, int ecn)
+static void set_ecn(struct msghdr *mess, uint8_t ecn)
 {
     if (ecn == 0)
         return;

--- a/src/cli.c
+++ b/src/cli.c
@@ -513,9 +513,9 @@ static void set_srcaddr(struct msghdr *mess, quicly_address_t *addr)
 #elif defined(IP_SENDSRCADDR)
         cmsg->cmsg_level = IPPROTO_IP;
         cmsg->cmsg_type = IP_SENDSRCADDR;
-        cmsg->cmsg_len = CMSG_LEN(sizeof(addr->sin));
-        memcpy(CMSG_DATA(cmsg), &addr->sin, sizeof(addr->sin));
-        mess->msg_controllen += CMSG_SPACE(sizeof(addr->sin));
+        cmsg->cmsg_len = CMSG_LEN(sizeof(addr->sin.sin_addr));
+        memcpy(CMSG_DATA(cmsg), &addr->sin.sin_addr, sizeof(addr->sin.sin_addr));
+        mess->msg_controllen += CMSG_SPACE(sizeof(addr->sin.sin_addr));
 #else
         assert(!"FIXME");
 #endif

--- a/t/cplusplus.t
+++ b/t/cplusplus.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#! /usr/bin/env perl
 
 use strict;
 use warnings;


### PR DESCRIPTION
Adopts https://github.com/h2o/picotls/pull/557 as well as making fixes so that `cli` works on FreeBSD.

The tests still fail due to `cli` binding to 127.0.0.1 and the command using `IP_SENDSRCADDR` to set the source address of packets to 127.0.0.1.