### PR TITLE
Fix max-stream-data and add stop_sending error_code

### DIFF
--- a/misc/qlog-adapter.py
+++ b/misc/qlog-adapter.py
@@ -166,7 +166,7 @@ def handle_max_stream_data_receive(event):
     return {
         "frame_type": "max_stream_data",
         "stream_id": event["stream-id"],
-        "maximum": event["maximum"]
+        "maximum": event["max-stream-data"]
     }
 
 def handle_max_stream_data_send(event):
@@ -267,7 +267,8 @@ def handle_stream_send(event):
 def handle_stream_on_send_stop(event):
     return {
         "frame_type": "stop_sending",
-        "stream_id": event["stream-id"]
+        "stream_id": event["stream-id"],
+        "error_code": event["err"]
     }
 
 def handle_streams_blocked_receive(event):


### PR DESCRIPTION
While it is "maximum" for `handle_max_stream_data_send` (https://github.com/h2o/quicly/blob/df55466e82f71a7a3aabdfbab37d88cd943c52d6/lib/quicly.c#L4109), it is "max_stream_data" when we receive that frame (https://github.com/h2o/quicly/blob/df55466e82f71a7a3aabdfbab37d88cd943c52d6/lib/quicly.c#L6182).

The error code is added to `stop_sending` in accordance with https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-quic-events-11#name-stopsendingframe.