### PR TITLE
define field iterator for stats and use that for tracing

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -676,140 +676,130 @@ typedef struct st_quicly_stats_t {
     size_t num_sentmap_packets_largest;
 } quicly_stats_t;
 
+/* clang-format off */
+
 #define QUICLY_STATS_FOREACH_NUM_PACKETS(apply)                                                                                    \
-    do {                                                                                                                           \
-        apply(num_packets.received, "num-packets.received");                                                                       \
-        apply(num_packets.decryption_failed, "num-packets.decryption-failed");                                                     \
-        apply(num_packets.sent, "num-packets.sent");                                                                               \
-        apply(num_packets.lost, "num-packets.lost");                                                                               \
-        apply(num_packets.lost_time_threshold, "num-packets.lost-time-threshold");                                                 \
-        apply(num_packets.ack_received, "num-packets.ack-received");                                                               \
-        apply(num_packets.late_acked, "num-packets.late-acked");                                                                   \
-        apply(num_packets.initial_received, "num-packets.initial-received");                                                       \
-        apply(num_packets.zero_rtt_received, "num-packets.zero-rtt-received");                                                     \
-        apply(num_packets.handshake_received, "num-packets.handshake-received");                                                   \
-        apply(num_packets.initial_sent, "num-packets.initial-sent");                                                               \
-        apply(num_packets.zero_rtt_sent, "num-packets.zero-rtt-sent");                                                             \
-        apply(num_packets.handshake_sent, "num-packets.handshake-sent");                                                           \
-        apply(num_packets.received_out_of_order, "num-packets.received-out-of-order");                                             \
-        apply(num_packets.received_ecn_counts[0], "num-packets.received-ecn-ect0");                                                \
-        apply(num_packets.received_ecn_counts[1], "num-packets.received-ecn-ect1");                                                \
-        apply(num_packets.received_ecn_counts[2], "num-packets.received-ecn-ce");                                                  \
-        apply(num_packets.acked_ecn_counts[0], "num-packets.acked-ecn-ect0");                                                      \
-        apply(num_packets.acked_ecn_counts[1], "num-packets.acked-ecn-ect1");                                                      \
-        apply(num_packets.acked_ecn_counts[2], "num-packets.acked-ecn-ce");                                                        \
-        apply(num_packets.sent_promoted_paths, "num-packets.sent-promoted-paths");                                                 \
-        apply(num_packets.ack_received_promoted_paths, "num-packets.ack-received-promoted-paths");                                 \
-    } while (0)
+    apply(num_packets.received, "num-packets.received")                                                                            \
+    apply(num_packets.decryption_failed, "num-packets.decryption-failed")                                                          \
+    apply(num_packets.sent, "num-packets.sent")                                                                                    \
+    apply(num_packets.lost, "num-packets.lost")                                                                                    \
+    apply(num_packets.lost_time_threshold, "num-packets.lost-time-threshold")                                                      \
+    apply(num_packets.ack_received, "num-packets.ack-received")                                                                    \
+    apply(num_packets.late_acked, "num-packets.late-acked")                                                                        \
+    apply(num_packets.initial_received, "num-packets.initial-received")                                                            \
+    apply(num_packets.zero_rtt_received, "num-packets.zero-rtt-received")                                                          \
+    apply(num_packets.handshake_received, "num-packets.handshake-received")                                                        \
+    apply(num_packets.initial_sent, "num-packets.initial-sent")                                                                    \
+    apply(num_packets.zero_rtt_sent, "num-packets.zero-rtt-sent")                                                                  \
+    apply(num_packets.handshake_sent, "num-packets.handshake-sent")                                                                \
+    apply(num_packets.received_out_of_order, "num-packets.received-out-of-order")                                                  \
+    apply(num_packets.received_ecn_counts[0], "num-packets.received-ecn-ect0")                                                     \
+    apply(num_packets.received_ecn_counts[1], "num-packets.received-ecn-ect1")                                                     \
+    apply(num_packets.received_ecn_counts[2], "num-packets.received-ecn-ce")                                                       \
+    apply(num_packets.acked_ecn_counts[0], "num-packets.acked-ecn-ect0")                                                           \
+    apply(num_packets.acked_ecn_counts[1], "num-packets.acked-ecn-ect1")                                                           \
+    apply(num_packets.acked_ecn_counts[2], "num-packets.acked-ecn-ce")                                                             \
+    apply(num_packets.sent_promoted_paths, "num-packets.sent-promoted-paths")                                                      \
+    apply(num_packets.ack_received_promoted_paths, "num-packets.ack-received-promoted-paths")
 
 #define QUICLY_STATS_FOREACH_NUM_BYTES(apply)                                                                                      \
