### PR TITLE
remote_cid: retired CID shift copies too few survivors

### DIFF
--- a/lib/remote_cid.c
+++ b/lib/remote_cid.c
@@ -162,6 +162,6 @@ void quicly_remote_cid_shift_retired(quicly_remote_cid_set_t *set, size_t count)
     assert(count <= set->retired.count);
 
     set->retired.count -= count;
-    for (size_t i = 0; i < count; ++i)
+    for (size_t i = 0; i < set->retired.count; ++i)
         set->retired.cids[i] = set->retired.cids[i + count];
 }


### PR DESCRIPTION
`quicly_remote_cid_shift_retired` removes `count` retired connection IDs from the front of the queue, decrements `set->retired.count`, and then shifts survivors forward.

The existing loop copies only `count` elements from `i + count` to `i`, which is insufficient whenever more than `count` entries survive.

As a result, the surviving prefix is corrupted and later retirement retries can reference the wrong sequence numbers.