### PR TITLE
Undo pico recovery for fully late-acked loss episodes

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -835,6 +835,8 @@ typedef struct st_quicly_stats_t {
     apply(cc.cwnd_minimum, "cc.cwnd-minimum")                                                                                      \
     apply(cc.cwnd_maximum, "cc.cwnd-maximum")                                                                                      \
     apply(cc.num_loss_episodes, "cc.num-loss-episodes")                                                                            \
+    apply(cc.num_loss_episodes_undone, "cc.num-loss-episodes-undone")                                                              \
+    apply(cc.num_loss_episodes_undone_in_startup, "cc.num-loss-episodes-undone-in-startup")                                        \
     apply(cc.num_ecn_loss_episodes, "cc.num-ecn-loss-episodes")                                                                    \
     apply(delivery_rate.latest, "delivery-rate.latest")                                                                            \
     apply(delivery_rate.smoothed, "delivery-rate.smoothed")                                                                        \

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -206,6 +206,14 @@ typedef struct st_quicly_cc_t {
      */
     uint32_t num_loss_episodes;
     /**
+     * Total number of loss episodes undone.
+     */
+    uint32_t num_loss_episodes_undone;
+    /**
+     * Total number of loss episodes undone that occurred during startup.
+     */
+    uint32_t num_loss_episodes_undone_in_startup;
+    /**
      * Total number of loss episodes that was reported only by ECN (hence no packet loss).
      */
     uint32_t num_ecn_loss_episodes;

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -117,6 +117,18 @@ typedef struct st_quicly_cc_t {
              * Number of bytes required to be acked in order to increase CWND by 1 MTU.
              */
             uint32_t bytes_per_mtu_increase;
+            /**
+             * State to undo a recovery episode when all packets deemed lost are later acknowledged. `num_packets_lost` retains
+             * the number of packets deemed lost during the recovery period. Other fields retain the values to be restored when
+             * `num_packets_lost` becomes zero.
+             */
+            struct {
+                uint32_t num_packets_lost;
+                uint64_t start_pn;
+                uint32_t cwnd;
+                uint32_t ssthresh;
+                uint32_t bytes_per_mtu_increase;
+            } undo;
         } pico;
         /**
          * State information for CUBIC congestion control.
@@ -232,6 +244,10 @@ struct st_quicly_cc_type_t {
      * Switches the underlying algorithm of `cc` to that of `cc_switch`, returning a boolean whether the operation was successful.
      */
     int (*cc_switch)(quicly_cc_t *cc);
+    /**
+     * [optional] Called when a packet previously detected as lost is later acknowledged.
+     */
+    void (*cc_on_late_ack)(quicly_cc_t *cc, uint64_t pn, int64_t now);
     /**
      * [optional] called by quicly to enter jumpstart.
      */

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -118,13 +118,14 @@ typedef struct st_quicly_cc_t {
              */
             uint32_t bytes_per_mtu_increase;
             /**
-             * State to undo a recovery episode when all packets deemed lost are later acknowledged. `num_packets_lost` retains
-             * the number of packets deemed lost during the recovery period. Other fields retain the values to be restored when
+             * State to undo a recovery episode when all packets deemed lost are later acknowledged. The packet number range being
+             * tracked for undo is: start_pn <= pn < recovery_end. `num_packets_lost` counts packets in that range that were
+             * declared lost and have not yet been late-ACKed. Other fields retain the values to be restored when
              * `num_packets_lost` becomes zero.
              */
             struct {
-                uint32_t num_packets_lost;
                 uint64_t start_pn;
+                uint32_t num_packets_lost;
                 uint32_t cwnd;
                 uint32_t ssthresh;
                 uint32_t bytes_per_mtu_increase;

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -126,6 +126,10 @@ typedef struct quicly_loss_t {
      */
     quicly_loss_thresholds_t thresholds;
     /**
+     * Minimum packet number of a late-acked packet that can relax reordering tolerance.
+     */
+    uint64_t min_pn_to_relax_reorder_tolerance;
+    /**
      * The number of consecutive PTOs (PTOs that have fired without receiving an ack).
      */
     int8_t pto_count;
@@ -179,8 +183,9 @@ static void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
 /**
  * called when an ACK is received
  */
-static void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, size_t epoch, int64_t now, int64_t sent_at,
-                                        uint64_t ack_delay_encoded, quicly_loss_ack_received_kind_t kind);
+static void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, uint64_t largest_late_acked, uint64_t next_pn,
+                                        size_t epoch, int64_t now, int64_t sent_at, uint64_t ack_delay_encoded,
+                                        quicly_loss_ack_received_kind_t kind);
 /* This function updates the loss detection timer and indicates to the caller how many packets should be sent.
  * After calling this function, app should:
  *  * send min_packets_to_send number of packets immediately. min_packets_to_send should never be 0.
@@ -256,6 +261,7 @@ inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, u
                          .max_ack_delay = max_ack_delay,
                          .ack_delay_exponent = ack_delay_exponent,
                          .thresholds = {.use_packet_based = 1, .time_based_percentile = 1024 / 8 /* start from 1/8 RTT */},
+                         .min_pn_to_relax_reorder_tolerance = 0,
                          .pto_count = 0,
                          .time_of_last_packet_sent = 0,
                          .largest_acked_packet_plus1 = {.per_epoch = {0}, .all_ = 0},
@@ -341,12 +347,25 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
 #undef SET_ALARM
 }
 
-inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, size_t epoch, int64_t now, int64_t sent_at,
-                                        uint64_t ack_delay_encoded, quicly_loss_ack_received_kind_t kind)
+inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, uint64_t largest_late_acked,
+                                        uint64_t next_pn, size_t epoch, int64_t now, int64_t sent_at, uint64_t ack_delay_encoded,
+                                        quicly_loss_ack_received_kind_t kind)
 {
     /* Reset PTO count if anything is newly acked, and if sender is not speculatively probing at a tail */
     if (largest_newly_acked != UINT64_MAX && r->pto_count > 0)
         r->pto_count = 0;
+
+    /* Adjust loss detection thresholds when receiving a late ACK above the current relaxation threshold. */
+    if (kind == QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING_LATE_ACK && largest_late_acked != UINT64_MAX &&
+        r->min_pn_to_relax_reorder_tolerance <= largest_late_acked) {
+        if (r->thresholds.use_packet_based) {
+            r->thresholds.use_packet_based = 0;
+        } else {
+            if ((r->thresholds.time_based_percentile *= 2) > 1024)
+                r->thresholds.time_based_percentile = 1024;
+        }
+        r->min_pn_to_relax_reorder_tolerance = next_pn;
+    }
 
     /* If largest newly acked is not larger than before, skip RTT sample */
     if (largest_newly_acked == UINT64_MAX || r->largest_acked_packet_plus1.per_epoch[epoch] > largest_newly_acked)
@@ -368,16 +387,6 @@ inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly
         ack_delay_millisecs = *r->max_ack_delay;
     quicly_rtt_update(&r->rtt, (uint32_t)(now - sent_at), ack_delay_millisecs);
 
-    /* Adjust loss detection thresholds when receiving a late ack. The strategy is, for each ACK carrying a late ack, first disable
-     * packet-based detection, then double the time-based threshold until it reaches 1 RTT. */
-    if (kind == QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING_LATE_ACK) {
-        if (r->thresholds.use_packet_based) {
-            r->thresholds.use_packet_based = 0;
-        } else {
-            if ((r->thresholds.time_based_percentile *= 2) > 1024)
-                r->thresholds.time_based_percentile = 1024;
-        }
-    }
 }
 
 inline quicly_error_t quicly_loss_on_alarm(quicly_loss_t *r, int64_t now, uint32_t max_ack_delay, int is_1rtt_only,

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -206,7 +206,13 @@ static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwn
     cubic_reset(cc, initcwnd);
 }
 
