### PR TITLE
Generate payload for multiple datagrams at once

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4206,42 +4206,171 @@ int quicly_can_send_data(quicly_conn_t *conn, quicly_send_context_t *s)
     return s->num_datagrams < s->max_datagrams;
 }
 
-/**
- * If necessary, changes the frame representation from one without length field to one that has if necessary. Or, as an alternative,
- * prepends PADDING frames. Upon return, `dst` points to the end of the frame being built. `*len`, `*wrote_all`, `*frame_type_at`
- * are also updated reflecting their values post-adjustment.
- */
-static inline void adjust_stream_frame_layout(uint8_t **dst, uint8_t *const dst_end, size_t *len, int *wrote_all,
-                                              uint8_t **frame_at)
+static void commit_stream_frame(quicly_stream_t *stream, quicly_sent_t *sent, uint64_t off, const uint8_t *data, size_t len,
+                                int wrote_all, int is_fin)
 {
-    size_t space_left = (dst_end - *dst) - *len, len_of_len = quicly_encodev_capacity(*len);
-
-    if (**frame_at == QUICLY_FRAME_TYPE_CRYPTO) {
-        /* CRYPTO frame: adjust payload length to make space for the length field, if necessary. */
-        if (space_left < len_of_len) {
-            *len = dst_end - *dst - len_of_len;
-            *wrote_all = 0;
-        }
+    /* update and log per-frame stats */
+    if (stream->stream_id < 0) {
+        ++stream->conn->super.stats.num_frames_sent.crypto;
     } else {
-        /* STREAM frame: insert length if space can be left for more frames. Otherwise, retain STREAM frame header omitting the
-         * length field, prepending PADDING if necessary. */
-        if (space_left <= len_of_len) {
-            if (space_left != 0) {
-                memmove(*frame_at + space_left, *frame_at, *dst + *len - *frame_at);
-                memset(*frame_at, QUICLY_FRAME_TYPE_PADDING, space_left);
-                *dst += space_left;
-                *frame_at += space_left;
-            }
-            *dst += *len;
-            return;
-        }
-        **frame_at |= QUICLY_FRAME_TYPE_STREAM_BIT_LEN;
+        ++stream->conn->super.stats.num_frames_sent.stream;
+    }
+    QUICLY_PROBE(STREAM_SEND, stream->conn, stream->conn->stash.now, stream, off, data, len, is_fin, wrote_all);
+    QUICLY_LOG_CONN(stream_send, stream->conn, {
+        PTLS_LOG_ELEMENT_SIGNED(stream_id, stream->stream_id);
+        PTLS_LOG_ELEMENT_UNSIGNED(off, off);
+        PTLS_LOG_APPDATA_ELEMENT_HEXDUMP(data, data, len);
+        PTLS_LOG_ELEMENT_BOOL(is_fin, is_fin);
+        PTLS_LOG_ELEMENT_BOOL(wrote_all, wrote_all);
+    });
+    QUICLY_PROBE(QUICTRACE_SEND_STREAM, stream->conn, stream->conn->stash.now, stream, off, len, is_fin);
+
+    /* setup sentmap */
+    sent->data.stream.stream_id = stream->stream_id;
+    sent->data.stream.args.start = off;
+    sent->data.stream.args.end = off + len + is_fin;
+}
+
+static quicly_error_t update_stream_sendstate(quicly_stream_t *stream, uint64_t off, size_t len, int is_fin, int wrote_all)
+{
+    quicly_error_t ret;
+
+    stream->conn->super.stats.num_bytes.stream_data_sent += len;
+    if (off < stream->sendstate.size_inflight)
+        stream->conn->super.stats.num_bytes.stream_data_resent +=
+            (stream->sendstate.size_inflight < off + len ? stream->sendstate.size_inflight : off + len) - off;
+
+    if (stream->sendstate.size_inflight < off + len) {
+        if (stream->stream_id >= 0)
+            stream->conn->egress.max_data.sent += off + len - stream->sendstate.size_inflight;
+        stream->sendstate.size_inflight = off + len;
+    }
+    if ((ret = quicly_ranges_subtract(&stream->sendstate.pending, off, off + len + is_fin)) != 0)
+        return ret;
+    if (wrote_all) {
+        if ((ret = quicly_ranges_subtract(&stream->sendstate.pending, stream->sendstate.size_inflight, UINT64_MAX)) != 0)
+            return ret;
+    }
+
+    return ret;
+}
+
+/**
+ * Assuming `dst` points to where the Length field of a CRYPTO frame should be inserted, inserts the field, changing `*len` and
+ * `*wrote_all` if necessary. Returns the end of the CRYPTO frame being adjusted.
+ */
+static uint8_t *adjust_crypto_frame_layout(uint8_t *dst, uint8_t *const dst_end, size_t *len, int *wrote_all)
+{
+    size_t space_left = (dst_end - dst) - *len, len_of_len = quicly_encodev_capacity(*len);
+
+    if (space_left < len_of_len) {
+        *len = dst_end - dst - len_of_len;
+        *wrote_all = 0;
     }
 
     /* insert length before payload of `*len` bytes */
-    memmove(*dst + len_of_len, *dst, *len);
-    *dst = quicly_encodev(*dst, *len);
-    *dst += *len;
+    memmove(dst + len_of_len, dst, *len);
+    dst = quicly_encodev(dst, *len);
+    dst += *len;
+
+    return dst;
+}
+
+/**
+ * Assuming that `header` and `header_len` point to a STREAM frame without a Length field, either inserts a Length field or prepends
+ * a PADDING frame if necessary. Returns the size increase of the header.
+ */
+static size_t adjust_last_stream_frame(uint8_t *header, size_t header_len, uint16_t payload_size, size_t space_left,
+                                       int move_payload)
+{
+    if (space_left == 0)
+        return 0;
+
+    size_t len_len = quicly_encodev_capacity(payload_size);
+
+    if (space_left <= len_len) {
+        /* prepend PADDING, as there is not enough space to insert the length field */
+        if (move_payload)
+            memmove(header + header_len + space_left, header + header_len, payload_size);
+        memmove(header + space_left, header, header_len);
+        memset(header, QUICLY_FRAME_TYPE_PADDING, space_left);
+        return space_left;
+    }
+
+    /* add the Length field */
+    if (move_payload)
+        memmove(header + header_len + len_len, header + header_len, payload_size);
+    header[0] |= QUICLY_FRAME_TYPE_STREAM_BIT_LEN;
+    quicly_encodev(header + header_len, payload_size);
+    return len_len;
+}
+
+/**
+ * Adjusts the STREAM frame layout. If given payload expands beyond the end of the current datagram, scatters the payload to the
+ * correct locations assuming that more datagrams would be built adjacently. STREAM headers are prepended to the scattered payload.
+ * Returns the end of the last stream frame.
+ */
+static uint8_t *scatter_stream_payload(quicly_send_context_t *s, uint16_t datagram_size, quicly_stream_id_t stream_id,
+                                       uint64_t stream_start, uint8_t *payload_start, size_t *len, int *wrote_all,
+                                       uint16_t *scattered_payload_lengths)
+{
+    /* fast path when no expansion is required; adjust the layout and return */
+    if (*len <= s->dst_end - payload_start) {
+        size_t space_left = s->dst_end - (payload_start + *len);
+        size_t add_space = adjust_last_stream_frame(s->dst, payload_start - s->dst, *len, space_left, 1);
+        payload_start += add_space;
+        scattered_payload_lengths[0] = 0;
+        return payload_start + *len;
+    }
+
+    struct {
+        uint8_t len;
+        uint8_t bytes[1 + 8 + 8 + 2];
+    } frame_headers[10];
+    size_t num_scattered, stream_offset = stream_start + (s->dst_end - payload_start), stream_end = stream_start + *len,
+                          datagram_prefix_len = 1 /* header byte */ + s->dcid->len + QUICLY_SEND_PN_SIZE,
+                          datagram_capacity = datagram_size - datagram_prefix_len - s->current.cipher->aead->algo->tag_size;
+
+    /* build frame headers for the extra datagrams, calculating their offsets */
+    for (num_scattered = 0; num_scattered < PTLS_ELEMENTSOF(frame_headers) && stream_offset < stream_end; ++num_scattered) {
+        uint8_t *hp = frame_headers[num_scattered].bytes;
+        *hp++ = QUICLY_FRAME_TYPE_STREAM_BASE | QUICLY_FRAME_TYPE_STREAM_BIT_OFF;
+        hp = quicly_encodev(hp, stream_id);
+        hp = quicly_encodev(hp, stream_offset);
+        frame_headers[num_scattered].len = hp - frame_headers[num_scattered].bytes;
+        scattered_payload_lengths[num_scattered] = datagram_capacity - frame_headers[num_scattered].len;
+        if (scattered_payload_lengths[num_scattered] > stream_end - stream_offset)
+            scattered_payload_lengths[num_scattered] = stream_end - stream_offset;
+        stream_offset += scattered_payload_lengths[num_scattered];
+    }
+    scattered_payload_lengths[num_scattered] = 0;
+
+    { /* adjust the encoding of the last frame */
+        size_t space_left =
+            datagram_capacity - (frame_headers[num_scattered - 1].len + scattered_payload_lengths[num_scattered - 1]);
+        frame_headers[num_scattered - 1].len +=
+            adjust_last_stream_frame(frame_headers[num_scattered - 1].bytes, frame_headers[num_scattered - 1].len,
+                                     scattered_payload_lengths[num_scattered - 1], space_left, 0);
+    }
+
+    /* adjust out parameters, move stream payload, and write frame headers for the expanded datagrams */
+    if (stream_offset - stream_start < *len) {
+        *wrote_all = 0;
+        *len = stream_offset - stream_start;
+    }
+
+    uint8_t *extra_packets_from = s->dst_end + s->current.cipher->aead->algo->tag_size;
+
+    /* move stream payload and write headers */
+    for (size_t i = num_scattered - 1; i != SIZE_MAX; --i) {
+        stream_offset -= scattered_payload_lengths[i];
+        memmove(extra_packets_from + datagram_size * i + datagram_prefix_len + frame_headers[i].len,
+                payload_start + stream_offset - stream_start, scattered_payload_lengths[i]);
+        memcpy(extra_packets_from + datagram_size * i + datagram_prefix_len, frame_headers[i].bytes, frame_headers[i].len);
+    }
+
+    return extra_packets_from + datagram_size * (num_scattered - 1) + datagram_prefix_len + frame_headers[num_scattered - 1].len +
+           scattered_payload_lengths[num_scattered - 1];
 }
 
 quicly_error_t quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t *s)
