### PR TITLE
fix test

### DIFF
--- a/t/e2e.t
+++ b/t/e2e.t
@@ -656,7 +656,7 @@ subtest "coalesced-initials" => sub {
 
 subtest "max-data" => sub {
     my $server = spawn_server(qw(-M 1048576 -m 16777216 -X 100 -e), "$tempdir/events");
-    my $conn = RawConnection->new("127.0.0.1", $port);
+    my $conn = t::RawConnection->new("127.0.0.1", $port);
     # open 100 streams, send one byte of "X" just before 1MB
     for (my $stream_id = 0; $stream_id < 400; $stream_id += 4) {
         $conn->send("\x0e\x80\x00" . pack("n", $stream_id) . "\x80\x0f\xff\xff\x01X");

--- a/t/e2e.t
+++ b/t/e2e.t
@@ -656,7 +656,7 @@ subtest "coalesced-initials" => sub {
 
 subtest "max-data" => sub {
     my $server = spawn_server(qw(-M 1048576 -m 16777216 -X 100 -e), "$tempdir/events");
-    my $conn = t::RawConnection->new("127.0.0.1", $port);
+    my $conn = t::RawConnection->new("127.0.0.1", $port, cli => $cli);
     # open 100 streams, send one byte of "X" just before 1MB
     for (my $stream_id = 0; $stream_id < 400; $stream_id += 4) {
         $conn->send("\x0e\x80\x00" . pack("n", $stream_id) . "\x80\x0f\xff\xff\x01X");


### PR DESCRIPTION
One of the vulnerability fixes uses RawConnection for testing, however it now needs the `t::` prefix.