-quicly_cc_type_t quicly_cc_type_cubic = {"cubic",         &quicly_cc_cubic_init,          cubic_on_acked,
-                                         cubic_on_lost,   cubic_on_persistent_congestion, cubic_on_sent,
-                                         cubic_on_switch, quicly_cc_jumpstart_enter};
+quicly_cc_type_t quicly_cc_type_cubic = {"cubic",
+                                         &quicly_cc_cubic_init,
+                                         cubic_on_acked,
+                                         cubic_on_lost,
+                                         cubic_on_persistent_congestion,
+                                         cubic_on_sent,
+                                         cubic_on_switch,
+                                         NULL,
+                                         quicly_cc_jumpstart_enter};
 quicly_init_cc_t quicly_cc_cubic_init = {cubic_init};

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -218,6 +218,7 @@ static void pico_on_late_ack(quicly_cc_t *cc, uint64_t pn, int64_t now)
         ++cc->num_loss_episodes_undone_in_startup;
         cc->cwnd_exiting_slow_start = 0;
         cc->exit_slow_start_at = INT64_MAX;
+        cc->rapid_start.newest_rtt_sample_until = 0;
     }
 }
 

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -207,6 +207,7 @@ static void pico_on_late_ack(quicly_cc_t *cc, uint64_t pn, int64_t now)
     int was_in_slow_start = cc->state.pico.undo.ssthresh == UINT32_MAX;
     cc->cwnd = cc->state.pico.undo.cwnd;
     cc->ssthresh = cc->state.pico.undo.ssthresh;
