### PR TITLE
Fix a couple of compiler warnings

### DIFF
--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -207,6 +207,7 @@ static int64_t quicly_loss_get_sentmap_expiration_time(quicly_loss_t *loss, uint
 
 inline void quicly_rtt_init(quicly_rtt_t *rtt, const quicly_loss_conf_t *conf, uint32_t initial_rtt)
 {
+    (void) conf;
     rtt->minimum = UINT32_MAX;
     rtt->latest = 0;
     rtt->smoothed = initial_rtt;

--- a/include/quicly/maxsender.h
+++ b/include/quicly/maxsender.h
@@ -77,6 +77,7 @@ inline void quicly_maxsender_init(quicly_maxsender_t *m, int64_t initial_value)
 
 inline void quicly_maxsender_dispose(quicly_maxsender_t *m)
 {
+    (void) m;
 }
 
 inline void quicly_maxsender_request_transmit(quicly_maxsender_t *m)


### PR DESCRIPTION
These warnings affect mainly users of Quicly's header files.

Actually I discovered this issue while using `libh2o` - consider the following test code:
```
// test.c
#include <h2o.h>

int main(void)
{
	return 0;
}
```
On Ubuntu 25.10 compile with:
```
cc -DH2O_USE_LIBUV=0 -I /tmp/h2o/include -pedantic -std=gnu11 -Wall -Wextra test.c
```
which results in:
```
In file included from /tmp/h2o/include/quicly/sentmap.h:32,
                 from /tmp/h2o/include/quicly/loss.h:33,
                 from /tmp/h2o/include/quicly.h:40,
                 from /tmp/h2o/include/h2o/httpclient.h:29,
                 from /tmp/h2o/include/h2o.h:45,
                 from test.c:2:
/tmp/h2o/include/quicly/maxsender.h: In function ‘quicly_maxsender_dispose’:
/tmp/h2o/include/quicly/maxsender.h:78:58: warning: unused parameter ‘m’ [-Wunused-parameter]
   78 | inline void quicly_maxsender_dispose(quicly_maxsender_t *m)
      |                                      ~~~~~~~~~~~~~~~~~~~~^
/tmp/h2o/include/quicly/loss.h: In function ‘quicly_rtt_init’:
/tmp/h2o/include/quicly/loss.h:208:74: warning: unused parameter ‘conf’ [-Wunused-parameter]
  208 | inline void quicly_rtt_init(quicly_rtt_t *rtt, const quicly_loss_conf_t *conf, uint32_t initial_rtt)
      |                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
```