### PR TITLE
add script for generating gnuplot script

### DIFF
--- a/quicly.xcodeproj/project.pbxproj
+++ b/quicly.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		0829878C26DF775B0053638F /* rate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rate.h; sourceTree = "<group>"; };
 		0829878D26E03D4D0053638F /* rate.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rate.c; sourceTree = "<group>"; };
 		0829879126E0A9DF0053638F /* rate.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rate.c; sourceTree = "<group>"; };
+		083944A02EC2F45100ACE544 /* simulator-gnuplot.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = "simulator-gnuplot.pl"; sourceTree = "<group>"; };
 		085125F728EFC0480074C124 /* cplusplus.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = cplusplus.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		085AB4D626427E9C00DF5209 /* pacer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pacer.h; sourceTree = "<group>"; };
 		085AB4D8264283D600DF5209 /* pacer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pacer.c; sourceTree = "<group>"; };
@@ -483,11 +484,12 @@
 				E9736534246FD3DA0039AA49 /* remote_cid.c */,
 				E920D22D1F4981E500799777 /* sentmap.c */,
 				E920D2241F49412900799777 /* simple.c */,
+				0829878226D37E370053638F /* simulator.c */,
+				083944A02EC2F45100ACE544 /* simulator-gnuplot.pl */,
 				E99B75E81F5D259400CF503E /* stream-concurrency.c */,
 				E9F6A4281F3C3B3F0083F0B2 /* test.h */,
 				E9CC44241EC1962700DC7D3E /* test.c */,
 				E98F4CBC20E5CF3A00362F15 /* udpfw.c */,
-				0829878226D37E370053638F /* simulator.c */,
 			);
 			path = t;
 			sourceTree = "<group>";

--- a/t/simulator-gnuplot.pl
+++ b/t/simulator-gnuplot.pl
@@ -1,0 +1,160 @@
+# This script runs the simulator with the given arguments specifying the network condition, with rapid start
+# on and off, and generates a gnuplot script that compares the results.
+use strict;
+use warnings;
+use Getopt::Long;
+use JSON;
+
+my $simulator = ($ENV{BINARY_DIR} || ".") . "/simulator";
+
+my $NETWORKS = {
+    DSL => {
+        rtt   => .03,
+        queue => .05,
+        bw    => 30e6,
+    },
+    Home_WiFi => {
+        rtt   => .025,
+        queue => .015,
+        bw    => 100e6, 
+    },
+    Public => {
+        rtt   => .04,
+        queue => .2, # bufferbloat
+        bw    => 20e6, 
+    },
+    Corporate_WiFi => {
+        rtt   => .01,
+        queue => .02,
+        bw    => 500e6, 
+    },
+    LTE => {
+        rtt   => .06,
+        queue => .12,
+        bw    => 30e6, 
+    },
+    '5G' => {
+        rtt   => .04,
+        queue => .08,
+        bw    => 100e6, 
+    },
+    LEO => {
+        rtt   => .04,
+        queue => .08,
+        bw    => 50e6, 
+    },
+    GEO => {
+        rtt   => .6,
+        queue => .6,
+        bw    => 50e6,
+    },
+    'DoCoMo@Office' => {
+        rtt   => .028,
+        queue => .245 - .028,
+        bw    => 140e6,
+    },
+    'au@Office' => {
+        rtt   => .02,
+        queue => .253 - .02,
+        bw    => 440e6,
+    },
+    'WiFi@Office' => {
+        rtt   => .004,
+        queue => .015 - .004,
+        bw    => 710e6,
+    },
+    'DoCoMo@mall' => {
+        rtt   => .041,
+        queue => .341 - .041,
+        bw    => 38e6,
+    },
+    congested => {
+        rtt   => 0.2,
+        queue => 0.4,
+        bw    => 1e6,
+    },
+};
+
+my $cc = 'pico';
+my $length = 1;
+my $network = $NETWORKS->{DSL};
+my $show_queue;
+
+# get options applied to all simulations
+GetOptions(
+    "cc=s" => \$cc,
+    "length=f" => \$length,
+    "network=s" => sub {
+        my ($optname, $optval) = @_;
+        $network = $NETWORKS->{$optval}
+            or die "unknown network: $optval";
+    },
+    "queue" => \$show_queue,
+) or die "bad options";
+
+# get options for each flow
+my @flows;
+while (@ARGV) {
+    my $label = shift;
+    my @flow_opts;
+    while (@ARGV && $ARGV[0] ne '--') {
+        push @flow_opts, shift(@ARGV);
+    }
+    push @flows, [$label, \@flow_opts];
+    shift @ARGV; # remove the -- separator
+}
+
+die "--queue cannot be used when multiple flows are given\n"
+    if $show_queue && @flows > 1;
+
+# run simulations
+for my $flow (@flows) {
+    open(
+        my $fh, "-|", $simulator, @{$flow->[1]},
+        '-d', $network->{rtt},
+        '-q', $network->{queue},
+        '-b', $network->{bw} / 8,
+        '-l', $length,
+        '-n', $cc,
+    ) or die "failed to run simulator: $!";
+    my ($bytes_avail, $queue_size) = simout_to_xy($fh);
+    close $fh
+        or die "simulator exited with a non-zero exit code: $?";
+    print << "GP";
+\$F_$flow->[0] << EOD
+${bytes_avail}EOD
+\$Q_$flow->[0] << EOD
+${queue_size}EOD
+GP
+}
+
+print << "GP";
+set xrange [0:$length]
+set key left top
+set y2tics
+GP
+
+print "plot ", join(", ", map {
+    qq!\$F_$_->[0] using 1:2 axis x1y1 with lines title "$_->[0] - deliver"!
+} @flows), "\n";
+if ($show_queue) {
+    print "replot ", join(", ", map {
+        qq!\$Q_$_->[0] using 1:2 axis x1y2 with lines title "$_->[0] - queue"!
+    } @flows), "\n";
+}
+
+# given the output of the simulator, convert to x,y pairs for gnuplot
+sub simout_to_xy {
+    my $fh = shift;
+    my $bytes_avail = "";
+    my $queue_size = "";
+    while (my $line = <$fh>) {
+        my $json = decode_json($line);
+        if ($json->{"bytes-available"}) {
+            $bytes_avail .= "@{[$json->{at} - 1000]} $json->{\"bytes-available\"}\n";
+        } elsif ($json->{bottleneck} && $json->{bottleneck} eq 'dequeue') {
+            $queue_size .= "@{[$json->{at} - 1000]} $json->{\"queue-size\"}\n";
+        }
+    }
+    return ($bytes_avail, $queue_size);
+}