+    cc->state.pico.stash = 0;
     cc->state.pico.bytes_per_mtu_increase = cc->state.pico.undo.bytes_per_mtu_increase;
     cc->recovery_end = 0;
     --cc->num_loss_episodes;

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -198,7 +198,9 @@ ClampMinAndUpdateMetrics:
 
 static void pico_on_late_ack(quicly_cc_t *cc, uint64_t pn, int64_t now)
 {
-    if (cc->state.pico.undo.num_packets_lost == 0 || pn < cc->state.pico.undo.start_pn || cc->recovery_end <= pn)
+    if (!(cc->state.pico.undo.start_pn <= pn && pn < cc->recovery_end))
+        return;
+    if (cc->state.pico.undo.num_packets_lost == 0)
         return;
 
     if (--cc->state.pico.undo.num_packets_lost != 0)

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -204,14 +204,16 @@ static void pico_on_late_ack(quicly_cc_t *cc, uint64_t pn, int64_t now)
     if (--cc->state.pico.undo.num_packets_lost != 0)
         return;
 
-    int was_in_slow_start = cc->state.pico.undo.ssthresh == UINT32_MAX;
+    int was_in_startup = cc->state.pico.undo.ssthresh == UINT32_MAX;
     cc->cwnd = cc->state.pico.undo.cwnd;
     cc->ssthresh = cc->state.pico.undo.ssthresh;
     cc->state.pico.stash = 0;
     cc->state.pico.bytes_per_mtu_increase = cc->state.pico.undo.bytes_per_mtu_increase;
     cc->recovery_end = 0;
     --cc->num_loss_episodes;
-    if (was_in_slow_start) {
+    ++cc->num_loss_episodes_undone;
+    if (was_in_startup) {
+        ++cc->num_loss_episodes_undone_in_startup;
         cc->cwnd_exiting_slow_start = 0;
         cc->exit_slow_start_at = INT64_MAX;
     }

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -131,6 +131,11 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
         cc->state.pico.undo.num_packets_lost = 1;
         cc->state.pico.undo.start_pn = lost_pn;
         cc->state.pico.undo.cwnd = cc->cwnd;
+        if (quicly_cc_in_jumpstart(cc)) {
+            cc->state.pico.undo.cwnd /= 2;
+            if (cc->state.pico.undo.cwnd < cc->cwnd_initial)
+                cc->state.pico.undo.cwnd = cc->cwnd_initial;
+        }
         cc->state.pico.undo.ssthresh = cc->ssthresh;
         cc->state.pico.undo.bytes_per_mtu_increase = cc->state.pico.bytes_per_mtu_increase;
     } else {
@@ -218,6 +223,7 @@ static void pico_on_late_ack(quicly_cc_t *cc, uint64_t pn, int64_t now)
         ++cc->num_loss_episodes_undone_in_startup;
         cc->cwnd_exiting_slow_start = 0;
         cc->exit_slow_start_at = INT64_MAX;
+        quicly_cc_jumpstart_reset(cc);
         cc->rapid_start.newest_rtt_sample_until = 0;
     }
 }

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -198,8 +198,6 @@ ClampMinAndUpdateMetrics:
 
 static void pico_on_late_ack(quicly_cc_t *cc, uint64_t pn, int64_t now)
 {
-    (void)now;
-
     if (cc->state.pico.undo.num_packets_lost == 0 || pn < cc->state.pico.undo.start_pn || cc->recovery_end <= pn)
         return;
 

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -116,11 +116,25 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
     /* Nothing to do if loss is in recovery window (modulo when exiting rapid start, in which case CWND is further reduced relative
      * to the number of bytes lost. */
     if (lost_pn < cc->recovery_end) {
+        if (bytes != 0 && cc->state.pico.undo.num_packets_lost != 0)
+            ++cc->state.pico.undo.num_packets_lost;
         if (cc->num_loss_episodes == 1 && quicly_cc_rapid_start_is_enabled(&cc->rapid_start)) {
             quicly_cc_rapid_start_on_recovery(&cc->rapid_start, &cc->cwnd, 0, bytes);
             goto ClampMinAndUpdateMetrics;
         }
         return;
+    }
+
+    /* Zero-byte congestion reports are ECN signals, not lost packets. They still enter recovery below, but cannot be undone by
+     * late ACKs because no packet was deemed lost. */
+    if (bytes != 0) {
+        cc->state.pico.undo.num_packets_lost = 1;
+        cc->state.pico.undo.start_pn = lost_pn;
+        cc->state.pico.undo.cwnd = cc->cwnd;
+        cc->state.pico.undo.ssthresh = cc->ssthresh;
+        cc->state.pico.undo.bytes_per_mtu_increase = cc->state.pico.bytes_per_mtu_increase;
+    } else {
+        cc->state.pico.undo.num_packets_lost = 0;
     }
 
     cc->recovery_end = next_pn;
@@ -180,6 +194,28 @@ ClampMinAndUpdateMetrics:
 
     if (cc->cwnd_minimum > cc->cwnd)
         cc->cwnd_minimum = cc->cwnd;
+}
+
+static void pico_on_late_ack(quicly_cc_t *cc, uint64_t pn, int64_t now)
+{
+    (void)now;
+
+    if (cc->state.pico.undo.num_packets_lost == 0 || pn < cc->state.pico.undo.start_pn || cc->recovery_end <= pn)
+        return;
+
+    if (--cc->state.pico.undo.num_packets_lost != 0)
+        return;
+
+    int was_in_slow_start = cc->state.pico.undo.ssthresh == UINT32_MAX;
+    cc->cwnd = cc->state.pico.undo.cwnd;
+    cc->ssthresh = cc->state.pico.undo.ssthresh;
+    cc->state.pico.bytes_per_mtu_increase = cc->state.pico.undo.bytes_per_mtu_increase;
+    cc->recovery_end = 0;
+    --cc->num_loss_episodes;
+    if (was_in_slow_start) {
+        cc->cwnd_exiting_slow_start = 0;
+        cc->exit_slow_start_at = INT64_MAX;
+    }
 }
 
 static void pico_on_persistent_congestion(quicly_cc_t *cc, const quicly_loss_t *loss, int64_t now)
