### PR TITLE
avoid fpe in quicly_pacer_calc_send_rate

### DIFF
--- a/include/quicly/pacer.h
+++ b/include/quicly/pacer.h
@@ -138,7 +138,10 @@ inline void quicly_pacer_consume_window(quicly_pacer_t *pacer, size_t delta)
 
 inline uint32_t quicly_pacer_calc_send_rate(uint32_t multiplier, uint32_t cwnd, uint32_t rtt)
 {
-    return (cwnd * multiplier + rtt - 1) / rtt;
+    uint64_t ret = ((uint64_t)cwnd * multiplier + rtt - 1) / rtt;
+    if (ret > UINT32_MAX)
+        ret = UINT32_MAX;
+    return ret;
 }
 
 #ifdef __cplusplus

--- a/t/pacer.c
+++ b/t/pacer.c
@@ -38,6 +38,10 @@ static void test_calc_rate(void)
     /* half the rate as above, due to multiplier being 1x */
     bytes_per_msec = quicly_pacer_calc_send_rate(1, 50 * 1200, 100);
     ok(bytes_per_msec == 600);
+
+    /* guard against overflow */
+    bytes_per_msec = quicly_pacer_calc_send_rate(2, 2147483648, 21);
+    ok(bytes_per_msec == 204522253);
 }
 
 static const uint16_t mtu = 1200;


### PR DESCRIPTION
The calculation of `(cwnd * multiplier + rtt - 1)` can overflow a `uint32_t`