### PR DESCRIPTION
t/simulator-gnuplot.pl is a wrapper around `t/simulator.c` that is used for visualizing the behavior of CC in simulated environments.

Users should read the source code to find out the details, however, the script can be used in two ways:

__1. Visualizing the Behavior of one CC__

The performance of congestion control can be quantified by integrating f(t), where f(t) is the amount of data (in bytes) that the client has received at time t after the start of the transfer; with a noted that, when short flows are taken into account, the region near t = 0 becomes especially important.

To achieve that, it is important for the CC to keep the bottleneck flowing (paraphrase: minimize the amount of time the bottleneck queue is drained), and avoid packet losses, as when packets are lost at the tail, their recovery incur an additional round-trip.

When invoked like:
```
% BINARY_DIR=build/default perl t/simulator-gnuplot.pl --queue --network=5G --length=1.5 -- slowstart -i 30 -p | gnuplot -p
```
a simulation of a 5G network (the --network option) for 1.5 seconds (--length) is run with an IW of 30 packets with pacing, and is named as "slowstart" (i.e., `-- slowstart -i 30 -p`).

Similarly, when invoked like:
```
% BINARY_DIR=build/default perl t/simulator-gnuplot.pl --queue --network=5G --length=1.5 -- rapidstart -i 30 -j 60 -p -R | gnuplot -p
```
it simulates the same network but, in addition to above, uses rapid start (-R) with a jump_cwnd of 60 packets (-j).

In both runs, `--queue` option instructs the script to collect the bottleneck queue size as well.

The outcome of the two invocation looks like below:
<img width="1286" height="583" alt="Screenshot 2025-11-11 at 13 45 41" src="https://github.com/user-attachments/assets/23f02bf2-366c-4573-b6a3-9d0c7bb040b6" />

The purple lines are f(t), and hence the performance of CC can be considered the area below the purple lines. The green lines show the amount of bytes stored in the bottleneck queue (Y-axis on the right side).

__2. Comparing CCs__

It is possible to specify multiple CCs and compare their results, like below. Note that `--queue` option cannot be used when specifying multiple CCs.

```
% BINARY_DIR=build/default perl t/simulator-gnuplot.pl --network=5G --length=1.5 -- slowstart -i 30 -p -- rapidstart -i 30 -j 60 -p -R | gnuplot -p
```
<img width="754" height="693" alt="Screenshot 2025-11-11 at 14 22 49" src="https://github.com/user-attachments/assets/db22caa3-eb4d-407e-8fea-e41a897cd42e" />

In this chart, f(t) of slow start is shown by the purple line, whereas that of rapid start is shown by the green line. It is evident that in this scenario, rapid start offers superior performance.