@@ -246,7 +282,14 @@ static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd
     pico_reset(cc, initcwnd);
 }
 
-quicly_cc_type_t quicly_cc_type_pico = {"pico",         &quicly_cc_pico_init,          pico_on_acked,
-                                        pico_on_lost,   pico_on_persistent_congestion, pico_on_sent,
-                                        pico_on_switch, quicly_cc_jumpstart_enter,     pico_enable_rapid_start};
+quicly_cc_type_t quicly_cc_type_pico = {"pico",
+                                        &quicly_cc_pico_init,
+                                        pico_on_acked,
+                                        pico_on_lost,
+                                        pico_on_persistent_congestion,
+                                        pico_on_sent,
+                                        pico_on_switch,
+                                        pico_on_late_ack,
+                                        quicly_cc_jumpstart_enter,
+                                        pico_enable_rapid_start};
 quicly_init_cc_t quicly_cc_pico_init = {pico_init};

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -143,6 +143,7 @@ quicly_cc_type_t quicly_cc_type_reno = {"reno",
                                         quicly_cc_reno_on_persistent_congestion,
                                         quicly_cc_reno_on_sent,
                                         reno_on_switch,
+                                        NULL,
                                         quicly_cc_jumpstart_enter};
 quicly_init_cc_t quicly_cc_reno_init = {reno_init};
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -6251,6 +6251,7 @@ static quicly_error_t handle_ack_frame(quicly_conn_t *conn, struct st_quicly_han
     } largest_newly_acked = {UINT64_MAX, INT64_MAX};
     size_t bytes_acked = 0;
     int includes_ack_eliciting = 0, includes_late_ack = 0;
