### PR TITLE
[jumpstart] fix crash introduced by #632

### DIFF
--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -121,7 +121,7 @@ static void cubic_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
 
     /* if detected loss before receiving all acks for jumpstart, restore original CWND */
     if (cc->ssthresh == UINT32_MAX)
-        quicly_cc_jumpstart_on_first_loss(cc, lost_pn);
+        quicly_cc_jumpstart_on_first_loss(cc, lost_pn, 0);
 
     ++cc->num_loss_episodes;
     if (cc->cwnd_exiting_slow_start == 0) {

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -130,8 +130,7 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
     if (cc->cwnd_exiting_slow_start == 0) {
         assert(cc->ssthresh == UINT32_MAX);
         /* jumpstart: if detected loss during the validating phase, advance to validating phase */
-        if (!quicly_cc_rapid_start_is_enabled(&cc->rapid_start))
-            quicly_cc_jumpstart_on_first_loss(cc, lost_pn);
+        quicly_cc_jumpstart_on_first_loss(cc, lost_pn, quicly_cc_rapid_start_is_enabled(&cc->rapid_start));
         /* save values */
         cc->cwnd_exiting_slow_start = cc->cwnd;
         cc->exit_slow_start_at = now;

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -71,7 +71,7 @@ void quicly_cc_reno_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t
 
     /* if detected loss before receiving all acks for jumpstart, restore original CWND */
     if (cc->ssthresh == UINT32_MAX)
-        quicly_cc_jumpstart_on_first_loss(cc, lost_pn);
+        quicly_cc_jumpstart_on_first_loss(cc, lost_pn, 0);
 
     ++cc->num_loss_episodes;
     if (cc->cwnd_exiting_slow_start == 0) {


### PR DESCRIPTION
#632 changed how the functions related to jumpstart are invoked, but that introduced a regression.

Specifically, when `quicly_cc_jumpstart_on_acked` is called *after* the first recovery period, the function might be tricked into thinking that it is still in unvalidated phase, and raise an assertion failure due to ssthresh already been shrunk.

This pull request fixes the regression by calling `quicly_cc_jumpstart_on_first_loss` even when rapidstart is used.