### PR TITLE
indicate close initiated by the local transport

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -1214,8 +1214,8 @@ static quicly_state_t quicly_get_state(quicly_conn_t *conn);
  * Returns the error code and other information regarding the closure of the connection. The out parameters may be NULL. This
  * function must only be called after the the state transitions to QUICLY_STATE_CLOSING or QUICLY_STATE_DRAINING.
  */
-quicly_error_t quicly_get_close_reason(quicly_conn_t *conn, int *is_remote, uint64_t *offending_frame_type,
-                                       const char **reason_phrase);
+quicly_error_t quicly_get_close_reason(quicly_conn_t *conn, uint64_t *offending_frame_type, const char **reason_phrase,
+                                       int *is_remote);
 /**
  *
  */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -133,10 +133,11 @@ QUICLY_CALLBACK_TYPE(quicly_error_t, stream_open, quicly_stream_t *stream);
  */
 QUICLY_CALLBACK_TYPE(void, receive_datagram_frame, quicly_conn_t *conn, ptls_iovec_t payload);
 /**
- * called when the connection is closed by remote peer
+ * Called when the connection is closed (i.e., when entering the closing or draining state). Otherwise the callback is not called;
+ * e.g., when `quicly_free` is called directly while the connection is in the connected state. Call `quicly_get_close_reason` to
+ * obtain the details of the closure.
  */
-QUICLY_CALLBACK_TYPE(void, closed_by_remote, quicly_conn_t *conn, quicly_error_t err, uint64_t frame_type, const char *reason,
-                     size_t reason_len);
+QUICLY_CALLBACK_TYPE(void, closed, quicly_conn_t *conn);
 /**
  * Returns current time in milliseconds. The returned value MUST monotonically increase (i.e., it is the responsibility of the
  * callback implementation to guarantee that the returned value never goes back to the past).
@@ -400,9 +401,9 @@ struct st_quicly_context_t {
      */
     quicly_receive_datagram_frame_t *receive_datagram_frame;
     /**
-     * callback called when a connection is closed by remote peer
+     * callback called when a connection enters closing or draining
      */
-    quicly_closed_by_remote_t *closed_by_remote;
+    quicly_closed_t *closed;
     /**
      * returns current time in milliseconds
      */
@@ -1209,6 +1210,12 @@ static const quicly_transport_parameters_t *quicly_get_remote_transport_paramete
  *
  */
 static quicly_state_t quicly_get_state(quicly_conn_t *conn);