@@ -4250,8 +4379,9 @@ quicly_error_t quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t
     quicly_sent_t *sent;
     uint8_t *dst; /* this pointer points to the current write position within the frame being built, while `s->dst` points to the
                    * beginning of the frame. */
-    size_t len;
+    size_t len, extra_datagrams = 0;
     int wrote_all, is_fin;
+    uint16_t scattered_payload_lengths[10];
     quicly_error_t ret;
 
     /* write frame type, stream_id and offset, calculate capacity (and store that in `len`) */
@@ -4285,10 +4415,9 @@ quicly_error_t quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t
             }
             memcpy(s->dst, header, hp - header);
             s->dst += hp - header;
-            len = 0;
-            wrote_all = 1;
-            is_fin = 1;
-            goto UpdateState;
+            commit_stream_frame(stream, sent, off, s->dst, 0, 1, 1);
+            update_stream_sendstate(stream, off, 0, 1, 1);
+            return 0;
         }
         if ((ret = allocate_ack_eliciting_frame(stream->conn, s, hp - header + 1, &sent, on_ack_stream)) != 0)
             return ret;
@@ -4296,6 +4425,14 @@ quicly_error_t quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t
         memcpy(dst, header, hp - header);
         dst += hp - header;
         len = s->dst_end - dst;
