### PR TITLE
Fix error types missed in int -> quicly_error_t refactor (compile fail in my env)

### DIFF
--- a/examples/echo.c
+++ b/examples/echo.c
@@ -115,13 +115,13 @@ static int forward_stdin(quicly_conn_t *conn)
     }
 }
 
-static void on_stop_sending(quicly_stream_t *stream, int err)
+static void on_stop_sending(quicly_stream_t *stream, quicly_error_t err)
 {
     fprintf(stderr, "received STOP_SENDING: %" PRIu16 "\n", QUICLY_ERROR_GET_ERROR_CODE(err));
     quicly_close(stream->conn, QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(0), "");
 }
 
-static void on_receive_reset(quicly_stream_t *stream, int err)
+static void on_receive_reset(quicly_stream_t *stream, quicly_error_t err)
 {
     fprintf(stderr, "received RESET_STREAM: %" PRIu16 "\n", QUICLY_ERROR_GET_ERROR_CODE(err));
     quicly_close(stream->conn, QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(0), "");
@@ -277,7 +277,7 @@ static int run_loop(int fd, quicly_conn_t *client)
     return 0;
 }
 
-static int on_stream_open(quicly_stream_open_t *self, quicly_stream_t *stream)
+static quicly_error_t on_stream_open(quicly_stream_open_t *self, quicly_stream_t *stream)
 {
     static const quicly_stream_callbacks_t stream_callbacks = {
         quicly_streambuf_destroy, quicly_streambuf_egress_shift, quicly_streambuf_egress_emit, on_stop_sending, on_receive,

--- a/t/simulator.c
+++ b/t/simulator.c
@@ -404,7 +404,7 @@ static int64_t quic_now_cb(quicly_now_t *self)
     return (int64_t)(now * 1000);
 }
 
-static void stream_destroy_cb(quicly_stream_t *stream, int err)
+static void stream_destroy_cb(quicly_stream_t *stream, quicly_error_t err)
 {
 }
 
@@ -419,7 +419,7 @@ static void stream_egress_emit_cb(quicly_stream_t *stream, size_t off, void *dst
     *wrote_all = 0;
 }
 
-static void stream_on_stop_sending_cb(quicly_stream_t *stream, int err)
+static void stream_on_stop_sending_cb(quicly_stream_t *stream, quicly_error_t err)
 {
     assert(!"unexpected");
 }
@@ -433,12 +433,12 @@ static void stream_on_receive_cb(quicly_stream_t *stream, size_t off, const void
         quicly_stream_sync_recvbuf(stream, stream->recvstate.received.ranges[0].end - stream->recvstate.data_off);
 }
 
-static void stream_on_receive_reset_cb(quicly_stream_t *stream, int err)
+static void stream_on_receive_reset_cb(quicly_stream_t *stream, quicly_error_t err)
 {
     assert(!"unexpected");
 }
 
-static int stream_open_cb(quicly_stream_open_t *self, quicly_stream_t *stream)
+static quicly_error_t stream_open_cb(quicly_stream_open_t *self, quicly_stream_t *stream)
 {
     static const quicly_stream_callbacks_t stream_callbacks = {stream_destroy_cb,     stream_egress_shift_cb,
                                                                stream_egress_emit_cb, stream_on_stop_sending_cb,


### PR DESCRIPTION
The error type refactor left behind some in the sample code, and it does not compile in my environment (Mac OS X, clang).