+    uint64_t largest_late_acked = UINT64_MAX;
     quicly_error_t ret;
 
     /* The flow is considered CC-limited if the packet was sent while `inflight >= 1/2 * CNWD` or acked under the same condition.
@@ -6319,6 +6320,7 @@ static quicly_error_t handle_ack_frame(quicly_conn_t *conn, struct st_quicly_han
                 if (sent->cc_bytes_in_flight == 0) {
                     is_late_ack = 1;
                     includes_late_ack = 1;
+                    largest_late_acked = pn_acked;
                     ++conn->super.stats.num_packets.late_acked;
                 }
             }
@@ -6374,8 +6376,8 @@ static quicly_error_t handle_ack_frame(quicly_conn_t *conn, struct st_quicly_han
 
     /* Update loss detection engine on ack. The function uses ack_delay only when the largest_newly_acked is also the largest acked
      * so far. So, it does not matter if the ack_delay being passed in does not apply to the largest_newly_acked. */
-    quicly_loss_on_ack_received(&conn->egress.loss, largest_newly_acked.pn, state->epoch, conn->stash.now,
-                                largest_newly_acked.sent_at, frame.ack_delay,
+    quicly_loss_on_ack_received(&conn->egress.loss, largest_newly_acked.pn, largest_late_acked, conn->egress.packet_number,
+                                state->epoch, conn->stash.now, largest_newly_acked.sent_at, frame.ack_delay,
                                 includes_ack_eliciting ? includes_late_ack ? QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING_LATE_ACK
                                                                            : QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING
                                                        : QUICLY_LOSS_ACK_RECEIVED_KIND_NON_ACK_ELICITING);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -6322,6 +6322,8 @@ static quicly_error_t handle_ack_frame(quicly_conn_t *conn, struct st_quicly_han
                     includes_late_ack = 1;
                     largest_late_acked = pn_acked;
                     ++conn->super.stats.num_packets.late_acked;
+                    if (conn->egress.pn_path_start <= pn_acked && conn->egress.cc.type->cc_on_late_ack != NULL)
+                        conn->egress.cc.type->cc_on_late_ack(&conn->egress.cc, pn_acked, conn->stash.now);
                 }
             }
             ++conn->super.stats.num_packets.ack_received;