+        /* if sending in 1-RTT, generate stream payload past the end of current datagram and move them to build datagrams */
+        if (get_epoch(s->current.first_byte) == QUICLY_EPOCH_1RTT) {
+            size_t max_udp_payload_size = stream->conn->egress.max_udp_payload_size;
+            extra_datagrams = (s->payload_buf.end - (s->dst_end + s->target.cipher->aead->algo->tag_size)) / max_udp_payload_size;
+            if (extra_datagrams > PTLS_ELEMENTSOF(scattered_payload_lengths) - 1)
+                extra_datagrams = PTLS_ELEMENTSOF(scattered_payload_lengths) - 1;
+            len += (max_udp_payload_size - (1 + s->dcid->len + QUICLY_SEND_PN_SIZE + 2)) * extra_datagrams;
+        }
         /* cap by max_stream_data */
         if (off + len > stream->_send_aux.max_stream_data)
             len = stream->_send_aux.max_stream_data - off;
@@ -4339,58 +4476,55 @@ quicly_error_t quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t
     }
     assert(len != 0);
 
-    adjust_stream_frame_layout(&dst, s->dst_end, &len, &wrote_all, &s->dst);
-
-    /* determine if the frame incorporates FIN */
-    if (off + len == stream->sendstate.final_size) {
-        assert(!quicly_sendstate_is_open(&stream->sendstate));
-        assert(s->dst != NULL);
-        is_fin = 1;
-        *s->dst |= QUICLY_FRAME_TYPE_STREAM_BIT_FIN;
-    } else {
-        is_fin = 0;
-    }
-
-    /* update s->dst now that frame construction is complete */
-    s->dst = dst;
-
-UpdateState:
+    /* Adjust the frame layout and commit. */
     if (stream->stream_id < 0) {
-        ++stream->conn->super.stats.num_frames_sent.crypto;
+        /* CRYPTO frame */
+        s->dst = adjust_crypto_frame_layout(dst, s->dst_end, &len, &wrote_all);
+        is_fin = 0;
     } else {
-        ++stream->conn->super.stats.num_frames_sent.stream;
+        /* STREAM frame; if the generated payload extends beyond the end of the current datagram,
+         * 1. Scatter the output to the payload position of the following datagrams for which the packet headers are yet to be
+         *    generated, as well as having the STREAM frame headers generated.
+         * 2. Repeatedly commit the packets until we reach the last one, which might not be full-sized. */
+        size_t capacity_of_first_packet = s->dst_end - dst;
+        dst = scatter_stream_payload(s, stream->conn->egress.max_udp_payload_size, stream->stream_id, off, dst, &len, &wrote_all,
+                                     scattered_payload_lengths);
+        uint64_t off_of_packet = off;
+        if (scattered_payload_lengths[0] > 0) {
+            s->dst = s->dst_end;
+            commit_stream_frame(stream, sent, off_of_packet, s->dst - capacity_of_first_packet, capacity_of_first_packet, 0, 0);
+            off_of_packet += capacity_of_first_packet;
+            for (size_t i = 0; scattered_payload_lengths[i + 1] != 0; ++i) {
+                if ((ret = allocate_ack_eliciting_frame(stream->conn, s, 1, &sent, on_ack_stream)) != 0)
+                    return ret;
+                assert(s->dst == s->dst_payload_from && "scatter does not expect other frames");
+                commit_stream_frame(stream, sent, off_of_packet, s->dst, scattered_payload_lengths[i], 0, 0);
+                off_of_packet += scattered_payload_lengths[i];
+                s->dst = s->dst_end;
+            }
+            if ((ret = allocate_ack_eliciting_frame(stream->conn, s, 1, &sent, on_ack_stream)) != 0)
+                return ret;
+            assert(s->dst == s->dst_payload_from && "scatter does not expect other frames");
+        }
+        /* determine if the frame incorporates FIN, set flags as necessary */
+        if (off + len == stream->sendstate.final_size) {
+            assert(!quicly_sendstate_is_open(&stream->sendstate));
+            is_fin = 1;
+            while (s->dst == QUICLY_FRAME_TYPE_PADDING)
+                ;
+            assert((*s->dst & ~QUICLY_FRAME_TYPE_STREAM_BITS) == QUICLY_FRAME_TYPE_STREAM_BASE);
+            *s->dst |= QUICLY_FRAME_TYPE_STREAM_BIT_FIN;
+        } else {
+            is_fin = 0;
+        }
+        /* commit the last STREAM frame (without committing the packet, as there could be space left) */
+        s->dst = dst;
+        size_t data_len = (off + len) - off_of_packet;
+        commit_stream_frame(stream, sent, off_of_packet, dst - data_len, data_len, wrote_all, is_fin);
     }
