### PR TITLE
emit payload and the `wrote_all` flag as part of the `stream_send` probe

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2144,7 +2144,7 @@ static quicly_error_t apply_stream_frame(quicly_stream_t *stream, quicly_stream_
     quicly_error_t ret;
 
     QUICLY_PROBE(STREAM_RECEIVE, stream->conn, stream->conn->stash.now, stream, frame->offset, frame->data.base, frame->data.len,
-                 frame->is_fin);
+                 (int)frame->is_fin);
     QUICLY_LOG_CONN(stream_receive, stream->conn, {
         PTLS_LOG_ELEMENT_SIGNED(stream_id, stream->stream_id);
         PTLS_LOG_ELEMENT_UNSIGNED(off, frame->offset);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2143,11 +2143,13 @@ static quicly_error_t apply_stream_frame(quicly_stream_t *stream, quicly_stream_
 {
     quicly_error_t ret;
 
-    QUICLY_PROBE(STREAM_RECEIVE, stream->conn, stream->conn->stash.now, stream, frame->offset, frame->data.len);
+    QUICLY_PROBE(STREAM_RECEIVE, stream->conn, stream->conn->stash.now, stream, frame->offset, frame->data.base, frame->data.len,
+                 frame->is_fin);
     QUICLY_LOG_CONN(stream_receive, stream->conn, {
         PTLS_LOG_ELEMENT_SIGNED(stream_id, stream->stream_id);
         PTLS_LOG_ELEMENT_UNSIGNED(off, frame->offset);
-        PTLS_LOG_ELEMENT_UNSIGNED(len, frame->data.len);
+        PTLS_LOG_APPDATA_ELEMENT_HEXDUMP(data, frame->data.base, frame->data.len);
+        PTLS_LOG_ELEMENT_BOOL(is_fin, frame->is_fin);
     });
 
     if (quicly_recvstate_transfer_complete(&stream->recvstate))

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4361,12 +4361,13 @@ UpdateState:
     if (off < stream->sendstate.size_inflight)
         stream->conn->super.stats.num_bytes.stream_data_resent +=
             (stream->sendstate.size_inflight < off + len ? stream->sendstate.size_inflight : off + len) - off;
-    QUICLY_PROBE(STREAM_SEND, stream->conn, stream->conn->stash.now, stream, off, len, is_fin);
+    QUICLY_PROBE(STREAM_SEND, stream->conn, stream->conn->stash.now, stream, off, s->dst - len, len, is_fin, wrote_all);
     QUICLY_LOG_CONN(stream_send, stream->conn, {
         PTLS_LOG_ELEMENT_SIGNED(stream_id, stream->stream_id);
         PTLS_LOG_ELEMENT_UNSIGNED(off, off);
-        PTLS_LOG_ELEMENT_UNSIGNED(len, len);
+        PTLS_LOG_APPDATA_ELEMENT_HEXDUMP(data, s->dst - len, len);
         PTLS_LOG_ELEMENT_BOOL(is_fin, is_fin);
+        PTLS_LOG_ELEMENT_BOOL(wrote_all, wrote_all);
     });
 
     QUICLY_PROBE(QUICTRACE_SEND_STREAM, stream->conn, stream->conn->stash.now, stream, off, len, is_fin);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2184,14 +2184,15 @@ static quicly_error_t apply_stream_frame(quicly_stream_t *stream, quicly_stream_
 
     if (apply_len != 0 || quicly_recvstate_transfer_complete(&stream->recvstate)) {
         uint64_t buf_offset = frame->offset + frame->data.len - apply_len - stream->recvstate.data_off;
-        const void *apply_src = frame->data.base + frame->data.len - apply_len;
-        QUICLY_PROBE(STREAM_ON_RECEIVE, stream->conn, stream->conn->stash.now, stream, (size_t)buf_offset, apply_src, apply_len);
+        size_t apply_off = frame->data.len - apply_len;
+        QUICLY_PROBE(STREAM_ON_RECEIVE, stream->conn, stream->conn->stash.now, stream, (size_t)buf_offset, apply_off, apply_len);
         QUICLY_LOG_CONN(stream_on_receive, stream->conn, {
             PTLS_LOG_ELEMENT_SIGNED(stream_id, stream->stream_id);
-            PTLS_LOG_ELEMENT_UNSIGNED(off, buf_offset);
-            PTLS_LOG_APPDATA_ELEMENT_HEXDUMP(src, apply_src, apply_len);
+            PTLS_LOG_ELEMENT_UNSIGNED(buf_off, buf_offset);
+            PTLS_LOG_ELEMENT_UNSIGNED(apply_off, apply_off);
+            PTLS_LOG_ELEMENT_UNSIGNED(apply_len, apply_len);
         });
-        stream->callbacks->on_receive(stream, (size_t)buf_offset, apply_src, apply_len);
+        stream->callbacks->on_receive(stream, (size_t)buf_offset, frame->data.base + apply_off, apply_len);
         if (stream->conn->super.state >= QUICLY_STATE_CLOSING)
             return QUICLY_ERROR_IS_CLOSING;
     }

--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -251,7 +251,7 @@ def handle_stream_receive(event):
     return {
         "frame_type": label,
         "stream_id": event["stream-id"],
-        "length": event["len"],
+        "length": len(event["data"]) / 2 if "data" in event else event["data-len"],
         "offset": event["off"]
     }
 
@@ -260,7 +260,7 @@ def handle_stream_send(event):
     return {
         "frame_type": label,
         "stream_id": event["stream-id"],
-        "length": event["len"],
+        "length": len(event["data"]) / 2 if "data" in event else event["data-len"],
         "offset": event["off"]
     }
 

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -88,8 +88,8 @@ provider quicly {
     probe application_close_send(struct st_quicly_conn_t *conn, int64_t at, uint64_t error_code, const char *reason_phrase);
     probe application_close_receive(struct st_quicly_conn_t *conn, int64_t at, uint64_t error_code, const char *reason_phrase);
 
-    probe stream_send(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off, size_t len,
-                      int is_fin);
+    probe stream_send(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off, const void *data,
+                      size_t data_len, int is_fin, int wrote_all);
     probe stream_receive(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off, size_t len);
     probe stream_acked(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t off, size_t len);
     probe stream_lost(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t off, size_t len);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -159,8 +159,8 @@ provider quicly {
     probe stream_on_send_emit(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, size_t off,
                               size_t capacity);
     probe stream_on_send_stop(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, int64_t err);
-    probe stream_on_receive(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, size_t off,
-                            const void *src, size_t src_len);
+    probe stream_on_receive(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, size_t buf_off,
+                            size_t apply_off, size_t apply_len);
     probe stream_on_receive_reset(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, int64_t err);
 
     probe enter_cc_limited(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);

--- a/quicly-probes.d
+++ b/quicly-probes.d
@@ -90,7 +90,8 @@ provider quicly {
 
     probe stream_send(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off, const void *data,
                       size_t data_len, int is_fin, int wrote_all);
-    probe stream_receive(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off, size_t len);
+    probe stream_receive(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stream_t *stream, uint64_t off,
+                         const void *data, size_t data_len, int is_fin);
     probe stream_acked(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t off, size_t len);
     probe stream_lost(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t off, size_t len);
 


### PR DESCRIPTION
Doing so helps debugging (note: we already have knobs to observe ingress payload).