### PR TITLE
stop sending Transport Parameters extension of multiple QUIC versions

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -436,7 +436,7 @@ struct st_quicly_conn_t {
         ptls_t *tls;
         ptls_handshake_properties_t handshake_properties;
         struct {
-            ptls_raw_extension_t ext[3];
+            ptls_raw_extension_t ext[2];
             ptls_buffer_t buf;
         } transport_params;
         unsigned async_in_progress : 1;
@@ -2789,12 +2789,9 @@ quicly_error_t quicly_connect(quicly_conn_t **_conn, quicly_context_t *ctx, cons
              NULL, NULL, conn->super.ctx->expand_client_hello ? conn->super.ctx->initial_egress_max_udp_payload_size : 0)) != 0)
         goto Exit;
     conn->crypto.transport_params.ext[0] =
-        (ptls_raw_extension_t){QUICLY_TLS_EXTENSION_TYPE_TRANSPORT_PARAMETERS_FINAL,
+        (ptls_raw_extension_t){get_transport_parameters_extension_id(conn->super.version),
                                {conn->crypto.transport_params.buf.base, conn->crypto.transport_params.buf.off}};
-    conn->crypto.transport_params.ext[1] =
-        (ptls_raw_extension_t){QUICLY_TLS_EXTENSION_TYPE_TRANSPORT_PARAMETERS_DRAFT,
-                               {conn->crypto.transport_params.buf.base, conn->crypto.transport_params.buf.off}};
-    conn->crypto.transport_params.ext[2] = (ptls_raw_extension_t){UINT16_MAX};
+    conn->crypto.transport_params.ext[1] = (ptls_raw_extension_t){UINT16_MAX};
     conn->crypto.handshake_properties.additional_extensions = conn->crypto.transport_params.ext;
     conn->crypto.handshake_properties.collected_extensions = client_collected_extensions;
 


### PR DESCRIPTION
Up until now, when running as a client, quicly has been sending two Transport Parameters extensions, one for QUIC version 1 and another for draft 27/29. The contents of the two extensions are identical, but the extension ID is different.

The assumption of doing so has been that QUIC stacks will pick the one having the extension ID corresponding to the QUIC version being selected.

But apparently, this approach fails when quicly tries to connect to mvfst. Fizz (mvfst) intentionally detects such use and refuses to complete the handshake; see https://github.com/facebook/mvfst/blob/b70f3d2a849690565513ee6cc6fe4a4f97688b34/quic/fizz/handshake/FizzTransportParameters.h#L164-L167.

While it is debatable which side is doing wrong, it would be easier for quicly to just stop sending a Transport Parameters extension of an ID other than the protocol version that quicly has chosen.