### PR TITLE
[pico][rapid start] increase rate in the first congestion avoidance phase is too small

### DIFF
--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -140,9 +140,12 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
     { /* Calculate increase rate based on CWND before reduction. When rapid start is on but the loss is observed while jump start is
        * in action, CWND is not adjusted in the code above, therefore jumpstart.bytes_acked is adopted here. */
         uint32_t bdp = cc->cwnd;
-        if (cc->num_loss_episodes == 1 && quicly_cc_rapid_start_is_enabled(&cc->rapid_start) &&
-            quicly_cc_is_jumpstart_ack(cc, lost_pn)) {
-            bdp = cc->jumpstart.bytes_acked;
+        if (cc->num_loss_episodes == 1 && quicly_cc_rapid_start_is_enabled(&cc->rapid_start)) {
+            if (quicly_cc_is_jumpstart_ack(cc, lost_pn)) {
+                bdp = cc->jumpstart.bytes_acked;
+            } else {
+                bdp = cc->cwnd / 3;
+            }
             if (bdp < cc->cwnd_initial)
                 bdp = cc->cwnd_initial;
         }


### PR DESCRIPTION
In the congestion avoidance phase, pico uses an increase rate calculated based on BDP and smoothed RTT, using CWND as an approximate of BDP.

However, after the first loss, CWND could be 3x as large as BDP, and that leads to the increase rate being too small, when rapid start is used. This is a non-issue when rapid start is _not_ used, because if not used, the 2nd recovery period immediately follows the first, and CWND becomes a better approximate of the BDP.

#632 fixed the same issue specifically for when a loss is observed in the validation phase of jumpstart (Careful Resume), but not generally.

This PR addresses the problem by adopting `CWND / 3` as the approximation of BDP when calculating the increase rate. We might end up adopting a rate that is 3x aggressive than what is correct, but probably being aggressive is alright considering that it is the first attempt for the connection. Traditional slow start is worse in this respect, after all.

The charts below represent runs of `BINARY_DIR=build/default perl t/simulator-gnuplot.pl --queue --network=Home_WiFi --length=15 -- rapidstart -i 30 -j 60 -p -R | gnuplot -p`. Left-hand side is master, right-hand side is this PR.

<img width="1286" height="582" alt="Screenshot 2025-11-12 at 20 42 20" src="https://github.com/user-attachments/assets/7b314ced-4cac-46a4-871f-b43e347079b2" />


Amends #622, #632.