+/**
+ * Returns the error code and other information regarding the closure of the connection. The out parameters may be NULL. This
+ * function must only be called after the the state transitions to QUICLY_STATE_CLOSING or QUICLY_STATE_DRAINING.
+ */
+quicly_error_t quicly_get_close_reason(quicly_conn_t *conn, int *is_remote, uint64_t *offending_frame_type,
+                                       const char **reason_phrase);
 /**
  *
  */

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -6072,11 +6072,18 @@ static int set_connection_close(quicly_conn_t *conn, quicly_error_t err, uint64_
 {
     assert(conn->connection_close.reason_phrase == NULL && "never called twice");
 
-    conn->connection_close.err = err;
     if (QUICLY_ERROR_IS_QUIC_APPLICATION(err)) {
+        conn->connection_close.err = err;
         conn->connection_close.frame_type = UINT64_MAX;
     } else {
         assert(frame_type != UINT64_MAX);
+        if (QUICLY_TRANSPORT_ERROR_CRYPTO(0) <= err && err <= QUICLY_TRANSPORT_ERROR_CRYPTO(0xff)) {
+            /* TLS alerts use the that of picotls */
+            uint8_t tls_alert = err - QUICLY_TRANSPORT_ERROR_CRYPTO(0);
+            conn->connection_close.err = is_remote ? PTLS_ALERT_TO_PEER_ERROR(tls_alert) : PTLS_ALERT_TO_SELF_ERROR(tls_alert);
+        } else {
+            conn->connection_close.err = err;
+        }
         conn->connection_close.frame_type = frame_type;
     }
     if ((conn->connection_close.reason_phrase = malloc(reason_phrase_len + 1)) == NULL)

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -443,7 +443,7 @@ struct st_quicly_conn_t {
      */
     struct {
         quicly_error_t err;
-        uint64_t frame_type;
+        uint64_t frame_type; /* UINT64_MAX if application close */
         char *reason_phrase;
         uint8_t is_remote : 1;
         unsigned long num_packets_received;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5191,13 +5191,16 @@ static quicly_error_t send_connection_close(quicly_conn_t *conn, size_t epoch, q
          * (PROTOCOL_VIOLATION) is used. The exact cause is communicated using the reason phrase field because it is sometimes
          * difficult for the peer to understand the problem without; e.g., when an ACK triggering the loss of a RETIRE_CONNECTION_ID
          * frame leading to the overflow of `quicly_conn_t::egress.retire_cid`. */
+        assert(offending_frame_type != UINT64_MAX);
         error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION);
         if (reason_phrase[0] == '\0')
             reason_phrase = "state exhaustion";
     } else if (QUICLY_ERROR_IS_QUIC_TRANSPORT(conn->connection_close.err)) {
+        assert(offending_frame_type != UINT64_MAX);
         error_code = QUICLY_ERROR_GET_ERROR_CODE(conn->connection_close.err);
     } else if (QUICLY_ERROR_IS_QUIC_APPLICATION(conn->connection_close.err)) {
         /* conceal application errors unless sending in the application packet number space */
+        assert(offending_frame_type == UINT64_MAX);
         switch (get_epoch(s->current.first_byte)) {
         case QUICLY_EPOCH_INITIAL:
         case QUICLY_EPOCH_HANDSHAKE:
@@ -5210,8 +5213,10 @@ static quicly_error_t send_connection_close(quicly_conn_t *conn, size_t epoch, q
             break;
         }
     } else if (PTLS_ERROR_GET_CLASS(conn->connection_close.err) == PTLS_ERROR_CLASS_SELF_ALERT) {
+        assert(offending_frame_type != UINT64_MAX);
         error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_CRYPTO(PTLS_ERROR_TO_ALERT(conn->connection_close.err)));
     } else {
+        assert(offending_frame_type != UINT64_MAX);
         error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_INTERNAL);
     }
 
@@ -5222,7 +5227,7 @@ static quicly_error_t send_connection_close(quicly_conn_t *conn, size_t epoch, q
     s->dst = quicly_encode_close_frame(s->dst, error_code, offending_frame_type, reason_phrase);
 
     /* update counter, probe */
-    if (!QUICLY_ERROR_IS_QUIC_APPLICATION(conn->connection_close.err)) {
+    if (offending_frame_type != UINT64_MAX) {
         ++conn->super.stats.num_frames_sent.transport_close;
         QUICLY_PROBE(TRANSPORT_CLOSE_SEND, conn, conn->stash.now, error_code, offending_frame_type, reason_phrase);
         QUICLY_LOG_CONN(transport_close_send, conn, {

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -5195,7 +5195,6 @@ static quicly_error_t send_connection_close(quicly_conn_t *conn, size_t epoch, q
         if (reason_phrase[0] == '\0')
             reason_phrase = "state exhaustion";
     } else if (QUICLY_ERROR_IS_QUIC_TRANSPORT(conn->connection_close.err)) {
-        assert(conn->connection_close.frame_type == UINT64_MAX);
         error_code = QUICLY_ERROR_GET_ERROR_CODE(conn->connection_close.err);
     } else if (QUICLY_ERROR_IS_QUIC_APPLICATION(conn->connection_close.err)) {
         /* conceal application errors unless sending in the application packet number space */
@@ -6066,10 +6065,15 @@ static quicly_error_t enter_close(quicly_conn_t *conn, int local_is_initiating, 
 static int set_connection_close(quicly_conn_t *conn, quicly_error_t err, uint64_t frame_type, const char *reason_phrase,
                                 size_t reason_phrase_len, int is_remote)
 {
-    assert(conn->connection_close.reason_phrase == NULL);
+    assert(conn->connection_close.reason_phrase == NULL && "never called twice");
 
     conn->connection_close.err = err;
-    conn->connection_close.frame_type = QUICLY_ERROR_IS_QUIC_APPLICATION(err) ? UINT64_MAX : frame_type;
+    if (QUICLY_ERROR_IS_QUIC_APPLICATION(err)) {
+        conn->connection_close.frame_type = UINT64_MAX;
+    } else {
+        assert(frame_type != UINT64_MAX);
+        conn->connection_close.frame_type = frame_type;
+    }
     if ((conn->connection_close.reason_phrase = malloc(reason_phrase_len + 1)) == NULL)
         return PTLS_ERROR_NO_MEMORY;
     memcpy(conn->connection_close.reason_phrase, reason_phrase, reason_phrase_len);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -442,9 +442,9 @@ struct st_quicly_conn_t {
      * close reason
      */
     struct {
-        uint64_t is_remote : 1;
-        uint64_t error_code : 62;
-        uint64_t frame_type; /* UINT64_MAX if application close */
+        uint8_t is_remote;
+        quicly_error_t err;
+        uint64_t frame_type;
         char *reason_phrase;
         unsigned long num_packets_received;
     } connection_close;
@@ -550,8 +550,6 @@ static const quicly_stream_callbacks_t crypto_stream_callbacks = {quicly_streamb
 static int update_traffic_key_cb(ptls_update_traffic_key_t *self, ptls_t *tls, int is_enc, size_t epoch, const void *secret);
 static quicly_error_t initiate_close(quicly_conn_t *conn, quicly_error_t err, uint64_t frame_type, const char *reason_phrase);
 static quicly_error_t handle_close(quicly_conn_t *conn, quicly_error_t err, uint64_t frame_type, ptls_iovec_t reason_phrase);
-static int set_connection_close(quicly_conn_t *conn, int is_remote, uint64_t error_code, uint64_t frame_type,
-                                const char *reason_phrase, size_t reason_phrase_len);
 static quicly_error_t discard_sentmap_by_epoch(quicly_conn_t *conn, unsigned ack_epochs);
 
 quicly_cid_plaintext_t quicly_cid_plaintext_invalid = {.node_id = UINT64_MAX, .thread_id = 0xffffff};
@@ -995,7 +993,7 @@ quicly_error_t quicly_get_close_reason(quicly_conn_t *conn, int *is_remote, uint
         *offending_frame_type = conn->connection_close.frame_type;
     if (reason_phrase != NULL)
         *reason_phrase = conn->connection_close.reason_phrase;
-    return conn->connection_close.frame_type != UINT64_MAX ? QUICLY_ERROR_FROM_TRANSPORT_ERROR_CODE(conn->connection_close.error_code) : QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(conn->connection_close.error_code);
+    return conn->connection_close.err;
 }
 
 static int stream_is_destroyable(quicly_stream_t *stream)
@@ -5174,8 +5172,6 @@ Exit:
 
 static quicly_error_t send_connection_close(quicly_conn_t *conn, size_t epoch, quicly_send_context_t *s)
 {
-    uint64_t error_code, offending_frame_type;
-    const char *reason_phrase;
     quicly_error_t ret;
 
     assert(!conn->connection_close.is_remote);
@@ -5185,10 +5181,24 @@ static quicly_error_t send_connection_close(quicly_conn_t *conn, size_t epoch, q
         return 0;
 
     /* determine the payload, masking the application error when sending the frame using an unauthenticated epoch */
-    error_code = conn->connection_close.error_code;
-    offending_frame_type = conn->connection_close.frame_type;
-    reason_phrase = conn->connection_close.reason_phrase;
-    if (offending_frame_type == UINT64_MAX) {
+    uint64_t error_code, offending_frame_type = conn->connection_close.frame_type;
+    const char *reason_phrase = conn->connection_close.reason_phrase;
+    if (conn->connection_close.err == 0) {
+        error_code = 0;
+        offending_frame_type = QUICLY_FRAME_TYPE_PADDING;
+    } else if (conn->connection_close.err == QUICLY_ERROR_STATE_EXHAUSTION) {
+        /* State exhaution is an error induced by the peer, but as there is no specific error code, the generic error code
+         * (PROTOCOL_VIOLATION) is used. The exact cause is communicated using the reason phrase field because it is sometimes
+         * difficult for the peer to understand the problem without; e.g., when an ACK triggering the loss of a RETIRE_CONNECTION_ID
+         * frame leading to the overflow of `quicly_conn_t::egress.retire_cid`. */
+        error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION);
+        if (reason_phrase[0] == '\0')
+            reason_phrase = "state exhaustion";
+    } else if (QUICLY_ERROR_IS_QUIC_TRANSPORT(conn->connection_close.err)) {
+        assert(conn->connection_close.frame_type == UINT64_MAX);
+        error_code = QUICLY_ERROR_GET_ERROR_CODE(conn->connection_close.err);
+    } else if (QUICLY_ERROR_IS_QUIC_APPLICATION(conn->connection_close.err)) {
+        /* conceal application errors unless sending in the application packet number space */
         switch (get_epoch(s->current.first_byte)) {
         case QUICLY_EPOCH_INITIAL:
         case QUICLY_EPOCH_HANDSHAKE:
@@ -5196,7 +5206,14 @@ static quicly_error_t send_connection_close(quicly_conn_t *conn, size_t epoch, q
             offending_frame_type = QUICLY_FRAME_TYPE_PADDING;
             reason_phrase = "";
             break;
+        default:
+            error_code = QUICLY_ERROR_GET_ERROR_CODE(conn->connection_close.err);
+            break;
         }
+    } else if (PTLS_ERROR_GET_CLASS(conn->connection_close.err) == PTLS_ERROR_CLASS_SELF_ALERT) {
+        error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_CRYPTO(PTLS_ERROR_TO_ALERT(conn->connection_close.err)));
+    } else {
+        error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_INTERNAL);
     }
 
     /* write frame */
@@ -5206,7 +5223,7 @@ static quicly_error_t send_connection_close(quicly_conn_t *conn, size_t epoch, q
     s->dst = quicly_encode_close_frame(s->dst, error_code, offending_frame_type, reason_phrase);
 
     /* update counter, probe */
-    if (offending_frame_type != UINT64_MAX) {
+    if (!QUICLY_ERROR_IS_QUIC_APPLICATION(conn->connection_close.err)) {
         ++conn->super.stats.num_frames_sent.transport_close;
         QUICLY_PROBE(TRANSPORT_CLOSE_SEND, conn, conn->stash.now, error_code, offending_frame_type, reason_phrase);
         QUICLY_LOG_CONN(transport_close_send, conn, {
@@ -6046,14 +6063,14 @@ static quicly_error_t enter_close(quicly_conn_t *conn, int local_is_initiating, 
     return 0;
 }
 
-static int set_connection_close(quicly_conn_t *conn, int is_remote, uint64_t error_code, uint64_t frame_type,
+static int set_connection_close(quicly_conn_t *conn, int is_remote, quicly_error_t err, uint64_t frame_type,
                                 const char *reason_phrase, size_t reason_phrase_len)
 {
     assert(conn->connection_close.reason_phrase == NULL);
 
     conn->connection_close.is_remote = is_remote;
-    conn->connection_close.error_code = error_code;
-    conn->connection_close.frame_type = frame_type;
+    conn->connection_close.err = err;
+    conn->connection_close.frame_type = QUICLY_ERROR_IS_QUIC_APPLICATION(err) ? UINT64_MAX : frame_type;
     if ((conn->connection_close.reason_phrase = malloc(reason_phrase_len + 1)) == NULL)
         return PTLS_ERROR_NO_MEMORY;
     memcpy(conn->connection_close.reason_phrase, reason_phrase, reason_phrase_len);
@@ -6064,40 +6081,17 @@ static int set_connection_close(quicly_conn_t *conn, int is_remote, uint64_t err
 
 quicly_error_t initiate_close(quicly_conn_t *conn, quicly_error_t err, uint64_t frame_type, const char *reason_phrase)
 {
-    uint64_t error_code;
+    quicly_error_t ret;
 
     if (conn->super.state >= QUICLY_STATE_CLOSING)
         return 0;
 
-    /* convert error code to QUIC error codes */
-    if (err == 0) {
-        frame_type = QUICLY_FRAME_TYPE_PADDING;
-        error_code = 0;
-    } else if (err == QUICLY_ERROR_STATE_EXHAUSTION) {
-        /* State exhaution is an error induced by the peer, but as there is no specific error code, the generic error code
-         * (PROTOCOL_VIOLATION) is used. The exact cause is communicated using the reason phrase field because it is sometimes
-         * difficult for the peer to understand the problem without; e.g., when an ACK triggering the loss of a RETIRE_CONNECTION_ID
-         * frame leading to the overflow of `quicly_conn_t::egress.retire_cid`. */
-        if (reason_phrase == NULL)
-            reason_phrase = "state exhaustion";
-        error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION);
-    } else if (QUICLY_ERROR_IS_QUIC_TRANSPORT(err)) {
-        error_code = QUICLY_ERROR_GET_ERROR_CODE(err);
-    } else if (QUICLY_ERROR_IS_QUIC_APPLICATION(err)) {
-        frame_type = UINT64_MAX;
-        error_code = QUICLY_ERROR_GET_ERROR_CODE(err);
-    } else if (PTLS_ERROR_GET_CLASS(err) == PTLS_ERROR_CLASS_SELF_ALERT) {
-        error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_CRYPTO(PTLS_ERROR_TO_ALERT(err)));
-    } else {
-        error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_INTERNAL);
-    }
-
     if (reason_phrase == NULL)
         reason_phrase = "";
 
-    if ((err = enter_close(conn, 1, 0)) != 0 ||
-        (err = set_connection_close(conn, 0, error_code, frame_type, reason_phrase, strlen(reason_phrase))) != 0)
-        return err;
+    if ((ret = enter_close(conn, 1, 0)) != 0 ||
+        (ret = set_connection_close(conn, 0, err, frame_type, reason_phrase, strlen(reason_phrase))) != 0)
+        return ret;
     if (conn->super.ctx->closed != NULL)
         conn->super.ctx->closed->cb(conn->super.ctx->closed, conn);
     return 0;
@@ -6840,8 +6834,7 @@ quicly_error_t handle_close(quicly_conn_t *conn, quicly_error_t err, uint64_t fr
     /* switch to closing state, notify the app (at this moment the streams are accessible), then destroy the streams */
     if ((ret = enter_close(conn, 0,
                            !(err == QUICLY_ERROR_RECEIVED_STATELESS_RESET || err == QUICLY_ERROR_NO_COMPATIBLE_VERSION))) != 0 ||
-        (ret = set_connection_close(conn, 1, QUICLY_ERROR_GET_ERROR_CODE(err), frame_type, (const char *)reason_phrase.base,
-                                    reason_phrase.len)) != 0)
+        (ret = set_connection_close(conn, 1, err, frame_type, (const char *)reason_phrase.base, reason_phrase.len)) != 0)
         return ret;
     if (conn->super.ctx->closed != NULL)
         conn->super.ctx->closed->cb(conn->super.ctx->closed, conn);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -329,15 +329,6 @@ struct st_quicly_conn_t {
          */
         uint16_t max_udp_payload_size;
         /**
-         * valid if state is CLOSING
-         */
-        struct {
-            uint64_t error_code;
-            uint64_t frame_type; /* UINT64_MAX if application close */
-            const char *reason_phrase;
-            unsigned long num_packets_received;
-        } connection_close;
-        /**
          *
          */
         struct {
@@ -448,6 +439,16 @@ struct st_quicly_conn_t {
         quicly_ratemeter_t ratemeter;
     } egress;
     /**
+     * close reason
+     */
+    struct {
+        uint64_t is_remote : 1;
+        uint64_t error_code : 62;
+        uint64_t frame_type; /* UINT64_MAX if application close */
+        char *reason_phrase;
+        unsigned long num_packets_received;
+    } connection_close;
+    /**
      * crypto data
      */
     struct {
@@ -549,6 +550,8 @@ static const quicly_stream_callbacks_t crypto_stream_callbacks = {quicly_streamb
 static int update_traffic_key_cb(ptls_update_traffic_key_t *self, ptls_t *tls, int is_enc, size_t epoch, const void *secret);
 static quicly_error_t initiate_close(quicly_conn_t *conn, quicly_error_t err, uint64_t frame_type, const char *reason_phrase);
 static quicly_error_t handle_close(quicly_conn_t *conn, quicly_error_t err, uint64_t frame_type, ptls_iovec_t reason_phrase);
+static int set_connection_close(quicly_conn_t *conn, int is_remote, uint64_t error_code, uint64_t frame_type,
+                                const char *reason_phrase, size_t reason_phrase_len);
 static quicly_error_t discard_sentmap_by_epoch(quicly_conn_t *conn, unsigned ack_epochs);
 
 quicly_cid_plaintext_t quicly_cid_plaintext_invalid = {.node_id = UINT64_MAX, .thread_id = 0xffffff};
@@ -980,6 +983,19 @@ static quicly_error_t update_max_streams(struct st_quicly_max_streams_t *m, uint
 int quicly_connection_is_ready(quicly_conn_t *conn)
 {
     return conn->application != NULL;
+}
+
+quicly_error_t quicly_get_close_reason(quicly_conn_t *conn, int *is_remote, uint64_t *offending_frame_type,
+                                       const char **reason_phrase)
+{
+    assert(conn->super.state >= QUICLY_STATE_CLOSING);
+    if (is_remote != NULL)
+        *is_remote = conn->connection_close.is_remote;
+    if (offending_frame_type != NULL)
+        *offending_frame_type = conn->connection_close.frame_type;
+    if (reason_phrase != NULL)
+        *reason_phrase = conn->connection_close.reason_phrase;
+    return conn->connection_close.frame_type != UINT64_MAX ? QUICLY_ERROR_FROM_TRANSPORT_ERROR_CODE(conn->connection_close.error_code) : QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(conn->connection_close.error_code);
 }
 
 static int stream_is_destroyable(quicly_stream_t *stream)
@@ -2227,6 +2243,8 @@ void quicly_free(quicly_conn_t *conn)
 
     if (conn->egress.pacer != NULL)
         free(conn->egress.pacer);
+    if (conn->connection_close.reason_phrase != NULL)
+        free(conn->connection_close.reason_phrase);
     free(conn->token.base);
     free(conn);
 }
@@ -5160,14 +5178,16 @@ static quicly_error_t send_connection_close(quicly_conn_t *conn, size_t epoch, q
     const char *reason_phrase;
     quicly_error_t ret;
 
+    assert(!conn->connection_close.is_remote);
+
     /* setup send epoch, or return if it's impossible to send in this epoch */
     if (setup_send_space(conn, epoch, s) == NULL)
         return 0;
 
     /* determine the payload, masking the application error when sending the frame using an unauthenticated epoch */
-    error_code = conn->egress.connection_close.error_code;
-    offending_frame_type = conn->egress.connection_close.frame_type;
-    reason_phrase = conn->egress.connection_close.reason_phrase;
+    error_code = conn->connection_close.error_code;
+    offending_frame_type = conn->connection_close.frame_type;
+    reason_phrase = conn->connection_close.reason_phrase;
     if (offending_frame_type == UINT64_MAX) {
         switch (get_epoch(s->current.first_byte)) {
         case QUICLY_EPOCH_INITIAL:
@@ -6026,43 +6046,61 @@ static quicly_error_t enter_close(quicly_conn_t *conn, int local_is_initiating, 
     return 0;
 }
 
+static int set_connection_close(quicly_conn_t *conn, int is_remote, uint64_t error_code, uint64_t frame_type,
+                                const char *reason_phrase, size_t reason_phrase_len)
+{
+    assert(conn->connection_close.reason_phrase == NULL);
+
+    conn->connection_close.is_remote = is_remote;
+    conn->connection_close.error_code = error_code;
+    conn->connection_close.frame_type = frame_type;
+    if ((conn->connection_close.reason_phrase = malloc(reason_phrase_len + 1)) == NULL)
+        return PTLS_ERROR_NO_MEMORY;
+    memcpy(conn->connection_close.reason_phrase, reason_phrase, reason_phrase_len);
+    conn->connection_close.reason_phrase[reason_phrase_len] = '\0';
+
+    return 0;
+}
+
 quicly_error_t initiate_close(quicly_conn_t *conn, quicly_error_t err, uint64_t frame_type, const char *reason_phrase)
 {
-    uint64_t quic_error_code;
+    uint64_t error_code;
 
     if (conn->super.state >= QUICLY_STATE_CLOSING)
         return 0;
 
     /* convert error code to QUIC error codes */
     if (err == 0) {
-        quic_error_code = 0;
         frame_type = QUICLY_FRAME_TYPE_PADDING;
+        error_code = 0;
     } else if (err == QUICLY_ERROR_STATE_EXHAUSTION) {
         /* State exhaution is an error induced by the peer, but as there is no specific error code, the generic error code
          * (PROTOCOL_VIOLATION) is used. The exact cause is communicated using the reason phrase field because it is sometimes
          * difficult for the peer to understand the problem without; e.g., when an ACK triggering the loss of a RETIRE_CONNECTION_ID
          * frame leading to the overflow of `quicly_conn_t::egress.retire_cid`. */
-        quic_error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION);
         if (reason_phrase == NULL)
             reason_phrase = "state exhaustion";
+        error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION);
     } else if (QUICLY_ERROR_IS_QUIC_TRANSPORT(err)) {
-        quic_error_code = QUICLY_ERROR_GET_ERROR_CODE(err);
+        error_code = QUICLY_ERROR_GET_ERROR_CODE(err);
     } else if (QUICLY_ERROR_IS_QUIC_APPLICATION(err)) {
-        quic_error_code = QUICLY_ERROR_GET_ERROR_CODE(err);
         frame_type = UINT64_MAX;
+        error_code = QUICLY_ERROR_GET_ERROR_CODE(err);
     } else if (PTLS_ERROR_GET_CLASS(err) == PTLS_ERROR_CLASS_SELF_ALERT) {
-        quic_error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_CRYPTO(PTLS_ERROR_TO_ALERT(err)));
+        error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_CRYPTO(PTLS_ERROR_TO_ALERT(err)));
     } else {
-        quic_error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_INTERNAL);
+        error_code = QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_INTERNAL);
     }
 
     if (reason_phrase == NULL)
         reason_phrase = "";
 
-    conn->egress.connection_close.error_code = quic_error_code;
-    conn->egress.connection_close.frame_type = frame_type;
-    conn->egress.connection_close.reason_phrase = reason_phrase;
-    return enter_close(conn, 1, 0);
+    if ((err = enter_close(conn, 1, 0)) != 0 ||
+        (err = set_connection_close(conn, 0, error_code, frame_type, reason_phrase, strlen(reason_phrase))) != 0)
+        return err;
+    if (conn->super.ctx->closed != NULL)
+        conn->super.ctx->closed->cb(conn->super.ctx->closed, conn);
+    return 0;
 }
 
 quicly_error_t quicly_close(quicly_conn_t *conn, quicly_error_t err, const char *reason_phrase)
@@ -6801,11 +6839,12 @@ quicly_error_t handle_close(quicly_conn_t *conn, quicly_error_t err, uint64_t fr
 
     /* switch to closing state, notify the app (at this moment the streams are accessible), then destroy the streams */
     if ((ret = enter_close(conn, 0,
-                           !(err == QUICLY_ERROR_RECEIVED_STATELESS_RESET || err == QUICLY_ERROR_NO_COMPATIBLE_VERSION))) != 0)
+                           !(err == QUICLY_ERROR_RECEIVED_STATELESS_RESET || err == QUICLY_ERROR_NO_COMPATIBLE_VERSION))) != 0 ||
+        (ret = set_connection_close(conn, 1, QUICLY_ERROR_GET_ERROR_CODE(err), frame_type, (const char *)reason_phrase.base,
+                                    reason_phrase.len)) != 0)
         return ret;
-    if (conn->super.ctx->closed_by_remote != NULL)
-        conn->super.ctx->closed_by_remote->cb(conn->super.ctx->closed_by_remote, conn, err, frame_type,
-                                              (const char *)reason_phrase.base, reason_phrase.len);
+    if (conn->super.ctx->closed != NULL)
+        conn->super.ctx->closed->cb(conn->super.ctx->closed, conn);
     destroy_all_streams(conn, err, 0);
 
     return QUICLY_ERROR_IS_CLOSING;
@@ -7385,9 +7424,9 @@ static quicly_error_t do_receive(quicly_conn_t *conn, struct sockaddr *dest_addr
 
     switch (conn->super.state) {
     case QUICLY_STATE_CLOSING:
-        ++conn->egress.connection_close.num_packets_received;
+        ++conn->connection_close.num_packets_received;
         /* respond with a CONNECTION_CLOSE frame using exponential back-off */
-        if (__builtin_popcountl(conn->egress.connection_close.num_packets_received) == 1)
+        if (__builtin_popcountl(conn->connection_close.num_packets_received) == 1)
             conn->egress.send_ack_at = 0;
         ret = 0;
         goto Exit;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -6719,7 +6719,7 @@ static quicly_error_t handle_version_negotiation_packet(quicly_conn_t *conn, qui
         }
     }
     if (selected_version == 0)
-        return handle_close(conn, QUICLY_ERROR_NO_COMPATIBLE_VERSION, UINT64_MAX, ptls_iovec_init("", 0));
+        return handle_close(conn, QUICLY_ERROR_NO_COMPATIBLE_VERSION, QUICLY_FRAME_TYPE_PADDING, ptls_iovec_init("", 0));
 
     return negotiate_using_version(conn, selected_version);
 }
@@ -7187,7 +7187,7 @@ static quicly_error_t handle_stateless_reset(quicly_conn_t *conn)
 {
     QUICLY_PROBE(STATELESS_RESET_RECEIVE, conn, conn->stash.now);
     QUICLY_LOG_CONN(stateless_reset_receive, conn, {});
-    return handle_close(conn, QUICLY_ERROR_RECEIVED_STATELESS_RESET, UINT64_MAX, ptls_iovec_init("", 0));
+    return handle_close(conn, QUICLY_ERROR_RECEIVED_STATELESS_RESET, QUICLY_FRAME_TYPE_PADDING, ptls_iovec_init("", 0));
 }
 
 static int validate_retry_tag(quicly_decoded_packet_t *packet, quicly_cid_t *odcid, ptls_aead_context_t *retry_aead)

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -442,10 +442,10 @@ struct st_quicly_conn_t {
      * close reason
      */
     struct {
-        uint8_t is_remote;
         quicly_error_t err;
         uint64_t frame_type;
         char *reason_phrase;
+        uint8_t is_remote : 1;
         unsigned long num_packets_received;
     } connection_close;
     /**
@@ -983,16 +983,16 @@ int quicly_connection_is_ready(quicly_conn_t *conn)
     return conn->application != NULL;
 }
 
-quicly_error_t quicly_get_close_reason(quicly_conn_t *conn, int *is_remote, uint64_t *offending_frame_type,
-                                       const char **reason_phrase)
+quicly_error_t quicly_get_close_reason(quicly_conn_t *conn, uint64_t *offending_frame_type, const char **reason_phrase,
+                                       int *is_remote)
 {
     assert(conn->super.state >= QUICLY_STATE_CLOSING);
-    if (is_remote != NULL)
-        *is_remote = conn->connection_close.is_remote;
     if (offending_frame_type != NULL)
         *offending_frame_type = conn->connection_close.frame_type;
     if (reason_phrase != NULL)
         *reason_phrase = conn->connection_close.reason_phrase;
+    if (is_remote != NULL)
+        *is_remote = conn->connection_close.is_remote;
     return conn->connection_close.err;
 }
 
@@ -6063,18 +6063,18 @@ static quicly_error_t enter_close(quicly_conn_t *conn, int local_is_initiating, 
     return 0;
 }
 
-static int set_connection_close(quicly_conn_t *conn, int is_remote, quicly_error_t err, uint64_t frame_type,
-                                const char *reason_phrase, size_t reason_phrase_len)
+static int set_connection_close(quicly_conn_t *conn, quicly_error_t err, uint64_t frame_type, const char *reason_phrase,
+                                size_t reason_phrase_len, int is_remote)
 {
     assert(conn->connection_close.reason_phrase == NULL);
 
-    conn->connection_close.is_remote = is_remote;
     conn->connection_close.err = err;
     conn->connection_close.frame_type = QUICLY_ERROR_IS_QUIC_APPLICATION(err) ? UINT64_MAX : frame_type;
     if ((conn->connection_close.reason_phrase = malloc(reason_phrase_len + 1)) == NULL)
         return PTLS_ERROR_NO_MEMORY;
     memcpy(conn->connection_close.reason_phrase, reason_phrase, reason_phrase_len);
     conn->connection_close.reason_phrase[reason_phrase_len] = '\0';
+    conn->connection_close.is_remote = is_remote;
 
     return 0;
 }
@@ -6090,7 +6090,7 @@ quicly_error_t initiate_close(quicly_conn_t *conn, quicly_error_t err, uint64_t 
         reason_phrase = "";
 
     if ((ret = enter_close(conn, 1, 0)) != 0 ||
-        (ret = set_connection_close(conn, 0, err, frame_type, reason_phrase, strlen(reason_phrase))) != 0)
+        (ret = set_connection_close(conn, err, frame_type, reason_phrase, strlen(reason_phrase), 0)) != 0)
         return ret;
     if (conn->super.ctx->closed != NULL)
         conn->super.ctx->closed->cb(conn->super.ctx->closed, conn);
@@ -6834,7 +6834,7 @@ quicly_error_t handle_close(quicly_conn_t *conn, quicly_error_t err, uint64_t fr
     /* switch to closing state, notify the app (at this moment the streams are accessible), then destroy the streams */
     if ((ret = enter_close(conn, 0,
                            !(err == QUICLY_ERROR_RECEIVED_STATELESS_RESET || err == QUICLY_ERROR_NO_COMPATIBLE_VERSION))) != 0 ||
-        (ret = set_connection_close(conn, 1, err, frame_type, (const char *)reason_phrase.base, reason_phrase.len)) != 0)
+        (ret = set_connection_close(conn, err, frame_type, (const char *)reason_phrase.base, reason_phrase.len, 1)) != 0)
         return ret;
     if (conn->super.ctx->closed != NULL)
         conn->super.ctx->closed->cb(conn->super.ctx->closed, conn);

--- a/src/cli.c
+++ b/src/cli.c
@@ -402,25 +402,31 @@ static quicly_error_t on_stream_open(quicly_stream_open_t *self, quicly_stream_t
 
 static quicly_stream_open_t stream_open = {&on_stream_open};
 
-static void on_closed_by_remote(quicly_closed_by_remote_t *self, quicly_conn_t *conn, quicly_error_t err, uint64_t frame_type,
-                                const char *reason, size_t reason_len)
+static void on_closed(quicly_closed_t *self, quicly_conn_t *conn)
 {
-    if (QUICLY_ERROR_IS_QUIC_TRANSPORT(err)) {
-        fprintf(stderr, "transport close:code=0x%" PRIx64 ";frame=%" PRIu64 ";reason=%.*s\n", QUICLY_ERROR_GET_ERROR_CODE(err),
-                frame_type, (int)reason_len, reason);
-    } else if (QUICLY_ERROR_IS_QUIC_APPLICATION(err)) {
-        fprintf(stderr, "application close:code=0x%" PRIx64 ";reason=%.*s\n", QUICLY_ERROR_GET_ERROR_CODE(err), (int)reason_len,
-                reason);
-    } else if (err == QUICLY_ERROR_RECEIVED_STATELESS_RESET) {
+    uint64_t error_code;
+    uint64_t frame_type;
+    const char *reason;
+    int is_remote;
+
+    quicly_get_close_reason(conn, &is_remote, &error_code, &frame_type, &reason);
+    if (!is_remote)
+        return;
+    if (frame_type != UINT64_MAX) {
+        fprintf(stderr, "transport close:code=0x%" PRIx64 ";frame=%" PRIu64 ";reason=%.*s\n", error_code, frame_type,
+                (int)strlen(reason), reason);
+    } else if (error_code == QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_APPLICATION)) {
+        fprintf(stderr, "application close:code=0x%" PRIx64 ";reason=%.*s\n", error_code, (int)strlen(reason), reason);
+    } else if (error_code == QUICLY_ERROR_GET_ERROR_CODE(QUICLY_ERROR_RECEIVED_STATELESS_RESET)) {
         fprintf(stderr, "stateless reset\n");
-    } else if (err == QUICLY_ERROR_NO_COMPATIBLE_VERSION) {
+    } else if (error_code == QUICLY_ERROR_GET_ERROR_CODE(QUICLY_ERROR_NO_COMPATIBLE_VERSION)) {
         fprintf(stderr, "no compatible version\n");
     } else {
-        fprintf(stderr, "unexpected close:code=%" PRId64 "\n", err);
+        fprintf(stderr, "unexpected close:code=0x%" PRIx64 "\n", error_code);
     }
 }
 
-static quicly_closed_by_remote_t closed_by_remote = {&on_closed_by_remote};
+static quicly_closed_t closed = {&on_closed};
 
 static quicly_error_t on_generate_resumption_token(quicly_generate_resumption_token_t *self, quicly_conn_t *conn,
                                                    ptls_buffer_t *buf, quicly_address_token_plaintext_t *token)
@@ -1505,7 +1511,7 @@ int main(int argc, char **argv)
     ctx = quicly_spec_context;
     ctx.tls = &tlsctx;
     ctx.stream_open = &stream_open;
-    ctx.closed_by_remote = &closed_by_remote;
+    ctx.closed = &closed;
     ctx.save_resumption_token = &save_resumption_token;
     ctx.generate_resumption_token = &generate_resumption_token;
     stream_scheduler = quicly_default_stream_scheduler;

--- a/src/cli.c
+++ b/src/cli.c
@@ -421,6 +421,8 @@ static void on_closed(quicly_closed_t *self, quicly_conn_t *conn)
         fprintf(stderr, "stateless reset\n");
     } else if (err == QUICLY_ERROR_NO_COMPATIBLE_VERSION) {
         fprintf(stderr, "no compatible version\n");
+    } else if (PTLS_ERROR_GET_CLASS(err) == PTLS_ERROR_CLASS_PEER_ALERT) {
+        fprintf(stderr, "TLS alert:code=%d\n", (int)PTLS_ERROR_TO_ALERT(err));
     } else {
         fprintf(stderr, "unexpected close:code=%" PRId64 "\n", err);
     }

--- a/src/cli.c
+++ b/src/cli.c
@@ -404,25 +404,25 @@ static quicly_stream_open_t stream_open = {&on_stream_open};
 
 static void on_closed(quicly_closed_t *self, quicly_conn_t *conn)
 {
-    uint64_t error_code;
+    int is_remote;
     uint64_t frame_type;
     const char *reason;
-    int is_remote;
+    quicly_error_t err = quicly_get_close_reason(conn, &is_remote, &frame_type, &reason);
 
-    quicly_get_close_reason(conn, &is_remote, &error_code, &frame_type, &reason);
     if (!is_remote)
         return;
-    if (frame_type != UINT64_MAX) {
-        fprintf(stderr, "transport close:code=0x%" PRIx64 ";frame=%" PRIu64 ";reason=%.*s\n", error_code, frame_type,
-                (int)strlen(reason), reason);
-    } else if (error_code == QUICLY_ERROR_GET_ERROR_CODE(QUICLY_TRANSPORT_ERROR_APPLICATION)) {
-        fprintf(stderr, "application close:code=0x%" PRIx64 ";reason=%.*s\n", error_code, (int)strlen(reason), reason);
-    } else if (error_code == QUICLY_ERROR_GET_ERROR_CODE(QUICLY_ERROR_RECEIVED_STATELESS_RESET)) {
+
+    if (QUICLY_ERROR_IS_QUIC_TRANSPORT(err)) {
+        fprintf(stderr, "transport close:code=0x%" PRIx64 ";frame=%" PRIu64 ";reason=%s\n", QUICLY_ERROR_GET_ERROR_CODE(err),
+                frame_type, reason);
+    } else if (QUICLY_ERROR_IS_QUIC_APPLICATION(err)) {
+        fprintf(stderr, "application close:code=0x%" PRIx64 ";reason=%s\n", QUICLY_ERROR_GET_ERROR_CODE(err), reason);
+    } else if (err == QUICLY_ERROR_RECEIVED_STATELESS_RESET) {
         fprintf(stderr, "stateless reset\n");
-    } else if (error_code == QUICLY_ERROR_GET_ERROR_CODE(QUICLY_ERROR_NO_COMPATIBLE_VERSION)) {
+    } else if (err == QUICLY_ERROR_NO_COMPATIBLE_VERSION) {
         fprintf(stderr, "no compatible version\n");
     } else {
-        fprintf(stderr, "unexpected close:code=0x%" PRIx64 "\n", error_code);
+        fprintf(stderr, "unexpected close:code=%" PRId64 "\n", err);
     }
 }
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -404,10 +404,10 @@ static quicly_stream_open_t stream_open = {&on_stream_open};
 
 static void on_closed(quicly_closed_t *self, quicly_conn_t *conn)
 {
-    int is_remote;
     uint64_t frame_type;
     const char *reason;
-    quicly_error_t err = quicly_get_close_reason(conn, &is_remote, &frame_type, &reason);
+    int is_remote;
+    quicly_error_t err = quicly_get_close_reason(conn, &frame_type, &reason, &is_remote);
 
     if (!is_remote)
         return;

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -296,11 +296,11 @@ subtest "0-rtt-vs-hrr" => sub {
 subtest "alpn" => sub {
     my $guard = spawn_server(qw(-a hq-23));
     my $resp = `$cli -p /12 127.0.0.1 $port 2>&1`;
-    like $resp, qr/transport close:code=0x178;/, "no ALPN";
+    like $resp, qr/TLS alert:code=120/, "no ALPN";
     $resp = `$cli -a hq-23 -p /12 127.0.0.1 $port 2>&1`;
     like $resp, qr/^hello world$/m, "ALPN match";
     $resp = `$cli -a hX-23 -p /12 127.0.0.1 $port 2>&1`;
-    like $resp, qr/transport close:code=0x178;/, "ALPN mismatch";
+    like $resp, qr/TLS alert:code=120/, "ALPN mismatch";
 };
 
 subtest "key-update" => sub {

--- a/t/simple.c
+++ b/t/simple.c
@@ -465,11 +465,11 @@ static void test_closed(quicly_closed_t *self, quicly_conn_t *conn)
     const char *reason;
     int is_remote;
 
-    quicly_error_t err = quicly_get_close_reason(conn, &is_remote, &frame_type, &reason);
-    ok(is_remote == (conn == server));
+    quicly_error_t err = quicly_get_close_reason(conn, &frame_type, &reason, &is_remote);
     ok(err == QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(1234567));
     ok(frame_type == UINT64_MAX);
     ok(strcmp(reason, "good bye") == 0);
+    ok(is_remote == (conn == server));
 }
 
 static void test_close(void)

--- a/t/simple.c
+++ b/t/simple.c
@@ -459,21 +459,22 @@ static void test_reset_during_loss(void)
     quic_ctx.transport_params.max_stream_data = max_stream_data_orig;
 }
 
-static uint64_t test_close_error_code;
-
-static void test_closed_by_remote(quicly_closed_by_remote_t *self, quicly_conn_t *conn, quicly_error_t err, uint64_t frame_type,
-                                  const char *reason, size_t reason_len)
+static void test_closed(quicly_closed_t *self, quicly_conn_t *conn)
 {
-    ok(QUICLY_ERROR_IS_QUIC_APPLICATION(err));
-    test_close_error_code = QUICLY_ERROR_GET_ERROR_CODE(err);
+    uint64_t frame_type;
+    const char *reason;
+    int is_remote;
+
+    quicly_error_t err = quicly_get_close_reason(conn, &is_remote, &frame_type, &reason);
+    ok(is_remote == (conn == server));
+    ok(err == QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(1234567));
     ok(frame_type == UINT64_MAX);
-    ok(reason_len == 8);
-    ok(memcmp(reason, "good bye", 8) == 0);
+    ok(strcmp(reason, "good bye") == 0);
 }
 
 static void test_close(void)
 {
-    quicly_closed_by_remote_t closed_by_remote = {test_closed_by_remote}, *orig_closed_by_remote = quic_ctx.closed_by_remote;
+    quicly_closed_t closed = {test_closed}, *orig_closed = quic_ctx.closed;
     quicly_address_t dest, src;
     struct iovec datagram;
     uint8_t datagram_buf[quic_ctx.transport_params.max_udp_payload_size];
@@ -481,7 +482,7 @@ static void test_close(void)
     int64_t client_timeout, server_timeout;
     quicly_error_t ret;
 
-    quic_ctx.closed_by_remote = &closed_by_remote;
+    quic_ctx.closed = &closed;
 
     /* client sends close */
     ret = quicly_close(client, QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(1234567), "good bye");
@@ -499,7 +500,6 @@ static void test_close(void)
         decode_packets(&decoded, &datagram, 1);
         ret = quicly_receive(server, NULL, &fake_address.sa, &decoded);
         ok(ret == 0);
-        ok(test_close_error_code == 1234567);
         ok(quicly_get_state(server) == QUICLY_STATE_DRAINING);
         server_timeout = quicly_get_first_timeout(server);
         ok(quic_now < server_timeout && server_timeout < quic_now + 1000); /* 3 pto or something */
@@ -524,7 +524,7 @@ static void test_close(void)
 
     client = NULL;
     server = NULL;
-    quic_ctx.closed_by_remote = orig_closed_by_remote;
+    quic_ctx.closed = orig_closed;
 }
 
 static void tiny_connection_window(void)

--- a/t/test.c
+++ b/t/test.c
@@ -1294,13 +1294,13 @@ static void test_state_exhaustion(void)
     ok(quicly_get_state(client) == QUICLY_STATE_DRAINING);
 
     /* sender should have received PROTOCOL_VIOLATION with the special reason phrase */
-    int is_remote;
     uint64_t offending_frame_type;
     const char *reason;
-    ret = quicly_get_close_reason(client, &is_remote, &offending_frame_type, &reason);
+    int is_remote;
+    ret = quicly_get_close_reason(client, &offending_frame_type, &reason, &is_remote);
     ok(ret == QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION);
-    ok(is_remote);
     ok(strcmp(reason, "state exhaustion") == 0);
+    ok(is_remote);
 
     quicly_free(client);
     quicly_free(server);

--- a/t/test.c
+++ b/t/test.c
@@ -1243,34 +1243,12 @@ static void test_setup_send_context(quicly_conn_t *conn, quicly_send_context_t *
     setup_send_space(conn, QUICLY_EPOCH_1RTT, s);
 }
 
-static struct {
-    quicly_conn_t *conn;
-    quicly_error_t err;
-    char reason[64];
-} test_state_exhaustion_closed_by_remote;
-
-static void test_state_exhaustion_on_closed_by_remote(quicly_closed_by_remote_t *self, quicly_conn_t *conn, quicly_error_t err,
-                                                      uint64_t frame_type, const char *reason, size_t reason_len)
-{
-    if (test_state_exhaustion_closed_by_remote.conn == NULL) {
-        test_state_exhaustion_closed_by_remote.conn = conn;
-        test_state_exhaustion_closed_by_remote.err = err;
-        memcpy(test_state_exhaustion_closed_by_remote.reason, reason, reason_len);
-        test_state_exhaustion_closed_by_remote.reason[reason_len] = '\0';
-    }
-}
-
 /**
  * This test checks STATE_EXHAUSTION error is correctly returned to the application, and if the application supplies the error code
  * to quicly, quicly sends a PROTCOL_VIOLATION error with the special reason phrase.
  */
 static void test_state_exhaustion(void)
 {
-    static quicly_closed_by_remote_t closed_by_remote = {test_state_exhaustion_on_closed_by_remote};
-
-    assert(quic_ctx.closed_by_remote == NULL);
-    quic_ctx.closed_by_remote = &closed_by_remote;
-    memset(&test_state_exhaustion_closed_by_remote, 0, sizeof(test_state_exhaustion_closed_by_remote));
     uint64_t orig_max_stream_data_bidi_remote = quic_ctx.transport_params.max_stream_data.bidi_remote;
     quic_ctx.transport_params.max_stream_data.bidi_remote = 65536; /* shrink to reduce # of gaps permitted */
 
@@ -1316,14 +1294,17 @@ static void test_state_exhaustion(void)
     ok(quicly_get_state(client) == QUICLY_STATE_DRAINING);
 
     /* sender should have received PROTOCOL_VIOLATION with the special reason phrase */
-    ok(test_state_exhaustion_closed_by_remote.conn == client);
-    ok(test_state_exhaustion_closed_by_remote.err == QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION);
-    ok(strcmp(test_state_exhaustion_closed_by_remote.reason, "state exhaustion") == 0);
+    int is_remote;
+    uint64_t offending_frame_type;
+    const char *reason;
+    ret = quicly_get_close_reason(client, &is_remote, &offending_frame_type, &reason);
+    ok(ret == QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION);
+    ok(is_remote);
+    ok(strcmp(reason, "state exhaustion") == 0);
 
     quicly_free(client);
     quicly_free(server);
 
-    quic_ctx.closed_by_remote = NULL;
     quic_ctx.transport_params.max_stream_data.bidi_remote = orig_max_stream_data_bidi_remote;
 }
 


### PR DESCRIPTION
Replaces the existing `closed_by_remote` callback with a `closed` callback that captures closures initiated by the local endpoint. Without the change, applications cannot detect closure initiated by the local transport.

This PR also adds an accessor for obtaining the close information rather than supplying the information via callback arguments, allowing applications to fetch the information asynchronously.