### PR TITLE
scaled slow start

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -155,7 +155,7 @@ QUICLY_CALLBACK_TYPE(quicly_error_t, generate_resumption_token, quicly_conn_t *c
  * called to initialize a congestion controller for a new connection.
  * should in turn call one of the quicly_cc_*_init functions from cc.h with customized parameters.
  */
-QUICLY_CALLBACK_TYPE(void, init_cc, quicly_cc_t *cc, uint32_t initcwnd, int64_t now);
+QUICLY_CALLBACK_TYPE(void, init_cc, quicly_cc_t *cc, uint32_t initcwnd, int64_t now, uint16_t slow_start_increase);
 /**
  * reference counting.
  * delta must be either 1 or -1.
@@ -344,6 +344,11 @@ struct st_quicly_context_t {
      */
     uint64_t max_path_validation_failures;
     /**
+     * If set to non-zero, CWND is be increased by `scaled_slow_start / 256` bytes for each byte acked. If set to zero, CWND
+     * increase is 1 byte per byte acked.
+     */
+    uint32_t scaled_slow_start;
+    /**
      * Jumpstart CWND to be used when there is no previous information. If set to zero, slow start is used. Note jumpstart is
      * possible only when the use_pacing flag is set.
      */
@@ -354,9 +359,10 @@ struct st_quicly_context_t {
      */
     uint32_t max_jumpstart_cwnd_packets;
     /**
-     * Probabilities for enabling jumpstart when they are configured, multiplied by 255. 0 means never, 255 (default) means always.
+     * Probabilities for enabling features when they are configured, multiplied by 255. 0 means never, 255 (default) means always.
      */
     struct {
+        uint8_t scaled_slow_start;
         struct {
             uint8_t non_resume;
             uint8_t resume;

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -39,6 +39,7 @@ extern "C" {
 
 #define QUICLY_MIN_CWND 2
 #define QUICLY_RENO_BETA 0.7
+#define QUICLY_STANDARD_SLOW_START_INCREASE 256 /* +1x */
 
 /**
  * Holds pointers to concrete congestion control implementation functions.
@@ -62,6 +63,10 @@ typedef struct st_quicly_cc_t {
      * Packet number indicating end of recovery period, if in recovery.
      */
     uint64_t recovery_end;
+    /**
+     * Bytes to add to CWND for each byte being acked, multiplied by 256 (default is QUICLY_STANDARD_SLOW_START_INCREASE)
+     */
+    uint16_t slow_start_increase;
     /**
      * If the most recent loss episode was signalled by ECN only (i.e., no packet loss).
      */

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -77,7 +77,7 @@ static void cubic_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t 
 
     /* Slow start. */
     if (cc->cwnd < cc->ssthresh) {
-        cc->cwnd = quicly_u32_add_saturating(cc->cwnd, bytes);
+        cc->cwnd = quicly_u32_add_saturating(cc->cwnd, (uint32_t)((uint64_t)bytes * cc->slow_start_increase / 256));
         if (cc->cwnd_maximum < cc->cwnd)
             cc->cwnd_maximum = cc->cwnd;
         return;
@@ -172,11 +172,12 @@ static void cubic_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
     cc->state.cubic.last_sent_time = now;
 }
 
-static void cubic_reset(quicly_cc_t *cc, uint32_t initcwnd)
+static void cubic_reset(quicly_cc_t *cc, uint32_t initcwnd, uint16_t slow_start_increase)
 {
     memset(cc, 0, sizeof(quicly_cc_t));
     cc->type = &quicly_cc_type_cubic;
     cc->cwnd = cc->cwnd_initial = cc->cwnd_maximum = initcwnd;
+    cc->slow_start_increase = slow_start_increase;
     cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
     cc->exit_slow_start_at = INT64_MAX;
 
@@ -193,7 +194,7 @@ static int cubic_on_switch(quicly_cc_t *cc)
         if (cc->cwnd_exiting_slow_start == 0) {
             cc->type = &quicly_cc_type_cubic;
         } else {
-            cubic_reset(cc, cc->cwnd_initial);
+            cubic_reset(cc, cc->cwnd_initial, cc->slow_start_increase);
         }
         return 1;
     }
@@ -201,9 +202,9 @@ static int cubic_on_switch(quicly_cc_t *cc)
     return 0;
 }
 
-static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
+static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now, uint16_t slow_start_add_ratio)
 {
-    cubic_reset(cc, initcwnd);
+    cubic_reset(cc, initcwnd, slow_start_add_ratio);
 }
 
 quicly_cc_type_t quicly_cc_type_cubic = {"cubic",         &quicly_cc_cubic_init,          cubic_on_acked,

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -53,13 +53,14 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                               DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
                                               DEFAULT_MAX_PROBE_PACKETS,
                                               DEFAULT_MAX_PATH_VALIDATION_FAILURES,
-                                              0,            /* default_jumpstart_cwnd_bytes */
-                                              0,            /* max_jumpstart_cwnd_bytes */
-                                              {{255, 255}}, /* enable_ratio */
-                                              0,            /* enlarge_client_hello */
-                                              1,            /* enable_ecn */
-                                              0,            /* use_pacing */
-                                              1,            /* cc_recognize_app_limited */
+                                              0,                 /* scaled_slow_start */
+                                              0,                 /* default_jumpstart_cwnd_bytes */
+                                              0,                 /* max_jumpstart_cwnd_bytes */
+                                              {255, {255, 255}}, /* enable_ratio */
+                                              0,                 /* enlarge_client_hello */
+                                              1,                 /* enable_ecn */
+                                              0,                 /* use_pacing */
+                                              1,                 /* cc_recognize_app_limited */
                                               NULL,
                                               NULL, /* on_stream_open */
                                               &quicly_default_stream_scheduler,
@@ -91,13 +92,14 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                     DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
                                                     DEFAULT_MAX_PROBE_PACKETS,
                                                     DEFAULT_MAX_PATH_VALIDATION_FAILURES,
-                                                    0,            /* default_jumpstart_cwnd_bytes */
-                                                    0,            /* max_jumpstart_cwnd_bytes */
-                                                    {{255, 255}}, /* enable_ratio */
-                                                    0,            /* enlarge_client_hello */
-                                                    1,            /* enable_ecn */
-                                                    0,            /* use_pacing */
-                                                    1,            /* cc_recognize_app_limited */
+                                                    0,                 /* scaled_slow_start */
+                                                    0,                 /* default_jumpstart_cwnd_bytes */
+                                                    0,                 /* max_jumpstart_cwnd_bytes */
+                                                    {255, {255, 255}}, /* enable_ratio */
+                                                    0,                 /* enlarge_client_hello */
+                                                    1,                 /* enable_ecn */
+                                                    0,                 /* use_pacing */
+                                                    1,                 /* cc_recognize_app_limited */
                                                     NULL,
                                                     NULL, /* on_stream_open */
                                                     &quicly_default_stream_scheduler,

--- a/t/jumpstart.c
+++ b/t/jumpstart.c
@@ -37,7 +37,7 @@ static void test_jumpstart_pattern(quicly_init_cc_t *init, const struct test_jum
     uint32_t packets_acked = 0, packets_inflight = 0;
     size_t ackcnt = 0;
 
-    init->cb(init, &cc, 10 * mtu, now);
+    init->cb(init, &cc, 10 * mtu, now, QUICLY_STANDARD_SLOW_START_INCREASE);
     ok(cc.cwnd == 10 * mtu);
     ok(cc.num_loss_episodes == 0);
 


### PR DESCRIPTION
Provides a knob to use a different increase ratio for Slow Start.

This PR depends on #620, and for the ease of reviewing the PR, the base is set to #620.