### PR TITLE
[xcode] remove compiler flags for AESNI

### DIFF
--- a/quicly.xcodeproj/project.pbxproj
+++ b/quicly.xcodeproj/project.pbxproj
@@ -995,13 +995,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-march=native",
-					"-maes",
-					"-mpclmul",
-					"-mvaes",
-					"-mvpclmulqdq",
-				);
+				OTHER_CFLAGS = "-march=native";
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -1055,13 +1049,7 @@
 				LIBRARY_SEARCH_PATHS = /opt/homebrew/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_CFLAGS = (
-					"-march=native",
-					"-maes",
-					"-mpclmul",
-					"-mvaes",
-					"-mvpclmulqdq",
-				);
+				OTHER_CFLAGS = "-march=native";
 				SDKROOT = macosx;
 			};
 			name = Release;


### PR DESCRIPTION
On arm, Xcode 26 refuses compilation when these flags are set. IIRC, in prior versions, they were warnings.