-    stream->conn->super.stats.num_bytes.stream_data_sent += len;
-    if (off < stream->sendstate.size_inflight)
-        stream->conn->super.stats.num_bytes.stream_data_resent +=
-            (stream->sendstate.size_inflight < off + len ? stream->sendstate.size_inflight : off + len) - off;
-    QUICLY_PROBE(STREAM_SEND, stream->conn, stream->conn->stash.now, stream, off, s->dst - len, len, is_fin, wrote_all);
-    QUICLY_LOG_CONN(stream_send, stream->conn, {
-        PTLS_LOG_ELEMENT_SIGNED(stream_id, stream->stream_id);
-        PTLS_LOG_ELEMENT_UNSIGNED(off, off);
-        PTLS_LOG_APPDATA_ELEMENT_HEXDUMP(data, s->dst - len, len);
-        PTLS_LOG_ELEMENT_BOOL(is_fin, is_fin);
-        PTLS_LOG_ELEMENT_BOOL(wrote_all, wrote_all);
-    });
 
-    QUICLY_PROBE(QUICTRACE_SEND_STREAM, stream->conn, stream->conn->stash.now, stream, off, len, is_fin);
-    /* update sendstate (and also MAX_DATA counter) */
-    if (stream->sendstate.size_inflight < off + len) {
-        if (stream->stream_id >= 0)
-            stream->conn->egress.max_data.sent += off + len - stream->sendstate.size_inflight;
-        stream->sendstate.size_inflight = off + len;
-    }
-    if ((ret = quicly_ranges_subtract(&stream->sendstate.pending, off, off + len + is_fin)) != 0)
-        return ret;
-    if (wrote_all) {
-        if ((ret = quicly_ranges_subtract(&stream->sendstate.pending, stream->sendstate.size_inflight, UINT64_MAX)) != 0)
-            return ret;
-    }
-
-    /* setup sentmap */
-    sent->data.stream.stream_id = stream->stream_id;
-    sent->data.stream.args.start = off;
-    sent->data.stream.args.end = off + len + is_fin;
+    /* update stream sendstate */
+    update_stream_sendstate(stream, off, len, is_fin, wrote_all);
 
     return 0;
 }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -4482,6 +4482,7 @@ quicly_error_t quicly_send_stream(quicly_stream_t *stream, quicly_send_context_t
     if (stream->stream_id < 0) {
         /* CRYPTO frame */
         s->dst = adjust_crypto_frame_layout(dst, s->dst_end, &len, &wrote_all);
+        commit_stream_frame(stream, sent, off, s->dst - len, len, wrote_all, 0);
         is_fin = 0;
     } else {
         /* STREAM frame; if the generated payload extends beyond the end of the current datagram,

--- a/t/test.c
+++ b/t/test.c
@@ -152,68 +152,125 @@ static void test_error_codes(void)
     ok(!QUICLY_ERROR_IS_QUIC_APPLICATION(a));
 }
 
-static void test_adjust_stream_frame_layout(void)
+static void test_adjust_crypto_frame_layout(void)
 {
-#define TEST(_is_crypto, _capacity, check)                                                                                         \
+#define TEST(_capacity, check)                                                                                                     \
     do {                                                                                                                           \
-        uint8_t buf[] = {0xff, 0x04, 'h', 'e', 'l', 'l', 'o', 0, 0, 0};                                                            \
-        uint8_t *dst = buf + 2, *const dst_end = buf + _capacity, *frame_at = buf;                                                 \
+        uint8_t buf[] = {0x06, 0x04, 'h', 'e', 'l', 'l', 'o', 0, 0, 0};                                                            \
+        uint8_t *dst = buf + 2, *const dst_end = buf + _capacity;                                                                  \
         size_t len = 5;                                                                                                            \
         int wrote_all = 1;                                                                                                         \
-        buf[0] = _is_crypto ? 0x06 : 0x08;                                                                                         \
-        adjust_stream_frame_layout(&dst, dst_end, &len, &wrote_all, &frame_at);                                                    \
+        dst = adjust_crypto_frame_layout(dst, dst_end, &len, &wrote_all);                                                          \
         do {                                                                                                                       \
             check                                                                                                                  \
         } while (0);                                                                                                               \
     } while (0);
 
     /* test CRYPTO frames that fit and don't when length is inserted */
-    TEST(1, 10, {
+    TEST(10, {
         ok(dst == buf + 8);
         ok(len == 5);
         ok(wrote_all);
-        ok(frame_at == buf);
         ok(memcmp(buf, "\x06\x04\x05hello", 8) == 0);
     });
-    TEST(1, 8, {
+    TEST(18, {
         ok(dst == buf + 8);
         ok(len == 5);
         ok(wrote_all);
-        ok(frame_at == buf);
         ok(memcmp(buf, "\x06\x04\x05hello", 8) == 0);
     });
-    TEST(1, 7, {
+    TEST(7, {
         ok(dst == buf + 7);
         ok(len == 4);
         ok(!wrote_all);
-        ok(frame_at == buf);
         ok(memcmp(buf, "\x06\x04\x04hell", 7) == 0);
     });
+#undef TEST
+}
+
+static void test_adjust_last_stream_frame(void)
+{
+#define TEST(space_left, check)                                                                                                    \
+    do {                                                                                                                           \
+        uint8_t buf[] = {0x08, 0x04, 'h', 'e', 'l', 'l', 'o', 0, 0, 0};                                                            \
+        size_t increase = adjust_last_stream_frame(buf, 2, 5, space_left, 1);                                                      \
+        do {                                                                                                                       \
+            check                                                                                                                  \
+        } while (0);                                                                                                               \
+    } while (0)
 
     /* test STREAM frames */
-    TEST(0, 9, {
-        ok(dst == buf + 8);
-        ok(len == 5);
-        ok(wrote_all);
-        ok(frame_at == buf);
-        ok(memcmp(buf, "\x0a\x04\x05hello", 8) == 0);
-    });
-    TEST(0, 8, {
-        ok(dst == buf + 8);
-        ok(len == 5);
-        ok(wrote_all);
-        ok(frame_at == buf + 1);
-        ok(memcmp(buf, "\x00\x08\x04hello", 8) == 0);
-    });
-    TEST(0, 7, {
-        ok(dst == buf + 7);
-        ok(len == 5);
-        ok(wrote_all);
-        ok(frame_at == buf);
+    TEST(0, {
+        ok(increase == 0);
         ok(memcmp(buf, "\x08\x04hello", 7) == 0);
+    });
+    TEST(1, {
+        ok(increase == 1);
+        ok(memcmp(buf, "\x00\x08\x04hello", 7) == 0);
+    });
+    TEST(2, {
+        ok(increase == 1);
+        ok(memcmp(buf, "\x0a\x04\x05hello", 7) == 0);
     });
 
 #undef TEST
+}
+
+static void test_scatter_stream_payload(void)
+{
+#define INPUT                                                                                                                      \
+    "\x08\x04"                                                                                                                     \
+    "Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she "  \
+    "had peeped into the book her sister was reading, but it had no pictures or conversations in it"
+
+    uint8_t buf[sizeof(INPUT) - 1];
+
+    quicly_cid_t dcid = {.cid = {'C', 'I', 'D'}, .len = 3};
+    ptls_aead_context_t aead = {.algo = &ptls_openssl_aes128gcm};
+    struct st_quicly_cipher_context_t cipher = {.aead = &aead};
+
+    {
+        static const uint16_t datagram_size = 38; /* 1 + 3 (dcid_len) + 2 (pn_size) + 16 (payload) + 16 (AEAD tag) */
+        memcpy(buf, INPUT, sizeof(INPUT) - 1);
+        quicly_send_context_t s = {
+            .dcid = &dcid,
+            .current.cipher = &cipher,
+            .dst = buf,
+            .dst_end = buf + 8,
+        };
+        size_t len = 34; /* 6 (current), 13+13+2 (extra) */
+        int wrote_all = 1;
+        uint16_t scattered_payload_lengths[11] = {99, 99, 99, 99, 99};
+        uint8_t *end_of_last_frame =
+            scatter_stream_payload(&s, datagram_size, 4, 0, buf + 2, &len, &wrote_all, scattered_payload_lengths);
+
+        ok(len == 34);
+        ok(wrote_all == 1);
+        ok(scattered_payload_lengths[0] == 13);
+        ok(scattered_payload_lengths[1] == 13);
+        ok(scattered_payload_lengths[2] == 2);
+        ok(scattered_payload_lengths[3] == 0);
+        ok(memcmp(buf,
+                  "\x08\x04"
+                  "Alice ",
+                  8) == 0);
+        size_t payload_gap = aead.algo->tag_size + 1 + dcid.len + QUICLY_SEND_PN_SIZE;
+        ok(memcmp(buf + 8 + payload_gap,
+                  "\x0c\x04\x06"
+                  "was beginning",
+                  16) == 0);
+        ok(memcmp(buf + 24 + payload_gap * 2,
+                  "\x0c\x04\x13"
+                  " to get very ",
+                  16) == 0);
+        ok(memcmp(buf + 40 + payload_gap * 3,
+                  "\x0e\x04\x20\x02"
+                  "ti",
+                  6) == 0);
+        ok(buf + 40 + payload_gap * 3 + 6 == end_of_last_frame);
+    }
+
+#undef INPUT
 }
 
 static int64_t get_now_cb(quicly_now_t *self)
@@ -937,7 +994,9 @@ int main(int argc, char **argv)
     subtest("pacer", test_pacer);
     subtest("sentmap", test_sentmap);
     subtest("loss", test_loss);
-    subtest("adjust-stream-frame-layout", test_adjust_stream_frame_layout);
+    subtest("adjust-crypto-frame-layout", test_adjust_crypto_frame_layout);
+    subtest("adjust-last-stream-frame", test_adjust_last_stream_frame);
+    subtest("scatter-stream-payload", test_scatter_stream_payload);
     subtest("test-vector", test_vector);
     subtest("test-retry-aead", test_retry_aead);
     subtest("transport-parameters", test_transport_parameters);


### PR DESCRIPTION
Up until now, `on_send_emit` callback has been invoked for each STREAM frame being built. This has become a bottleneck, due to two reasons:
* Applications might have high static cost for generating each payload. For examples, they might be calling `pread` for each call to `on_send_emit`.
* Running Accounting and prioritization logic for each packet being built is also expensive.

To mitigate the issuse, this PR refactors the `quicly_send_stream` function to generate STREAM frames for as much as 10 packets at once.

This PR calls the `on_send_emit` callback that already exists, and scatters the data being read by calling `memmove`.

There are two alternatives that we might consider:
* Introduce a new callback to read payload into vectors of vectors (i.e., like `readv`) that match to the payload section of multiple STREAM frames being generated.
* Let the application provide a pointer to a contiguous temporary buffer that holds data to be sent, and scatter that.

It might turn out that we'd want to try these alternatives, but they require changes to the API. Therefore, as the first cut, we are trying the approach using `memmove`.