-    do {                                                                                                                           \
-        apply(num_bytes.received, "num-bytes.received");                                                                           \
-        apply(num_bytes.sent, "num-bytes.sent");                                                                                   \
-        apply(num_bytes.lost, "num-bytes.lost");                                                                                   \
-        apply(num_bytes.ack_received, "num-bytes.ack-received");                                                                   \
-        apply(num_bytes.stream_data_sent, "num-bytes.stream-data-sent");                                                           \
-        apply(num_bytes.stream_data_resent, "num-bytes.stream-data-resent");                                                       \
-    } while (0)
+    apply(num_bytes.received, "num-bytes.received")                                                                                \
+    apply(num_bytes.sent, "num-bytes.sent")                                                                                        \
+    apply(num_bytes.lost, "num-bytes.lost")                                                                                        \
+    apply(num_bytes.ack_received, "num-bytes.ack-received")                                                                        \
+    apply(num_bytes.stream_data_sent, "num-bytes.stream-data-sent")                                                                \
+    apply(num_bytes.stream_data_resent, "num-bytes.stream-data-resent")
 
 #define QUICLY_STATS__DO_FOREACH_NUM_FRAMES(name, dir, apply)                                                                      \
     apply(num_frames_##dir.name, "num-frames-" PTLS_TO_STR(dir) "." PTLS_TO_STR(name))
 
 #define QUICLY_STATS_FOREACH_NUM_FRAMES(dir, apply)                                                                                \
-    do {                                                                                                                           \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(padding, dir, apply);                                                                  \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(ping, dir, apply);                                                                     \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(ack, dir, apply);                                                                      \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(reset_stream, dir, apply);                                                             \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(stop_sending, dir, apply);                                                             \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(crypto, dir, apply);                                                                   \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(new_token, dir, apply);                                                                \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(stream, dir, apply);                                                                   \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(max_data, dir, apply);                                                                 \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(max_stream_data, dir, apply);                                                          \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(max_streams_bidi, dir, apply);                                                         \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(max_streams_uni, dir, apply);                                                          \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(data_blocked, dir, apply);                                                             \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(stream_data_blocked, dir, apply);                                                      \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(streams_blocked, dir, apply);                                                          \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(new_connection_id, dir, apply);                                                        \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(retire_connection_id, dir, apply);                                                     \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(path_challenge, dir, apply);                                                           \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(path_response, dir, apply);                                                            \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(transport_close, dir, apply);                                                          \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(application_close, dir, apply);                                                        \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(handshake_done, dir, apply);                                                           \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(datagram, dir, apply);                                                                 \
-        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(ack_frequency, dir, apply);                                                            \
-    } while (0)
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(padding, dir, apply)                                                                       \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(ping, dir, apply)                                                                          \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(ack, dir, apply)                                                                           \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(reset_stream, dir, apply)                                                                  \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(stop_sending, dir, apply)                                                                  \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(crypto, dir, apply)                                                                        \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(new_token, dir, apply)                                                                     \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(stream, dir, apply)                                                                        \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(max_data, dir, apply)                                                                      \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(max_stream_data, dir, apply)                                                               \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(max_streams_bidi, dir, apply)                                                              \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(max_streams_uni, dir, apply)                                                               \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(data_blocked, dir, apply)                                                                  \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(stream_data_blocked, dir, apply)                                                           \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(streams_blocked, dir, apply)                                                               \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(new_connection_id, dir, apply)                                                             \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(retire_connection_id, dir, apply)                                                          \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(path_challenge, dir, apply)                                                                \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(path_response, dir, apply)                                                                 \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(transport_close, dir, apply)                                                               \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(application_close, dir, apply)                                                             \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(handshake_done, dir, apply)                                                                \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(datagram, dir, apply)                                                                      \
+    QUICLY_STATS__DO_FOREACH_NUM_FRAMES(ack_frequency, dir, apply)
 
 #define QUICLY_STATS_FOREACH_TRANSPORT_COUNTERS(apply)                                                                             \
-    do {                                                                                                                           \
-        apply(num_paths.created, "num-paths.created");                                                                             \
-        apply(num_paths.validated, "num-paths.validated");                                                                         \
-        apply(num_paths.validation_failed, "num-paths.validation-failed");                                                         \
-        apply(num_paths.migration_elicited, "num-paths.migration-elicited");                                                       \
-        apply(num_paths.promoted, "num-paths.promoted");                                                                           \
-        apply(num_paths.closed_no_dcid, "num-paths.closed-no-dcid");                                                               \
-        apply(num_paths.ecn_validated, "num-paths.ecn-validated");                                                                 \
-        apply(num_paths.ecn_failed, "num-paths.ecn-failed");                                                                       \
-        apply(num_ptos, "num-ptos");                                                                                               \
-        apply(num_handshake_timeouts, "num-handshake-timeouts");                                                                   \
-        apply(num_initial_handshake_exceeded, "num-initial-handshake-exceeded");                                                   \
-    } while (0)
+        apply(num_paths.created, "num-paths.created")                                                                                  \
+        apply(num_paths.validated, "num-paths.validated")                                                                              \
+        apply(num_paths.validation_failed, "num-paths.validation-failed")                                                              \
+        apply(num_paths.migration_elicited, "num-paths.migration-elicited")                                                            \
+        apply(num_paths.promoted, "num-paths.promoted")                                                                                \
+        apply(num_paths.closed_no_dcid, "num-paths.closed-no-dcid")                                                                    \
+        apply(num_paths.ecn_validated, "num-paths.ecn-validated")                                                                      \
+        apply(num_paths.ecn_failed, "num-paths.ecn-failed")                                                                            \
+        apply(num_ptos, "num-ptos")                                                                                                    \
+        apply(num_handshake_timeouts, "num-handshake-timeouts")                                                                        \
+        apply(num_initial_handshake_exceeded, "num-initial-handshake-exceeded")
 
 /**
  * Macro for iterating QUICLY_STATS_PREBUILT_COUNTERS.
  */
 #define QUICLY_STATS_FOREACH_COUNTERS(apply)                                                                                       \
-    do {                                                                                                                           \
-        QUICLY_STATS_FOREACH_NUM_PACKETS(apply);                                                                                   \
-        QUICLY_STATS_FOREACH_NUM_BYTES(apply);                                                                                     \
-        QUICLY_STATS_FOREACH_NUM_FRAMES(received, apply);                                                                          \
-        QUICLY_STATS_FOREACH_NUM_FRAMES(sent, apply);                                                                              \
-        QUICLY_STATS_FOREACH_TRANSPORT_COUNTERS(apply);                                                                            \
-    } while (0)
+    QUICLY_STATS_FOREACH_NUM_PACKETS(apply)                                                                                        \
+    QUICLY_STATS_FOREACH_NUM_BYTES(apply)                                                                                          \
+    QUICLY_STATS_FOREACH_NUM_FRAMES(received, apply)                                                                               \
+    QUICLY_STATS_FOREACH_NUM_FRAMES(sent, apply)                                                                                   \
+    QUICLY_STATS_FOREACH_TRANSPORT_COUNTERS(apply)
 
 /**
  * Macro for iterating the fields of `quicly_stats_t` other than QUICLY_STATS_PREBUILT_COUNTERS.
  */
 #define QUICLY_STATS_FOREACH_NON_COUNTERS(apply)                                                                                   \
-    do {                                                                                                                           \
-        apply(handshake_confirmed_msec, "handshake-confirmed-msec");                                                               \
-        apply(jumpstart.prev_rate, "jumpstart.prev-rate");                                                                         \
-        apply(jumpstart.prev_rtt, "jumpstart.prev-rtt");                                                                           \
-        apply(jumpstart.new_rtt, "jumpstart.prev-rtt");                                                                            \
-        apply(jumpstart.cwnd, "jumpstart.cwnd");                                                                                   \
-        apply(token_sent.at, "token-sent.at");                                                                                     \
-        apply(token_sent.rate, "token-sent.rate");                                                                                 \
-        apply(token_sent.rtt, "token-sent.rtt");                                                                                   \
-        apply(rtt.minimum, "rtt.minimum");                                                                                         \
-        apply(rtt.smoothed, "rtt.smoothed");                                                                                       \
-        apply(rtt.variance, "rtt.variance");                                                                                       \
-        apply(rtt.latest, "rtt.latest");                                                                                           \
-        apply(loss_thresholds.use_packet_based, "loss-thresholds.use-packet-based");                                               \
-        apply(loss_thresholds.time_based_percentile, "loss-thresholds.time-based-percentile");                                     \
-        apply(cc.cwnd, "cc.cwnd");                                                                                                 \
-        apply(cc.ssthresh, "cc.ssthresh");                                                                                         \
-        apply(cc.cwnd_initial, "cc.cwnd-initial");                                                                                 \
-        apply(cc.cwnd_exiting_slow_start, "cc.cwnd-exiting-slow-start");                                                           \
-        apply(cc.exit_slow_start_at, "cc.exit-slow-start-at");                                                                     \
-        apply(cc.cwnd_exiting_jumpstart, "cc.jumpstart-exit-cwnd");                                                                \
-        apply(cc.cwnd_minimum, "cc.cwnd-minimum");                                                                                 \
-        apply(cc.cwnd_maximum, "cc.cwnd-maximum");                                                                                 \
-        apply(cc.num_loss_episodes, "cc.num-loss-episodes");                                                                       \
-        apply(cc.num_ecn_loss_episodes, "cc.num-ecn-loss-episodes");                                                               \
-        apply(delivery_rate.latest, "delivery-rate.latest");                                                                       \
-        apply(delivery_rate.smoothed, "delivery-rate.smoothed");                                                                   \
-        apply(delivery_rate.stdev, "delivery-rate.stdev");                                                                         \
-        apply(num_sentmap_packets_largest, "num-sentmap-packets-largest");                                                         \
-    } while (0)
+    apply(handshake_confirmed_msec, "handshake-confirmed-msec")                                                                    \
+    apply(jumpstart.prev_rate, "jumpstart.prev-rate")                                                                              \
+    apply(jumpstart.prev_rtt, "jumpstart.prev-rtt")                                                                                \
+    apply(jumpstart.new_rtt, "jumpstart.prev-rtt")                                                                                 \
+    apply(jumpstart.cwnd, "jumpstart.cwnd")                                                                                        \
+    apply(token_sent.at, "token-sent.at")                                                                                          \
+    apply(token_sent.rate, "token-sent.rate")                                                                                      \
+    apply(token_sent.rtt, "token-sent.rtt")                                                                                        \
+    apply(rtt.minimum, "rtt.minimum")                                                                                              \
+    apply(rtt.smoothed, "rtt.smoothed")                                                                                            \
+    apply(rtt.variance, "rtt.variance")                                                                                            \
+    apply(rtt.latest, "rtt.latest")                                                                                                \
+    apply(loss_thresholds.use_packet_based, "loss-thresholds.use-packet-based")                                                    \
+    apply(loss_thresholds.time_based_percentile, "loss-thresholds.time-based-percentile")                                          \
+    apply(cc.cwnd, "cc.cwnd")                                                                                                      \
+    apply(cc.ssthresh, "cc.ssthresh")                                                                                              \
+    apply(cc.cwnd_initial, "cc.cwnd-initial")                                                                                      \
+    apply(cc.cwnd_exiting_slow_start, "cc.cwnd-exiting-slow-start")                                                                \
+    apply(cc.exit_slow_start_at, "cc.exit-slow-start-at")                                                                          \
+    apply(cc.cwnd_exiting_jumpstart, "cc.jumpstart-exit-cwnd")                                                                     \
+    apply(cc.cwnd_minimum, "cc.cwnd-minimum")                                                                                      \
+    apply(cc.cwnd_maximum, "cc.cwnd-maximum")                                                                                      \
+    apply(cc.num_loss_episodes, "cc.num-loss-episodes")                                                                            \
+    apply(cc.num_ecn_loss_episodes, "cc.num-ecn-loss-episodes")                                                                    \
+    apply(delivery_rate.latest, "delivery-rate.latest")                                                                            \
+    apply(delivery_rate.smoothed, "delivery-rate.smoothed")                                                                        \
+    apply(delivery_rate.stdev, "delivery-rate.stdev")                                                                              \
+    apply(num_sentmap_packets_largest, "num-sentmap-packets-largest")
 
 #define QUICLY_STATS_FOREACH(apply)                                                                                                \
-    do {                                                                                                                           \
-        QUICLY_STATS_FOREACH_COUNTERS(apply);                                                                                      \
-        QUICLY_STATS_FOREACH_NON_COUNTERS(apply);                                                                                  \
-    } while (0)
+    QUICLY_STATS_FOREACH_COUNTERS(apply)                                                                                           \
+    QUICLY_STATS_FOREACH_NON_COUNTERS(apply)
+
+/* clang-format on */
 
 /**
  * The state of the default stream scheduler.

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -769,7 +769,7 @@ typedef struct st_quicly_stats_t {
     apply(handshake_confirmed_msec, "handshake-confirmed-msec")                                                                    \
     apply(jumpstart.prev_rate, "jumpstart.prev-rate")                                                                              \
     apply(jumpstart.prev_rtt, "jumpstart.prev-rtt")                                                                                \
-    apply(jumpstart.new_rtt, "jumpstart.prev-rtt")                                                                                 \
+    apply(jumpstart.new_rtt, "jumpstart.new-rtt")                                                                                 \
     apply(jumpstart.cwnd, "jumpstart.cwnd")                                                                                        \
     apply(token_sent.at, "token-sent.at")                                                                                          \
     apply(token_sent.rate, "token-sent.rate")                                                                                      \
@@ -785,7 +785,7 @@ typedef struct st_quicly_stats_t {
     apply(cc.cwnd_initial, "cc.cwnd-initial")                                                                                      \
     apply(cc.cwnd_exiting_slow_start, "cc.cwnd-exiting-slow-start")                                                                \
     apply(cc.exit_slow_start_at, "cc.exit-slow-start-at")                                                                          \
-    apply(cc.cwnd_exiting_jumpstart, "cc.jumpstart-exit-cwnd")                                                                     \
+    apply(cc.cwnd_exiting_jumpstart, "cc.cwnd-exiting-jumpstart")                                                                  \
     apply(cc.cwnd_minimum, "cc.cwnd-minimum")                                                                                      \
     apply(cc.cwnd_maximum, "cc.cwnd-maximum")                                                                                      \
     apply(cc.num_loss_episodes, "cc.num-loss-episodes")                                                                            \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -452,10 +452,10 @@ struct st_quicly_conn_streamgroup_state_t {
 };
 
 /**
- * Aggregatable counters that do not need to be gathered upon the invocation of `quicly_get_stats`. We use typedef to define the
- * same fields in the same order for quicly_stats_t and `struct st_quicly_conn_public_t::stats`.
+ * Fields that do not need to be gathered upon the invocation of `quicly_get_stats`. We use typedef to define the same fields in the
+ * same order for `quicly_stats_t` and `struct st_quicly_conn_public_t::stats`.
  */
-#define QUICLY_STATS_PREBUILT_COUNTERS                                                                                             \
+#define QUICLY_STATS_PREBUILT_FIELDS                                                                                               \
     struct {                                                                                                                       \
         /**                                                                                                                        \
          * Total number of packets received.                                                                                       \
@@ -642,7 +642,7 @@ typedef struct st_quicly_stats_t {
     /**
      * The pre-built fields. This MUST be the first member of `quicly_stats_t` so that we can use `memcpy`.
      */
-    QUICLY_STATS_PREBUILT_COUNTERS;
+    QUICLY_STATS_PREBUILT_FIELDS;
     /**
      * RTT stats.
      */
@@ -839,7 +839,7 @@ struct _st_quicly_conn_public_t {
     quicly_cid_t original_dcid;
     struct st_quicly_default_scheduler_state_t _default_scheduler;
     struct {
-        QUICLY_STATS_PREBUILT_COUNTERS;
+        QUICLY_STATS_PREBUILT_FIELDS;
         /**
          * Time took until handshake is confirmed. UINT64_MAX if handshake is not confirmed yet.
          */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -734,7 +734,7 @@ typedef struct st_quicly_stats_t {
         apply(num_sentmap_packets_largest, "num-sentmap-packets-largest");                                                         \
     } while (0)
 
-#define QUICLY_STATS__DO_FOREACH_NUM_FRAMES(name, dir, apply) apply(num_frames_##dir.name, PTLS_TO_STR(name) "-" PTLS_TO_SRT(dir))
+#define QUICLY_STATS__DO_FOREACH_NUM_FRAMES(name, dir, apply) apply(num_frames_##dir.name, PTLS_TO_STR(name) "-" PTLS_TO_STR(dir))
 
 #define QUICLY_STATS_FOREACH_NUM_FRAMES(dir, apply)                                                                                \
     do {                                                                                                                           \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -691,6 +691,8 @@ typedef struct st_quicly_stats_t {
         apply(num_packets.acked_ecn_counts[0], "packets-acked-ecn-ect0");                                                          \
         apply(num_packets.acked_ecn_counts[1], "packets-acked-ecn-ect1");                                                          \
         apply(num_packets.acked_ecn_counts[2], "packets-acked-ecn-ce");                                                            \
+        apply(num_packets.sent_promoted_paths, "packets-sent-promoted-paths");                                                     \
+        apply(num_packets.ack_received_promoted_paths, "packets-ack-received-promoted-paths");                                     \
     } while (0)
 
 #define QUICLY_STATS_FOREACH_NUM_BYTES(apply)                                                                                      \
@@ -705,6 +707,12 @@ typedef struct st_quicly_stats_t {
 
 #define QUICLY_STATS_FOREACH_TRANSPORT(apply)                                                                                      \
     do {                                                                                                                           \
+        apply(num_paths.created, "paths-created");                                                                                 \
+        apply(num_paths.validated, "paths-validated");                                                                             \
+        apply(num_paths.validation_failed, "paths-validation-failed");                                                             \
+        apply(num_paths.migration_elicited, "paths-migration-elicited");                                                           \
+        apply(num_paths.promoted, "paths-promoted");                                                                               \
+        apply(num_paths.closed_no_dcid, "paths-closed-no-dcid");                                                                   \
         apply(num_paths.ecn_validated, "paths-ecn-validated");                                                                     \
         apply(num_paths.ecn_failed, "paths-ecn-failed");                                                                           \
         apply(rtt.minimum, "rtt-minimum");                                                                                         \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -619,6 +619,10 @@ struct st_quicly_conn_streamgroup_state_t {
 #define QUICLY_STATS_PREBUILT_FIELDS                                                                                               \
     QUICLY_STATS_PREBUILT_COUNTERS;                                                                                                \
     /**                                                                                                                            \
+     * Time took until handshake is confirmed. UINT64_MAX if handshake is not confirmed yet.                                       \
+     */                                                                                                                            \
+    uint64_t handshake_confirmed_msec;                                                                                             \
+    /**                                                                                                                            \
      * jumpstart parameters and the CWND being adopted (see also quicly_cc_t::cwnd_exiting_jumpstart)                              \
      */                                                                                                                            \
     struct {                                                                                                                       \
@@ -670,10 +674,6 @@ typedef struct st_quicly_stats_t {
      * largest number of packets contained in the sentmap
      */
     size_t num_sentmap_packets_largest;
-    /**
-     * Time took until handshake is confirmed. UINT64_MAX if handshake is not confirmed yet.
-     */
-    uint64_t handshake_confirmed_msec;
 } quicly_stats_t;
 
 #define QUICLY_STATS_FOREACH_NUM_PACKETS(apply)                                                                                    \
@@ -774,6 +774,7 @@ typedef struct st_quicly_stats_t {
  */
 #define QUICLY_STATS_FOREACH_NON_COUNTERS(apply)                                                                                   \
     do {                                                                                                                           \
+        apply(handshake_confirmed_msec, "handshake-confirmed-msec");                                                               \
         apply(jumpstart.prev_rate, "jumpstart-prev-rate");                                                                         \
         apply(jumpstart.prev_rtt, "jumpstart-prev-rtt");                                                                           \
         apply(jumpstart.new_rtt, "jumpstart-prev-rtt");                                                                            \
@@ -801,7 +802,6 @@ typedef struct st_quicly_stats_t {
         apply(delivery_rate.smoothed, "delivery-rate-smoothed");                                                                   \
         apply(delivery_rate.stdev, "delivery-rate-stdev");                                                                         \
         apply(num_sentmap_packets_largest, "num-sentmap-packets-largest");                                                         \
-        apply(handshake_confirmed_msec, "handshake-confirmed-msec");                                                               \
     } while (0)
 
 #define QUICLY_STATS_FOREACH(apply)                                                                                                \
@@ -865,10 +865,6 @@ struct _st_quicly_conn_public_t {
     struct st_quicly_default_scheduler_state_t _default_scheduler;
     struct {
         QUICLY_STATS_PREBUILT_FIELDS;
-        /**
-         * Time took until handshake is confirmed. UINT64_MAX if handshake is not confirmed yet.
-         */
-        uint64_t handshake_confirmed_msec;
     } stats;
     uint32_t version;
     void *data;

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -722,15 +722,15 @@ typedef struct st_quicly_stats_t {
         apply(jumpstart.prev_rtt, "jumpstart-prev-rtt");                                                                           \
         apply(jumpstart.new_rtt, "jumpstart-prev-rtt");                                                                            \
         apply(jumpstart.cwnd, "jumpstart-cwnd");                                                                                   \
-        apply(token_sent.at, "token_sent-at");                                                                                     \
-        apply(token_sent.rate, "token_sent-rate");                                                                                 \
-        apply(token_sent.rtt, "token_sent-rtt");                                                                                   \
+        apply(token_sent.at, "token-sent-at");                                                                                     \
+        apply(token_sent.rate, "token-sent-rate");                                                                                 \
+        apply(token_sent.rtt, "token-sent-rtt");                                                                                   \
         apply(rtt.minimum, "rtt-minimum");                                                                                         \
         apply(rtt.smoothed, "rtt-smoothed");                                                                                       \
         apply(rtt.variance, "rtt-variance");                                                                                       \
         apply(rtt.latest, "rtt-latest");                                                                                           \
-        apply(loss_thresholds.use_packet_based, "loss_thresholds-use_packet_based"); \
-        apply(loss_thresholds.time_based_percentile, "loss_thresholds-time_based_percentile"); \
+        apply(loss_thresholds.use_packet_based, "loss-thresholds-use-packet-based"); \
+        apply(loss_thresholds.time_based_percentile, "loss-thresholds-time-based-percentile"); \
         apply(cc.cwnd, "cwnd");                                                                                                    \
         apply(cc.ssthresh, "ssthresh");                                                                                            \
         apply(cc.cwnd_initial, "cwnd-initial");                                                                                    \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -556,6 +556,15 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t stream_data_resent;                                                                                               \
     } num_bytes;                                                                                                                   \
+    /**                                                                                                                            \
+     * Total number of each frame being sent / received.                                                                           \
+     */                                                                                                                            \
+    struct {                                                                                                                       \
+        uint64_t padding, ping, ack, reset_stream, stop_sending, crypto, new_token, stream, max_data, max_stream_data,             \
+            max_streams_bidi, max_streams_uni, data_blocked, stream_data_blocked, streams_blocked, new_connection_id,              \
+            retire_connection_id, path_challenge, path_response, transport_close, application_close, handshake_done, datagram,     \
+            ack_frequency;                                                                                                         \
+    } num_frames_received, num_frames_sent;                                                                                        \
     struct {                                                                                                                       \
         /**                                                                                                                        \
          * number of alternate paths created                                                                                       \
@@ -590,15 +599,6 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t ecn_failed;                                                                                                       \
     } num_paths;                                                                                                                   \
-    /**                                                                                                                            \
-     * Total number of each frame being sent / received.                                                                           \
-     */                                                                                                                            \
-    struct {                                                                                                                       \
-        uint64_t padding, ping, ack, reset_stream, stop_sending, crypto, new_token, stream, max_data, max_stream_data,             \
-            max_streams_bidi, max_streams_uni, data_blocked, stream_data_blocked, streams_blocked, new_connection_id,              \
-            retire_connection_id, path_challenge, path_response, transport_close, application_close, handshake_done, datagram,     \
-            ack_frequency;                                                                                                         \
-    } num_frames_sent, num_frames_received;                                                                                        \
     /**                                                                                                                            \
      * Total number of PTOs observed during the connection.                                                                        \
      */                                                                                                                            \
@@ -779,9 +779,9 @@ typedef struct st_quicly_stats_t {
     do {                                                                                                                           \
         QUICLY_STATS_FOREACH_NUM_PACKETS(apply);                                                                                   \
         QUICLY_STATS_FOREACH_NUM_BYTES(apply);                                                                                     \
-        QUICLY_STATS_FOREACH_TRANSPORT(apply);                                                                                     \
         QUICLY_STATS_FOREACH_NUM_FRAMES(received, apply);                                                                          \
         QUICLY_STATS_FOREACH_NUM_FRAMES(sent, apply);                                                                              \
+        QUICLY_STATS_FOREACH_TRANSPORT(apply);                                                                                     \
     } while (0)
 
 /**

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -452,10 +452,10 @@ struct st_quicly_conn_streamgroup_state_t {
 };
 
 /**
- * Fields that do not need to be gathered upon the invocation of `quicly_get_stats`. We use typedef to define the same fields in the
- * same order for `quicly_stats_t` and `struct st_quicly_conn_public_t::stats`.
+ * Aggregatable counters that do not need to be gathered upon the invocation of `quicly_get_stats`. We use typedef to define the
+ * same fields in the same order for quicly_stats_t and `struct st_quicly_conn_public_t::stats`.
  */
-#define QUICLY_STATS_PREBUILT_FIELDS                                                                                               \
+#define QUICLY_STATS_PREBUILT_COUNTERS                                                                                             \
     struct {                                                                                                                       \
         /**                                                                                                                        \
          * Total number of packets received.                                                                                       \
@@ -642,7 +642,7 @@ typedef struct st_quicly_stats_t {
     /**
      * The pre-built fields. This MUST be the first member of `quicly_stats_t` so that we can use `memcpy`.
      */
-    QUICLY_STATS_PREBUILT_FIELDS;
+    QUICLY_STATS_PREBUILT_COUNTERS;
     /**
      * RTT stats.
      */
@@ -845,7 +845,7 @@ struct _st_quicly_conn_public_t {
     quicly_cid_t original_dcid;
     struct st_quicly_default_scheduler_state_t _default_scheduler;
     struct {
-        QUICLY_STATS_PREBUILT_FIELDS;
+        QUICLY_STATS_PREBUILT_COUNTERS;
         /**
          * Time took until handshake is confirmed. UINT64_MAX if handshake is not confirmed yet.
          */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -729,26 +729,23 @@ typedef struct st_quicly_stats_t {
         apply(rtt.smoothed, "rtt-smoothed");                                                                                       \
         apply(rtt.variance, "rtt-variance");                                                                                       \
         apply(rtt.latest, "rtt-latest");                                                                                           \
+        apply(loss_thresholds.use_packet_based, "loss_thresholds-use_packet_based"); \
+        apply(loss_thresholds.time_based_percentile, "loss_thresholds-time_based_percentile"); \
         apply(cc.cwnd, "cwnd");                                                                                                    \
         apply(cc.ssthresh, "ssthresh");                                                                                            \
         apply(cc.cwnd_initial, "cwnd-initial");                                                                                    \
         apply(cc.cwnd_exiting_slow_start, "cwnd-exiting-slow-start");                                                              \
         apply(cc.exit_slow_start_at, "exit-slow-start-at");                                                                        \
+        apply(cc.cwnd_exiting_jumpstart, "jumpstart-exit-cwnd");                                                                   \
         apply(cc.cwnd_minimum, "cwnd-minimum");                                                                                    \
         apply(cc.cwnd_maximum, "cwnd-maximum");                                                                                    \
-        apply(jumpstart.prev_rate, "jumpstart-prev-rate");                                                                         \
-        apply(jumpstart.prev_rtt, "jumpstart-pret-rtt");                                                                           \
-        apply(jumpstart.cwnd, "jumpstart-cwnd");                                                                                   \
-        apply(cc.cwnd_exiting_jumpstart, "jumpstart-exit-cwnd");                                                                   \
         apply(cc.num_loss_episodes, "num-loss-episodes");                                                                          \
         apply(cc.num_ecn_loss_episodes, "num-ecn-loss-episodes");                                                                  \
         apply(delivery_rate.latest, "delivery-rate-latest");                                                                       \
         apply(delivery_rate.smoothed, "delivery-rate-smoothed");                                                                   \
         apply(delivery_rate.stdev, "delivery-rate-stdev");                                                                         \
-        apply(token_sent.at, "token-sent-at");                                                                                     \
-        apply(token_sent.rate, "token-sent-rate");                                                                                 \
-        apply(token_sent.rtt, "token-sent-rtt");                                                                                   \
         apply(num_sentmap_packets_largest, "num-sentmap-packets-largest");                                                         \
+        apply(handshake_confirmed_msec, "handshake-confirmed-msec");                                                               \
     } while (0)
 
 #define QUICLY_STATS__DO_FOREACH_NUM_FRAMES(name, dir, apply) apply(num_frames_##dir.name, PTLS_TO_STR(name) "-" PTLS_TO_STR(dir))

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -715,6 +715,16 @@ typedef struct st_quicly_stats_t {
         apply(num_paths.closed_no_dcid, "paths-closed-no-dcid");                                                                   \
         apply(num_paths.ecn_validated, "paths-ecn-validated");                                                                     \
         apply(num_paths.ecn_failed, "paths-ecn-failed");                                                                           \
+        apply(num_ptos, "num-ptos");                                                                                               \
+        apply(num_handshake_timeouts, "num-handshake-timeouts");                                                                   \
+        apply(num_initial_handshake_exceeded, "num-initial-handshake-exceeded");                                                   \
+        apply(jumpstart.prev_rate, "jumpstart-prev-rate");                                                                         \
+        apply(jumpstart.prev_rtt, "jumpstart-prev-rtt");                                                                           \
+        apply(jumpstart.new_rtt, "jumpstart-prev-rtt");                                                                            \
+        apply(jumpstart.cwnd, "jumpstart-cwnd");                                                                                   \
+        apply(token_sent.at, "token_sent-at");                                                                                     \
+        apply(token_sent.rate, "token_sent-rate");                                                                                 \
+        apply(token_sent.rtt, "token_sent-rtt");                                                                                   \
         apply(rtt.minimum, "rtt-minimum");                                                                                         \
         apply(rtt.smoothed, "rtt-smoothed");                                                                                       \
         apply(rtt.variance, "rtt-variance");                                                                                       \
@@ -732,7 +742,6 @@ typedef struct st_quicly_stats_t {
         apply(cc.cwnd_exiting_jumpstart, "jumpstart-exit-cwnd");                                                                   \
         apply(cc.num_loss_episodes, "num-loss-episodes");                                                                          \
         apply(cc.num_ecn_loss_episodes, "num-ecn-loss-episodes");                                                                  \
-        apply(num_ptos, "num-ptos");                                                                                               \
         apply(delivery_rate.latest, "delivery-rate-latest");                                                                       \
         apply(delivery_rate.smoothed, "delivery-rate-smoothed");                                                                   \
         apply(delivery_rate.stdev, "delivery-rate-stdev");                                                                         \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -672,17 +672,11 @@ typedef struct st_quicly_stats_t {
 #define QUICLY_STATS_FOREACH_NUM_PACKETS(apply)                                                                                    \
     do {                                                                                                                           \
         apply(num_packets.received, "packets-received");                                                                           \
-        apply(num_packets.received_ecn_counts[0], "packets-received-ecn-ect0");                                                    \
-        apply(num_packets.received_ecn_counts[1], "packets-received-ecn-ect1");                                                    \
-        apply(num_packets.received_ecn_counts[2], "packets-received-ecn-ce");                                                      \
         apply(num_packets.decryption_failed, "packets-decryption-failed");                                                         \
         apply(num_packets.sent, "packets-sent");                                                                                   \
         apply(num_packets.lost, "packets-lost");                                                                                   \
         apply(num_packets.lost_time_threshold, "packets-lost-time-threshold");                                                     \
         apply(num_packets.ack_received, "packets-ack-received");                                                                   \
-        apply(num_packets.acked_ecn_counts[0], "packets-acked-ecn-ect0");                                                          \
-        apply(num_packets.acked_ecn_counts[1], "packets-acked-ecn-ect1");                                                          \
-        apply(num_packets.acked_ecn_counts[2], "packets-acked-ecn-ce");                                                            \
         apply(num_packets.late_acked, "late-acked");                                                                               \
         apply(num_packets.initial_received, "initial-received");                                                                   \
         apply(num_packets.zero_rtt_received, "zero-rtt-received");                                                                 \
@@ -691,6 +685,12 @@ typedef struct st_quicly_stats_t {
         apply(num_packets.zero_rtt_sent, "zero-rtt-sent");                                                                         \
         apply(num_packets.handshake_sent, "handshake-sent");                                                                       \
         apply(num_packets.received_out_of_order, "packets-received-out-of-order");                                                 \
+        apply(num_packets.received_ecn_counts[0], "packets-received-ecn-ect0");                                                    \
+        apply(num_packets.received_ecn_counts[1], "packets-received-ecn-ect1");                                                    \
+        apply(num_packets.received_ecn_counts[2], "packets-received-ecn-ce");                                                      \
+        apply(num_packets.acked_ecn_counts[0], "packets-acked-ecn-ect0");                                                          \
+        apply(num_packets.acked_ecn_counts[1], "packets-acked-ecn-ect1");                                                          \
+        apply(num_packets.acked_ecn_counts[2], "packets-acked-ecn-ce");                                                            \
     } while (0)
 
 #define QUICLY_STATS_FOREACH_NUM_BYTES(apply)                                                                                      \

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -768,6 +768,7 @@ typedef struct st_quicly_stats_t {
         QUICLY_STATS__DO_FOREACH_NUM_FRAMES(transport_close, dir, apply);                                                          \
         QUICLY_STATS__DO_FOREACH_NUM_FRAMES(application_close, dir, apply);                                                        \
         QUICLY_STATS__DO_FOREACH_NUM_FRAMES(handshake_done, dir, apply);                                                           \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(datagram, dir, apply);                                                                 \
         QUICLY_STATS__DO_FOREACH_NUM_FRAMES(ack_frequency, dir, apply);                                                            \
     } while (0)
 

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -669,6 +669,113 @@ typedef struct st_quicly_stats_t {
     uint64_t handshake_confirmed_msec;
 } quicly_stats_t;
 
+#define QUICLY_STATS_FOREACH_NUM_PACKETS(apply)                                                                                    \
+    do {                                                                                                                           \
+        apply(num_packets.received, "packets-received");                                                                           \
+        apply(num_packets.received_ecn_counts[0], "packets-received-ecn-ect0");                                                    \
+        apply(num_packets.received_ecn_counts[1], "packets-received-ecn-ect1");                                                    \
+        apply(num_packets.received_ecn_counts[2], "packets-received-ecn-ce");                                                      \
+        apply(num_packets.decryption_failed, "packets-decryption-failed");                                                         \
+        apply(num_packets.sent, "packets-sent");                                                                                   \
+        apply(num_packets.lost, "packets-lost");                                                                                   \
+        apply(num_packets.lost_time_threshold, "packets-lost-time-threshold");                                                     \
+        apply(num_packets.ack_received, "packets-ack-received");                                                                   \
+        apply(num_packets.acked_ecn_counts[0], "packets-acked-ecn-ect0");                                                          \
+        apply(num_packets.acked_ecn_counts[1], "packets-acked-ecn-ect1");                                                          \
+        apply(num_packets.acked_ecn_counts[2], "packets-acked-ecn-ce");                                                            \
+        apply(num_packets.late_acked, "late-acked");                                                                               \
+        apply(num_packets.initial_received, "initial-received");                                                                   \
+        apply(num_packets.zero_rtt_received, "zero-rtt-received");                                                                 \
+        apply(num_packets.handshake_received, "handshake-received");                                                               \
+        apply(num_packets.initial_sent, "initial-sent");                                                                           \
+        apply(num_packets.zero_rtt_sent, "zero-rtt-sent");                                                                         \
+        apply(num_packets.handshake_sent, "handshake-sent");                                                                       \
+        apply(num_packets.received_out_of_order, "packets-received-out-of-order");                                                 \
+    } while (0)
+
+#define QUICLY_STATS_FOREACH_NUM_BYTES(apply)                                                                                      \
+    do {                                                                                                                           \
+        apply(num_bytes.received, "bytes-received");                                                                               \
+        apply(num_bytes.sent, "bytes-sent");                                                                                       \
+        apply(num_bytes.lost, "bytes-lost");                                                                                       \
+        apply(num_bytes.ack_received, "bytes-ack-received");                                                                       \
+        apply(num_bytes.stream_data_sent, "bytes-stream-data-sent");                                                               \
+        apply(num_bytes.stream_data_resent, "bytes-stream-data-resent");                                                           \
+    } while (0)
+
+#define QUICLY_STATS_FOREACH_TRANSPORT(apply)                                                                                      \
+    do {                                                                                                                           \
+        apply(num_paths.ecn_validated, "paths-ecn-validated");                                                                     \
+        apply(num_paths.ecn_failed, "paths-ecn-failed");                                                                           \
+        apply(rtt.minimum, "rtt-minimum");                                                                                         \
+        apply(rtt.smoothed, "rtt-smoothed");                                                                                       \
+        apply(rtt.variance, "rtt-variance");                                                                                       \
+        apply(rtt.latest, "rtt-latest");                                                                                           \
+        apply(cc.cwnd, "cwnd");                                                                                                    \
+        apply(cc.ssthresh, "ssthresh");                                                                                            \
+        apply(cc.cwnd_initial, "cwnd-initial");                                                                                    \
+        apply(cc.cwnd_exiting_slow_start, "cwnd-exiting-slow-start");                                                              \
+        apply(cc.exit_slow_start_at, "exit-slow-start-at");                                                                        \
+        apply(cc.cwnd_minimum, "cwnd-minimum");                                                                                    \
+        apply(cc.cwnd_maximum, "cwnd-maximum");                                                                                    \
+        apply(jumpstart.prev_rate, "jumpstart-prev-rate");                                                                         \
+        apply(jumpstart.prev_rtt, "jumpstart-pret-rtt");                                                                           \
+        apply(jumpstart.cwnd, "jumpstart-cwnd");                                                                                   \
+        apply(cc.cwnd_exiting_jumpstart, "jumpstart-exit-cwnd");                                                                   \
+        apply(cc.num_loss_episodes, "num-loss-episodes");                                                                          \
+        apply(cc.num_ecn_loss_episodes, "num-ecn-loss-episodes");                                                                  \
+        apply(num_ptos, "num-ptos");                                                                                               \
+        apply(delivery_rate.latest, "delivery-rate-latest");                                                                       \
+        apply(delivery_rate.smoothed, "delivery-rate-smoothed");                                                                   \
+        apply(delivery_rate.stdev, "delivery-rate-stdev");                                                                         \
+        apply(token_sent.at, "token-sent-at");                                                                                     \
+        apply(token_sent.rate, "token-sent-rate");                                                                                 \
+        apply(token_sent.rtt, "token-sent-rtt");                                                                                   \
+        apply(num_sentmap_packets_largest, "num-sentmap-packets-largest");                                                         \
+    } while (0)
+
+#define QUICLY_STATS__DO_FOREACH_NUM_FRAMES(name, dir, apply) apply(num_frames_##dir.name, PTLS_TO_STR(name) "-" PTLS_TO_SRT(dir))
+
+#define QUICLY_STATS_FOREACH_NUM_FRAMES(dir, apply)                                                                                \
+    do {                                                                                                                           \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(padding, dir, apply);                                                                  \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(ping, dir, apply);                                                                     \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(ack, dir, apply);                                                                      \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(reset_stream, dir, apply);                                                             \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(stop_sending, dir, apply);                                                             \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(crypto, dir, apply);                                                                   \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(new_token, dir, apply);                                                                \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(stream, dir, apply);                                                                   \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(max_data, dir, apply);                                                                 \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(max_stream_data, dir, apply);                                                          \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(max_streams_bidi, dir, apply);                                                         \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(max_streams_uni, dir, apply);                                                          \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(data_blocked, dir, apply);                                                             \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(stream_data_blocked, dir, apply);                                                      \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(streams_blocked, dir, apply);                                                          \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(new_connection_id, dir, apply);                                                        \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(retire_connection_id, dir, apply);                                                     \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(path_challenge, dir, apply);                                                           \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(path_response, dir, apply);                                                            \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(transport_close, dir, apply);                                                          \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(application_close, dir, apply);                                                        \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(handshake_done, dir, apply);                                                           \
+        QUICLY_STATS__DO_FOREACH_NUM_FRAMES(ack_frequency, dir, apply);                                                            \
+    } while (0)
+
+/**
+ * Macro for iterating the fields of `quicly_stats_t`. Specific categories can be iterated by using the foreach macro with suffixes;
+ * e.g., `QUICLY_STATS_FOREACH_TRANSPORT`.
+ */
+#define QUICLY_STATS_FOREACH(apply)                                                                                                \
+    do {                                                                                                                           \
+        QUICLY_STATS_FOREACH_NUM_PACKETS(apply);                                                                                   \
+        QUICLY_STATS_FOREACH_NUM_BYTES(apply);                                                                                     \
+        QUICLY_STATS_FOREACH_TRANSPORT(apply);                                                                                     \
+        QUICLY_STATS_FOREACH_NUM_FRAMES(received, apply);                                                                          \
+        QUICLY_STATS_FOREACH_NUM_FRAMES(sent, apply);                                                                              \
+    } while (0)
+
 /**
  * The state of the default stream scheduler.
  * `active` is a linked-list of streams for which STREAM frames can be emitted.  `blocked` is a linked-list of streams that have

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -678,41 +678,42 @@ typedef struct st_quicly_stats_t {
 
 #define QUICLY_STATS_FOREACH_NUM_PACKETS(apply)                                                                                    \
     do {                                                                                                                           \
-        apply(num_packets.received, "packets-received");                                                                           \
-        apply(num_packets.decryption_failed, "packets-decryption-failed");                                                         \
-        apply(num_packets.sent, "packets-sent");                                                                                   \
-        apply(num_packets.lost, "packets-lost");                                                                                   \
-        apply(num_packets.lost_time_threshold, "packets-lost-time-threshold");                                                     \
-        apply(num_packets.ack_received, "packets-ack-received");                                                                   \
-        apply(num_packets.late_acked, "late-acked");                                                                               \
-        apply(num_packets.initial_received, "initial-received");                                                                   \
-        apply(num_packets.zero_rtt_received, "zero-rtt-received");                                                                 \
-        apply(num_packets.handshake_received, "handshake-received");                                                               \
-        apply(num_packets.initial_sent, "initial-sent");                                                                           \
-        apply(num_packets.zero_rtt_sent, "zero-rtt-sent");                                                                         \
-        apply(num_packets.handshake_sent, "handshake-sent");                                                                       \
-        apply(num_packets.received_out_of_order, "packets-received-out-of-order");                                                 \
-        apply(num_packets.received_ecn_counts[0], "packets-received-ecn-ect0");                                                    \
-        apply(num_packets.received_ecn_counts[1], "packets-received-ecn-ect1");                                                    \
-        apply(num_packets.received_ecn_counts[2], "packets-received-ecn-ce");                                                      \
-        apply(num_packets.acked_ecn_counts[0], "packets-acked-ecn-ect0");                                                          \
-        apply(num_packets.acked_ecn_counts[1], "packets-acked-ecn-ect1");                                                          \
-        apply(num_packets.acked_ecn_counts[2], "packets-acked-ecn-ce");                                                            \
-        apply(num_packets.sent_promoted_paths, "packets-sent-promoted-paths");                                                     \
-        apply(num_packets.ack_received_promoted_paths, "packets-ack-received-promoted-paths");                                     \
+        apply(num_packets.received, "num-packets.received");                                                                       \
+        apply(num_packets.decryption_failed, "num-packets.decryption-failed");                                                     \
+        apply(num_packets.sent, "num-packets.sent");                                                                               \
+        apply(num_packets.lost, "num-packets.lost");                                                                               \
+        apply(num_packets.lost_time_threshold, "num-packets.lost-time-threshold");                                                 \
+        apply(num_packets.ack_received, "num-packets.ack-received");                                                               \
+        apply(num_packets.late_acked, "num-packets.late-acked");                                                                   \
+        apply(num_packets.initial_received, "num-packets.initial-received");                                                       \
+        apply(num_packets.zero_rtt_received, "num-packets.zero-rtt-received");                                                     \
+        apply(num_packets.handshake_received, "num-packets.handshake-received");                                                   \
+        apply(num_packets.initial_sent, "num-packets.initial-sent");                                                               \
+        apply(num_packets.zero_rtt_sent, "num-packets.zero-rtt-sent");                                                             \
+        apply(num_packets.handshake_sent, "num-packets.handshake-sent");                                                           \
+        apply(num_packets.received_out_of_order, "num-packets.received-out-of-order");                                             \
+        apply(num_packets.received_ecn_counts[0], "num-packets.received-ecn-ect0");                                                \
+        apply(num_packets.received_ecn_counts[1], "num-packets.received-ecn-ect1");                                                \
+        apply(num_packets.received_ecn_counts[2], "num-packets.received-ecn-ce");                                                  \
+        apply(num_packets.acked_ecn_counts[0], "num-packets.acked-ecn-ect0");                                                      \
+        apply(num_packets.acked_ecn_counts[1], "num-packets.acked-ecn-ect1");                                                      \
+        apply(num_packets.acked_ecn_counts[2], "num-packets.acked-ecn-ce");                                                        \
+        apply(num_packets.sent_promoted_paths, "num-packets.sent-promoted-paths");                                                 \
+        apply(num_packets.ack_received_promoted_paths, "num-packets.ack-received-promoted-paths");                                 \
     } while (0)
 
 #define QUICLY_STATS_FOREACH_NUM_BYTES(apply)                                                                                      \
     do {                                                                                                                           \
-        apply(num_bytes.received, "bytes-received");                                                                               \
-        apply(num_bytes.sent, "bytes-sent");                                                                                       \
-        apply(num_bytes.lost, "bytes-lost");                                                                                       \
-        apply(num_bytes.ack_received, "bytes-ack-received");                                                                       \
-        apply(num_bytes.stream_data_sent, "bytes-stream-data-sent");                                                               \
-        apply(num_bytes.stream_data_resent, "bytes-stream-data-resent");                                                           \
+        apply(num_bytes.received, "num-bytes.received");                                                                           \
+        apply(num_bytes.sent, "num-bytes.sent");                                                                                   \
+        apply(num_bytes.lost, "num-bytes.lost");                                                                                   \
+        apply(num_bytes.ack_received, "num-bytes.ack-received");                                                                   \
+        apply(num_bytes.stream_data_sent, "num-bytes.stream-data-sent");                                                           \
+        apply(num_bytes.stream_data_resent, "num-bytes.stream-data-resent");                                                       \
     } while (0)
 
-#define QUICLY_STATS__DO_FOREACH_NUM_FRAMES(name, dir, apply) apply(num_frames_##dir.name, PTLS_TO_STR(name) "-" PTLS_TO_STR(dir))
+#define QUICLY_STATS__DO_FOREACH_NUM_FRAMES(name, dir, apply)                                                                      \
+    apply(num_frames_##dir.name, "num-frames-" PTLS_TO_STR(dir) "." PTLS_TO_STR(name))
 
 #define QUICLY_STATS_FOREACH_NUM_FRAMES(dir, apply)                                                                                \
     do {                                                                                                                           \
@@ -744,14 +745,14 @@ typedef struct st_quicly_stats_t {
 
 #define QUICLY_STATS_FOREACH_TRANSPORT_COUNTERS(apply)                                                                             \
     do {                                                                                                                           \
-        apply(num_paths.created, "paths-created");                                                                                 \
-        apply(num_paths.validated, "paths-validated");                                                                             \
-        apply(num_paths.validation_failed, "paths-validation-failed");                                                             \
-        apply(num_paths.migration_elicited, "paths-migration-elicited");                                                           \
-        apply(num_paths.promoted, "paths-promoted");                                                                               \
-        apply(num_paths.closed_no_dcid, "paths-closed-no-dcid");                                                                   \
-        apply(num_paths.ecn_validated, "paths-ecn-validated");                                                                     \
-        apply(num_paths.ecn_failed, "paths-ecn-failed");                                                                           \
+        apply(num_paths.created, "num-paths.created");                                                                             \
+        apply(num_paths.validated, "num-paths.validated");                                                                         \
+        apply(num_paths.validation_failed, "num-paths.validation-failed");                                                         \
+        apply(num_paths.migration_elicited, "num-paths.migration-elicited");                                                       \
+        apply(num_paths.promoted, "num-paths.promoted");                                                                           \
+        apply(num_paths.closed_no_dcid, "num-paths.closed-no-dcid");                                                               \
+        apply(num_paths.ecn_validated, "num-paths.ecn-validated");                                                                 \
+        apply(num_paths.ecn_failed, "num-paths.ecn-failed");                                                                       \
         apply(num_ptos, "num-ptos");                                                                                               \
         apply(num_handshake_timeouts, "num-handshake-timeouts");                                                                   \
         apply(num_initial_handshake_exceeded, "num-initial-handshake-exceeded");                                                   \
@@ -775,32 +776,32 @@ typedef struct st_quicly_stats_t {
 #define QUICLY_STATS_FOREACH_NON_COUNTERS(apply)                                                                                   \
     do {                                                                                                                           \
         apply(handshake_confirmed_msec, "handshake-confirmed-msec");                                                               \
-        apply(jumpstart.prev_rate, "jumpstart-prev-rate");                                                                         \
-        apply(jumpstart.prev_rtt, "jumpstart-prev-rtt");                                                                           \
-        apply(jumpstart.new_rtt, "jumpstart-prev-rtt");                                                                            \
-        apply(jumpstart.cwnd, "jumpstart-cwnd");                                                                                   \
-        apply(token_sent.at, "token-sent-at");                                                                                     \
-        apply(token_sent.rate, "token-sent-rate");                                                                                 \
-        apply(token_sent.rtt, "token-sent-rtt");                                                                                   \
-        apply(rtt.minimum, "rtt-minimum");                                                                                         \
-        apply(rtt.smoothed, "rtt-smoothed");                                                                                       \
-        apply(rtt.variance, "rtt-variance");                                                                                       \
-        apply(rtt.latest, "rtt-latest");                                                                                           \
-        apply(loss_thresholds.use_packet_based, "loss-thresholds-use-packet-based");                                               \
-        apply(loss_thresholds.time_based_percentile, "loss-thresholds-time-based-percentile");                                     \
-        apply(cc.cwnd, "cwnd");                                                                                                    \
-        apply(cc.ssthresh, "ssthresh");                                                                                            \
-        apply(cc.cwnd_initial, "cwnd-initial");                                                                                    \
-        apply(cc.cwnd_exiting_slow_start, "cwnd-exiting-slow-start");                                                              \
-        apply(cc.exit_slow_start_at, "exit-slow-start-at");                                                                        \
-        apply(cc.cwnd_exiting_jumpstart, "jumpstart-exit-cwnd");                                                                   \
-        apply(cc.cwnd_minimum, "cwnd-minimum");                                                                                    \
-        apply(cc.cwnd_maximum, "cwnd-maximum");                                                                                    \
-        apply(cc.num_loss_episodes, "num-loss-episodes");                                                                          \
-        apply(cc.num_ecn_loss_episodes, "num-ecn-loss-episodes");                                                                  \
-        apply(delivery_rate.latest, "delivery-rate-latest");                                                                       \
-        apply(delivery_rate.smoothed, "delivery-rate-smoothed");                                                                   \
-        apply(delivery_rate.stdev, "delivery-rate-stdev");                                                                         \
+        apply(jumpstart.prev_rate, "jumpstart.prev-rate");                                                                         \
+        apply(jumpstart.prev_rtt, "jumpstart.prev-rtt");                                                                           \
+        apply(jumpstart.new_rtt, "jumpstart.prev-rtt");                                                                            \
+        apply(jumpstart.cwnd, "jumpstart.cwnd");                                                                                   \
+        apply(token_sent.at, "token-sent.at");                                                                                     \
+        apply(token_sent.rate, "token-sent.rate");                                                                                 \
+        apply(token_sent.rtt, "token-sent.rtt");                                                                                   \
+        apply(rtt.minimum, "rtt.minimum");                                                                                         \
+        apply(rtt.smoothed, "rtt.smoothed");                                                                                       \
+        apply(rtt.variance, "rtt.variance");                                                                                       \
+        apply(rtt.latest, "rtt.latest");                                                                                           \
+        apply(loss_thresholds.use_packet_based, "loss-thresholds.use-packet-based");                                               \
+        apply(loss_thresholds.time_based_percentile, "loss-thresholds.time-based-percentile");                                     \
+        apply(cc.cwnd, "cc.cwnd");                                                                                                 \
+        apply(cc.ssthresh, "cc.ssthresh");                                                                                         \
+        apply(cc.cwnd_initial, "cc.cwnd-initial");                                                                                 \
+        apply(cc.cwnd_exiting_slow_start, "cc.cwnd-exiting-slow-start");                                                           \
+        apply(cc.exit_slow_start_at, "cc.exit-slow-start-at");                                                                     \
+        apply(cc.cwnd_exiting_jumpstart, "cc.jumpstart-exit-cwnd");                                                                \
+        apply(cc.cwnd_minimum, "cc.cwnd-minimum");                                                                                 \
+        apply(cc.cwnd_maximum, "cc.cwnd-maximum");                                                                                 \
+        apply(cc.num_loss_episodes, "cc.num-loss-episodes");                                                                       \
+        apply(cc.num_ecn_loss_episodes, "cc.num-ecn-loss-episodes");                                                               \
+        apply(delivery_rate.latest, "delivery-rate.latest");                                                                       \
+        apply(delivery_rate.smoothed, "delivery-rate.smoothed");                                                                   \
+        apply(delivery_rate.stdev, "delivery-rate.stdev");                                                                         \
         apply(num_sentmap_packets_largest, "num-sentmap-packets-largest");                                                         \
     } while (0)
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2008,11 +2008,17 @@ void quicly_free(quicly_conn_t *conn)
     QUICLY_PROBE(FREE, conn, conn->stash.now);
     QUICLY_LOG_CONN(free, conn, {});
 
-    if (QUICLY_PROBE_ENABLED(CONN_STATS)) {
+    PTLS_LOG_DEFINE_POINT(quicly, conn_stats, conn_stats_logpoint);
+    if (QUICLY_PROBE_ENABLED(CONN_STATS) ||
+        (ptls_log_point_maybe_active(&conn_stats_logpoint) &
+         ptls_log_conn_maybe_active(ptls_get_log_state(conn->crypto.tls), (const char *(*)(void *))ptls_get_server_name,
+                                    conn->crypto.tls)) != 0) {
         quicly_stats_t stats;
         quicly_get_stats(conn, &stats);
         QUICLY_PROBE(CONN_STATS, conn, conn->stash.now, &stats, sizeof(stats));
-        // TODO: emit stats with QUICLY_LOG_CONN()
+#define EMIT_FIELD(fld, lit) PTLS_LOG_ELEMENT_UNSIGNED(lit, stats.fld)
+        QUICLY_LOG_CONN(conn_stats, conn, { QUICLY_STATS_FOREACH(EMIT_FIELD); });
+#undef EMIT_FIELD
     }
 
     destroy_all_streams(conn, 0, 1);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -1377,7 +1377,6 @@ quicly_error_t quicly_get_stats(quicly_conn_t *conn, quicly_stats_t *stats)
     }
     quicly_ratemeter_report(&conn->egress.ratemeter, &stats->delivery_rate);
     stats->num_sentmap_packets_largest = conn->egress.loss.sentmap.num_packets_largest;
-    stats->handshake_confirmed_msec = conn->super.stats.handshake_confirmed_msec;
 
     return 0;
 }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2016,7 +2016,7 @@ void quicly_free(quicly_conn_t *conn)
         quicly_stats_t stats;
         quicly_get_stats(conn, &stats);
         QUICLY_PROBE(CONN_STATS, conn, conn->stash.now, &stats, sizeof(stats));
-#define EMIT_FIELD(fld, lit) PTLS_LOG_ELEMENT_UNSIGNED(lit, stats.fld)
+#define EMIT_FIELD(fld, lit) PTLS_LOG__DO_ELEMENT_UNSIGNED(lit, stats.fld)
         QUICLY_LOG_CONN(conn_stats, conn, { QUICLY_STATS_FOREACH(EMIT_FIELD); });
 #undef EMIT_FIELD
     }

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2015,7 +2015,7 @@ void quicly_free(quicly_conn_t *conn)
         quicly_stats_t stats;
         quicly_get_stats(conn, &stats);
         QUICLY_PROBE(CONN_STATS, conn, conn->stash.now, &stats, sizeof(stats));
-#define EMIT_FIELD(fld, lit) PTLS_LOG__DO_ELEMENT_UNSIGNED(lit, stats.fld)
+#define EMIT_FIELD(fld, lit) PTLS_LOG__DO_ELEMENT_UNSIGNED(lit, stats.fld);
         QUICLY_LOG_CONN(conn_stats, conn, { QUICLY_STATS_FOREACH(EMIT_FIELD); });
 #undef EMIT_FIELD
     }

--- a/t/test.c
+++ b/t/test.c
@@ -1037,6 +1037,10 @@ static void test_stats_foreach_field(size_t off, size_t size)
 #define GAP(before, after) offsetof(quicly_stats_t, before), offsetof(quicly_stats_t, after)
         GAP(jumpstart.cwnd, token_sent.at),
         GAP(token_sent.rtt, rtt.minimum),
+        GAP(loss_thresholds.use_packet_based, loss_thresholds.time_based_percentile),
+        GAP(loss_thresholds.time_based_percentile, cc.cwnd),
+        GAP(cc.ssthresh, cc.cwnd_initial),
+        GAP(cc.num_ecn_loss_episodes, delivery_rate.latest),
 #undef GAP
         SIZE_MAX};
     for (size_t i = 0; gaps[i] != SIZE_MAX; i += 2) {

--- a/t/test.c
+++ b/t/test.c
@@ -1026,6 +1026,22 @@ static void test_migration_during_handshake(void)
     subtest("migrate-before-3nd", do_test_migration_during_handshake, 1);
 }
 
+static size_t test_stats_foreach_next_off = 0;
+
+static void test_stats_foreach_field(size_t off, size_t size)
+{
+    ok(test_stats_foreach_next_off == off);
+    test_stats_foreach_next_off += size;
+}
+
+static void test_stats_foreach(void)
+{
+#define CHECK(fld, name)                                                                                                           \
+    subtest(name, test_stats_foreach_field, offsetof(quicly_stats_t, fld), sizeof(((quicly_stats_t *)NULL)->fld))
+    QUICLY_STATS_FOREACH(CHECK);
+#undef CHECK
+}
+
 int main(int argc, char **argv)
 {
     static ptls_iovec_t cert;
@@ -1100,6 +1116,8 @@ int main(int argc, char **argv)
 
     subtest("state-exhaustion", test_state_exhaustion);
     subtest("migration-during-handshake", test_migration_during_handshake);
+
+    subtest("stats-foreach", test_stats_foreach);
 
     return done_testing();
 }

--- a/t/test.c
+++ b/t/test.c
@@ -1056,12 +1056,23 @@ static void test_stats_foreach_field(size_t off, size_t size)
 
 static void test_stats_foreach(void)
 {
-    test_stats_foreach_next_off = 0;
 #define CHECK(fld, name)                                                                                                           \
     subtest(name, test_stats_foreach_field, offsetof(quicly_stats_t, fld), sizeof(((quicly_stats_t *)NULL)->fld))
+
+    /* check QUICLY_STATS_FOREACH touches all fields, in the correct order */
+    test_stats_foreach_next_off = 0;
     QUICLY_STATS_FOREACH(CHECK);
-#undef CHECK
     ok(test_stats_foreach_next_off == sizeof(quicly_stats_t));
+
+    /* check QUICLY_STATS_FOREACH_COUNTERS only check the counters */
+    struct counters_only {
+        QUICLY_STATS_PREBUILT_COUNTERS;
+    };
+    test_stats_foreach_next_off = 0;
+    QUICLY_STATS_FOREACH_COUNTERS(CHECK);
+    ok(test_stats_foreach_next_off == sizeof(struct counters_only));
+
+#undef CHECK
 }
 
 int main(int argc, char **argv)

--- a/t/test.c
+++ b/t/test.c
@@ -1058,7 +1058,7 @@ static void test_stats_foreach_field(size_t off, size_t size)
 static void test_stats_foreach(void)
 {
 #define CHECK(fld, name)                                                                                                           \
-    subtest(name, test_stats_foreach_field, offsetof(quicly_stats_t, fld), sizeof(((quicly_stats_t *)NULL)->fld))
+    subtest(name, test_stats_foreach_field, offsetof(quicly_stats_t, fld), sizeof(((quicly_stats_t *)NULL)->fld));
 
     /* check QUICLY_STATS_FOREACH touches all fields, in the correct order */
     test_stats_foreach_next_off = 0;

--- a/t/test.c
+++ b/t/test.c
@@ -1032,9 +1032,10 @@ static void test_stats_foreach_field(size_t off, size_t size)
 {
     ok(test_stats_foreach_next_off == off);
 
-    /* if a gap exists after the current slot, then the next field exists at the end of the gap */
+    /* Due to alignment, padding might exist between two fields when their types are different. The `gaps` list calls out the ones
+     * that "might" have such padding on some architectures. */
     static const size_t gaps[] = {
-#define GAP(before, after) offsetof(quicly_stats_t, before), offsetof(quicly_stats_t, after)
+#define GAP(after, before) offsetof(quicly_stats_t, after), offsetof(quicly_stats_t, before)
         GAP(jumpstart.cwnd, token_sent.at),
         GAP(token_sent.rtt, rtt.minimum),
         GAP(loss_thresholds.use_packet_based, loss_thresholds.time_based_percentile),


### PR DESCRIPTION
The iterator is defined as a macro, and the names are stolen from the `log_quic_stats` function of h2o, so that h2o can depend instead on the iterator introduced to quicly.