--- a/t/cc.c
+++ b/t/cc.c
@@ -110,6 +110,33 @@ static void test_pico_undo_rapid_start_loss(void)
     ok(cc.ssthresh == cc.cwnd);
 }
 
+static void test_pico_undo_jumpstart_loss(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 10 * mtu, jumpcwnd = 24 * mtu;
+
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0);
+    cc.type->cc_jumpstart(&cc, jumpcwnd, 10);
+    ok(quicly_cc_in_jumpstart(&cc));
+    ok(cc.cwnd == jumpcwnd);
+
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    ok(cc.state.pico.undo.cwnd == jumpcwnd / 2);
+    ok(cc.cwnd < jumpcwnd);
+    ok(!quicly_cc_in_jumpstart(&cc));
+
+    cc.type->cc_on_late_ack(&cc, 10, 1100);
+    ok(cc.recovery_end == 0);
+    ok(cc.cwnd == jumpcwnd / 2);
+    ok(cc.ssthresh == UINT32_MAX);
+
+    cc.type->cc_on_acked(&cc, &loss, mtu, 11, 18 * mtu, 1, 20, 1200, mtu);
+    ok(cc.cwnd != 18 * mtu);
+    ok(cc.cwnd_exiting_jumpstart == 0);
+    ok(!quicly_cc_in_jumpstart(&cc));
+}
+
 static void test_rapid_start(void)
 {
     struct st_quicly_cc_rapid_start_t rs;
@@ -149,4 +176,5 @@ void test_cc(void)
     subtest("pico-undo-loss", test_pico_undo_loss);
     subtest("pico-undo-multiple-losses", test_pico_undo_multiple_losses);
     subtest("pico-undo-rapid-start-loss", test_pico_undo_rapid_start_loss);
+    subtest("pico-undo-jumpstart-loss", test_pico_undo_jumpstart_loss);
 }

--- a/t/cc.c
+++ b/t/cc.c
@@ -19,8 +19,68 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-#include "quicly/cc.h"
+#include "quicly.h"
 #include "test.h"
+
+static void test_pico_undo_loss(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 10 * mtu;
+
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0);
+    uint32_t bytes_per_mtu_increase = cc.state.pico.bytes_per_mtu_increase;
+
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    ok(cc.recovery_end == 20);
+    ok(cc.num_loss_episodes == 1);
+    ok(cc.state.pico.undo.num_packets_lost == 1);
+    ok(cc.cwnd < initcwnd);
+    ok(cc.ssthresh == cc.cwnd);
+    ok(cc.cwnd_exiting_slow_start == initcwnd);
+    ok(cc.exit_slow_start_at == 1000);
+
+    cc.type->cc_on_late_ack(&cc, 10, 1100);
+    ok(cc.recovery_end == 0);
+    ok(cc.num_loss_episodes == 0);
+    ok(cc.state.pico.undo.num_packets_lost == 0);
+    ok(cc.cwnd == initcwnd);
+    ok(cc.ssthresh == UINT32_MAX);
+    ok(cc.state.pico.bytes_per_mtu_increase == bytes_per_mtu_increase);
+    ok(cc.cwnd_exiting_slow_start == 0);
+    ok(cc.exit_slow_start_at == INT64_MAX);
+}
+
+static void test_pico_undo_multiple_losses(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 10 * mtu;
+
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0);
+
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    uint32_t reduced_cwnd = cc.cwnd;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 11, 20, 1001, mtu);
+    ok(cc.state.pico.undo.num_packets_lost == 2);
+
+    cc.type->cc_on_late_ack(&cc, 9, 1099);
+    ok(cc.state.pico.undo.num_packets_lost == 2);
+    ok(cc.recovery_end == 20);
+
+    cc.type->cc_on_late_ack(&cc, 10, 1100);
+    ok(cc.state.pico.undo.num_packets_lost == 1);
+    ok(cc.recovery_end == 20);
+    ok(cc.cwnd == reduced_cwnd);
+    ok(cc.num_loss_episodes == 1);
+
+    cc.type->cc_on_late_ack(&cc, 11, 1101);
+    ok(cc.state.pico.undo.num_packets_lost == 0);
+    ok(cc.recovery_end == 0);
+    ok(cc.cwnd == initcwnd);
+    ok(cc.ssthresh == UINT32_MAX);
+    ok(cc.num_loss_episodes == 0);
+}
 
 static void test_rapid_start(void)
 {
@@ -58,4 +118,6 @@ static void test_rapid_start(void)
 void test_cc(void)
 {
     subtest("rapid-start", test_rapid_start);
+    subtest("pico-undo-loss", test_pico_undo_loss);
+    subtest("pico-undo-multiple-losses", test_pico_undo_multiple_losses);
 }

--- a/t/cc.c
+++ b/t/cc.c
@@ -86,6 +86,30 @@ static void test_pico_undo_multiple_losses(void)
     ok(cc.num_loss_episodes_undone_in_startup == 1);
 }
 
