### PR TITLE
avoid wasting one full MTU by generating an immediate ACK for partial ClientHello

### DIFF
--- a/t/test.c
+++ b/t/test.c
@@ -620,15 +620,15 @@ static void do_test_record_receipt(size_t epoch)
 
     if (epoch == QUICLY_EPOCH_1RTT) {
         /* 2nd packet triggers an ack */
-        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
+        ok(record_receipt(space, pn++, 0, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now + QUICLY_DELAYED_ACK_TIMEOUT);
         now += 1;
-        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
+        ok(record_receipt(space, pn++, 0, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now);
         now += 1;
     } else {
         /* every packet triggers an ack */
-        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
+        ok(record_receipt(space, pn++, 0, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now);
         now += 1;
     }
@@ -638,23 +638,23 @@ static void do_test_record_receipt(size_t epoch)
     send_ack_at = INT64_MAX;
 
     /* ack-only packets do not elicit an ack */
-    ok(record_receipt(space, pn++, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
+    ok(record_receipt(space, pn++, 0, 1, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == INT64_MAX);
     now += 1;
-    ok(record_receipt(space, pn++, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
+    ok(record_receipt(space, pn++, 0, 1, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == INT64_MAX);
     now += 1;
     pn++; /* gap */
-    ok(record_receipt(space, pn++, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
+    ok(record_receipt(space, pn++, 0, 1, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == INT64_MAX);
     now += 1;
-    ok(record_receipt(space, pn++, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
+    ok(record_receipt(space, pn++, 0, 1, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == INT64_MAX);
     now += 1;
 
     /* gap triggers an ack */
     pn += 1; /* gap */
-    ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
+    ok(record_receipt(space, pn++, 0, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == now);
     now += 1;
 
@@ -666,10 +666,10 @@ static void do_test_record_receipt(size_t epoch)
     if (epoch == QUICLY_EPOCH_1RTT) {
         space->ignore_order = 1;
         pn++; /* gap */
-        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
+        ok(record_receipt(space, pn++, 0, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now + QUICLY_DELAYED_ACK_TIMEOUT);
         now += 1;
-        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
+        ok(record_receipt(space, pn++, 0, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now);
         now += 1;
     }


### PR DESCRIPTION
This PR changes the behavior of quicly when running as a server so that, if an Initial or a Handshake packet is received before the client's address is validated, it uses a 1ms ack delay rather than acknowledging immediately. Note that for these types of packets, ACKs will be bundled whenever application data is sent.

The net effect of this change is that when the client's first flight is split into two packets (e.g., when mlkem768x25519 is used) and the server receives the 1st packet, the server waits for 1ms before sending an ACK. By doing so, the server would avoid wasting one full MTU for just sending an ACK-only packet, if the other packet from the client arrives within the delay.

Closes #639. Builds on top of #640.