+static void test_pico_undo_rapid_start_loss(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 10 * mtu;
+
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0);
+    cc.type->enable_rapid_start(&cc, 900);
+    ok(quicly_cc_rapid_start_is_enabled(&cc.rapid_start));
+
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    ok(cc.rapid_start.newest_rtt_sample_until == -1);
+
+    cc.type->cc_on_late_ack(&cc, 10, 1100);
+    ok(cc.rapid_start.newest_rtt_sample_until == 0);
+    ok(cc.recovery_end == 0);
+    ok(cc.cwnd == initcwnd);
+    ok(cc.ssthresh == UINT32_MAX);
+
+    cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 1200, mtu);
+    ok(cc.cwnd == initcwnd / 2);
+    ok(cc.ssthresh == cc.cwnd);
+}
+
 static void test_rapid_start(void)
 {
     struct st_quicly_cc_rapid_start_t rs;
@@ -124,4 +148,5 @@ void test_cc(void)
     subtest("rapid-start", test_rapid_start);
     subtest("pico-undo-loss", test_pico_undo_loss);
     subtest("pico-undo-multiple-losses", test_pico_undo_multiple_losses);
+    subtest("pico-undo-rapid-start-loss", test_pico_undo_rapid_start_loss);
 }

--- a/t/cc.c
+++ b/t/cc.c
@@ -43,6 +43,8 @@ static void test_pico_undo_loss(void)
     cc.type->cc_on_late_ack(&cc, 10, 1100);
     ok(cc.recovery_end == 0);
     ok(cc.num_loss_episodes == 0);
+    ok(cc.num_loss_episodes_undone == 1);
+    ok(cc.num_loss_episodes_undone_in_startup == 1);
     ok(cc.state.pico.undo.num_packets_lost == 0);
     ok(cc.cwnd == initcwnd);
     ok(cc.ssthresh == UINT32_MAX);
@@ -80,6 +82,8 @@ static void test_pico_undo_multiple_losses(void)
     ok(cc.cwnd == initcwnd);
     ok(cc.ssthresh == UINT32_MAX);
     ok(cc.num_loss_episodes == 0);
+    ok(cc.num_loss_episodes_undone == 1);
+    ok(cc.num_loss_episodes_undone_in_startup == 1);
 }
 
 static void test_rapid_start(void)

--- a/t/loss.c
+++ b/t/loss.c
@@ -44,7 +44,8 @@ static void acked(quicly_loss_t *loss, uint64_t pn, size_t epoch)
     int64_t sent_at = sent->sent_at;
     ok(quicly_sentmap_update(&loss->sentmap, &iter, QUICLY_SENTMAP_EVENT_ACKED) == 0);
 
-    quicly_loss_on_ack_received(loss, pn, epoch, now, sent_at, 0, 1);
+    quicly_loss_on_ack_received(loss, pn, UINT64_MAX, pn + 1, epoch, now, sent_at, 0,
+                                QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING);
 }
 
 static void test_time_detection(void)
@@ -184,9 +185,50 @@ static void test_slow_cert_verify(void)
     quicly_loss_dispose(&loss);
 }
 
+static void test_late_ack_threshold_adjustment(void)
+{
+    quicly_loss_t loss;
+
+    now = 0;
+
+    quicly_loss_init(&loss, &quicly_spec_context.loss, 20, &quicly_spec_context.transport_params.max_ack_delay,
+                     &quicly_spec_context.transport_params.ack_delay_exponent);
+
+    ok(loss.min_pn_to_relax_reorder_tolerance == 0);
+    ok(loss.thresholds.use_packet_based);
+    ok(loss.thresholds.time_based_percentile == 1024 / 8);
+
+    quicly_loss_on_ack_received(&loss, 100, 100, 200, QUICLY_EPOCH_1RTT, now, now - 20, 0,
+                                QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING_LATE_ACK);
+    ok(loss.min_pn_to_relax_reorder_tolerance == 200);
+    ok(!loss.thresholds.use_packet_based);
+    ok(loss.thresholds.time_based_percentile == 1024 / 8);
+
+    quicly_loss_on_ack_received(&loss, 101, 101, 200, QUICLY_EPOCH_1RTT, now, now - 20, 0,
+                                QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING_LATE_ACK);
+    ok(loss.min_pn_to_relax_reorder_tolerance == 200);
+    ok(!loss.thresholds.use_packet_based);
+    ok(loss.thresholds.time_based_percentile == 1024 / 8);
+
+    quicly_loss_on_ack_received(&loss, 250, 199, 300, QUICLY_EPOCH_1RTT, now, now - 20, 0,
+                                QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING_LATE_ACK);
+    ok(loss.min_pn_to_relax_reorder_tolerance == 200);
+    ok(!loss.thresholds.use_packet_based);
+    ok(loss.thresholds.time_based_percentile == 1024 / 8);
+
+    quicly_loss_on_ack_received(&loss, 200, 200, 300, QUICLY_EPOCH_1RTT, now, now - 20, 0,
+                                QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING_LATE_ACK);
+    ok(loss.min_pn_to_relax_reorder_tolerance == 300);
+    ok(!loss.thresholds.use_packet_based);
+    ok(loss.thresholds.time_based_percentile == 1024 / 4);
+
+    quicly_loss_dispose(&loss);
+}
+
 void test_loss(void)
 {
     subtest("time-detection", test_time_detection);
     subtest("pn-detection", test_pn_detection);
     subtest("slow-cert-verify", test_slow_cert_verify);
+    subtest("late-ack-threshold-adjustment", test_late_ack_threshold_adjustment);
 }


### PR DESCRIPTION
## Summary

This PR teaches pico to undo a packet-loss recovery episode when every packet deemed lost in that episode is later acknowledged.

When entering packet-loss recovery, pico now snapshots the core CC state needed for undo. Each packet declared lost during that recovery is counted, and each late ACK for those packets decrements the count. When the count reaches zero, pico restores the pre-recovery `cwnd`, `ssthresh`, and increase threshold, clears `recovery_end`, and updates recovery-undo stats.

Jumpstart and rapid-start optimization state is intentionally not restored. Undo returns pico to the core pre-loss CC state, while leaving those startup accelerators disabled after the false loss signal.

## Reorder Tolerance Fixes

This also fixes two issues around late ACK based tolerance relaxation:

- avoid relaxing reorder tolerance repeatedly for multiple late ACK frames that refer to the same sent packet range
- relax tolerance before ACK-processing early returns, so ACK frames that do not update RTT or largest-acked state can still reduce future false loss detection

## Stats

Adds stats for observing recovery undo behavior:

- `cc.num-loss-episodes-undone`
- `cc.num-loss-episodes-undone-in-startup`

## Tests

- `make -C build/default test.t`
- `build/default/test.t`
