### PR TITLE
simulator: fix multi-flow analysis, broken since #656; add fairness charts

### DIFF
--- a/t/simulator-plot.rb
+++ b/t/simulator-plot.rb
@@ -53,20 +53,40 @@ def parse_simulator_output(lines)
   end
 end
 
-def build_values(events, labels, show_queue)
-  src_to_label = {}
-  next_label_index = 0
+# Clients are given addresses in the order they are created, which is the order of the flow blocks, the server having taken the
+# first one. Deriving the mapping from that order rather than from the order the flows are first seen keeps the labels correct
+# even when the flows are started at different times (-s).
+def build_src_to_label(labels)
+  labels.each_with_index.to_h { |label, index| [index + 2, label] }
+end
 
-  assign_label = lambda do |src|
-    return nil if src.nil?
-    return src_to_label[src] if src_to_label.key?(src)
-    return nil if next_label_index >= labels.length
+# Computes the egress rate of each flow at the bottleneck, by bucketing `dequeue` events into fixed-width buckets. This is what
+# the bottleneck actually forwarded, in contrast to `bytes-available`, which is the in-order delivery to the application and
+# therefore stalls while a loss is being recovered. A "total" series is emitted alongside the per-flow ones.
+def build_throughput_values(events, src_to_label, bucket)
+  rows = Jrf.new(
+    proc { select(_["bottleneck"] == "dequeue" && src_to_label.key?(_["packet-src"])) },
+    proc do
+      {
+        "at" => ((_["at"] - 1000.0) / bucket).floor * bucket,
+        "flow" => src_to_label.fetch(_["packet-src"]),
+        "bytes" => _["packet-size"]
+      }
+    end
+  ).call(events)
 
-    label = labels[next_label_index]
-    src_to_label[src] = label
-    next_label_index += 1
-    label
+  values = rows.group_by { |row| [row["at"], row["flow"]] }.map do |(at, flow), grouped|
+    { "at" => at, "value" => grouped.sum { |row| row["bytes"] } / bucket, "flow" => flow, "metric" => "throughput" }
   end
+  values += rows.group_by { |row| row["at"] }.map do |at, grouped|
+    { "at" => at, "value" => grouped.sum { |row| row["bytes"] } / bucket, "flow" => "total", "metric" => "throughput" }
+  end
+
+  values.sort_by { |value| [value["at"], value["flow"]] }
+end
+
+def build_values(events, labels, show_queue)
+  src_to_label = build_src_to_label(labels)
 
   Jrf.new(
     proc do
@@ -77,7 +97,7 @@ def build_values(events, labels, show_queue)
     end,
     proc do
       if _.key?("bytes-available")
-        flow = labels.length == 1 ? labels[0] : assign_label.call(_["packet-src"])
+        flow = labels.length == 1 ? labels[0] : src_to_label[_["packet-src"]]
         if flow.nil?
           select(false)
         else
@@ -99,7 +119,7 @@ def build_values(events, labels, show_queue)
   ).call(events)
 end
 
-def build_spec(values:, length:, title:, show_queue:, width:, height:, flow_count:)
+def build_spec(values:, length:, title:, show_queue:, width:, height:, flow_count:, throughput: false)
   x_encoding = {
     "field" => "at",
     "type" => "quantitative",
@@ -109,14 +129,14 @@ def build_spec(values:, length:, title:, show_queue:, width:, height:, flow_coun
 
   layers = [
     {
-      "transform" => [{ "filter" => "datum.metric == 'deliver'" }],
+      "transform" => [{ "filter" => "datum.metric == '#{throughput ? "throughput" : "deliver"}'" }],
       "mark" => { "type" => "line" },
       "encoding" => {
         "x" => x_encoding,
         "y" => {
           "field" => "value",
           "type" => "quantitative",
-          "title" => "bytes available"
+          "title" => throughput ? "throughput (bytes/sec)" : "bytes available"
         }
       }
     }
@@ -163,7 +183,8 @@ def build_spec(values:, length:, title:, show_queue:, width:, height:, flow_coun
       }
     end
   else
-    if flow_count > 1
+    # in throughput mode there is always more than one series, as the total is drawn alongside the per-flow ones
+    if throughput || flow_count > 1
       layers[0]["encoding"]["color"] = {
         "field" => "flow",
         "type" => "nominal",
@@ -207,6 +228,8 @@ cc = "pico"
 length = 1.0
 network_name = "DSL"
 show_queue = false
+throughput = false
+bucket = nil
 output_prefix = "simulator"
 render = true
 auto_open = true
@@ -227,6 +250,8 @@ OptionParser.new do |opt|
     network_name = v
   end
   opt.on("--queue") { show_queue = true }
+  opt.on("--throughput") { throughput = true }
+  opt.on("--bucket=SECONDS", Float) { |v| bucket = v }
   opt.on("--output=PREFIX") { |v| output_prefix = v }
   opt.on("--title=TEXT") { |v| title_override = v }
   opt.on("--width=PX", Integer) { |v| width = v }
@@ -240,6 +265,12 @@ raise ArgumentError, "no flows given; expected: -- label <opts...> -- ..." if fl
 if show_queue && flows.length > 1
   raise ArgumentError, "--queue cannot be used when multiple flows are given"
 end
+raise ArgumentError, "--throughput and --queue cannot be used together" if throughput && show_queue
+raise ArgumentError, "--bucket requires --throughput" if bucket && !throughput
+raise ArgumentError, "--bucket must be positive" if bucket && bucket <= 0
+
+# one bucket per 1/200 of the simulated period; the RTT would be a more natural unit but it is a per-flow property (-d)
+bucket ||= length / 200.0
 
 network = NETWORKS.fetch(network_name)
 cmd = [
@@ -258,13 +289,19 @@ end
 labels = flows.map(&:first)
 values = nil
 Open3.popen3(*cmd) do |_stdin, stdout, stderr, wait_thr|
-  values = build_values(parse_simulator_output(stdout.each_line), labels, show_queue)
+  events = parse_simulator_output(stdout.each_line)
+  values = if throughput
+             build_throughput_values(events, build_src_to_label(labels), bucket)
+           else
+             build_values(events, labels, show_queue)
+           end
   err = stderr.read
   status = wait_thr.value
   raise "simulator failed: #{err.strip}" unless status.success?
 end
 
-missing = labels.reject { |label| values.any? { |value| value["flow"] == label && value["metric"] == "deliver" } }
+metric = throughput ? "throughput" : "deliver"
+missing = labels.reject { |label| values.any? { |value| value["flow"] == label && value["metric"] == metric } }
 raise "simulator did not emit data for flows: #{missing.join(", ")}" unless missing.empty?
 raise "no data produced by simulator" if values.empty?
 
@@ -275,7 +312,8 @@ spec = build_spec(
   show_queue: show_queue,
   width: width,
   height: height,
-  flow_count: flows.length
+  flow_count: flows.length,
+  throughput: throughput
 )
 spec_json = JSON.pretty_generate(spec)
 

--- a/t/simulator.c
+++ b/t/simulator.c
@@ -735,7 +735,9 @@ int main(int argc, char **argv)
     for (int seg_start = first_sep + 1; seg_start < argc;) {
         int seg_end = find_next_separator(argc, argv, seg_start);
         if (seg_end > seg_start) {
-            quicly_context_t flow_ctx = quicctx;
+            /* the context is retained by the connection being created below, therefore it has to be allocated on heap */
+            quicly_context_t *flow_ctx = malloc(sizeof(*flow_ctx));
+            *flow_ctx = quicctx;
             double flow_delay = delay, flow_start = start;
 
             int flow_argc = seg_end - seg_start + 1;
@@ -746,7 +748,7 @@ int main(int argc, char **argv)
             if (seg_end < argc)
                 argv[seg_end] = NULL;
 
-            if (!parse_options(flow_argc, flow_argv, &flow_ctx, &flow_delay, &flow_start, NULL, NULL, NULL, NULL, NULL))
+            if (!parse_options(flow_argc, flow_argv, flow_ctx, &flow_delay, &flow_start, NULL, NULL, NULL, NULL, NULL))
                 exit(1);
             flow_argv[0] = saved_argv0;
             if (seg_end < argc)
@@ -760,7 +762,7 @@ int main(int argc, char **argv)
             struct net_endpoint *client_node = malloc(sizeof(*client_node));
             net_endpoint_init(client_node);
             client_node->start_at = now + flow_start;
-            int ret = quicly_connect(&client_node->conns[0].quic, &flow_ctx, "hello.example.com", &server_node.node.addr.sa,
+            int ret = quicly_connect(&client_node->conns[0].quic, flow_ctx, "hello.example.com", &server_node.node.addr.sa,
                                      &client_node->addr.sa, &next_quic_cid, ptls_iovec_init(NULL, 0), NULL, NULL, NULL);
             ++next_quic_cid.master_id;
             assert(ret == 0);


### PR DESCRIPTION
## Summary
Since #656, multi-flow analysis has been producing wrong results, silently.
Every flow ran the configuration of the *last* flow block, so a chart comparing
two flows was really the same connection drawn twice. The same defect crashed
the simulator outright under loss, single-flow included.

This PR fixes that, and adds a `--throughput` mode to `t/simulator-plot.rb` that
charts the rate each flow gets at the bottleneck. Together they give the repo the
ability to produce fairness charts of competing flows from a single command.

## What was broken
`quicly_connect` retains the `quicly_context_t` it is given, but `flow_ctx` was
a local of the block parsing each flow block, so every connection pointed at a
stack slot that had gone out of scope. Introduced by 635d163 (#656), which
replaced the positional `-n` flows with `--`-separated blocks; until then the
context was `quicctx` of `main`, which outlives every connection.

- **per-flow options collapsed.** All flows shared one slot, so `-c`, `-i`,
  `-j`, `-p`, `-R` took the values of the last block. Blocks with identical
  options were unaffected, which is likely why it went unnoticed — #658's
  verification used two identical flows, and #657's stated scenario (flows with
  different CC settings) was exactly the one that could not work.
- **crash under loss.** Once the frame was reused the retained values became
  garbage and the simulator jumped to a bogus address while sending. Easy to hit
  with `-r`, as loss recovery reaches deeper call paths. ASan:
  ```
  ERROR: AddressSanitizer: stack-use-after-scope
  READ of size 8 in lock_now quicly.c:620 / quicly_send quicly.c:5897
  Address is inside this variable: 'flow_ctx' (line 738)
  ```

## What this adds
`t/simulator-plot.rb --throughput` buckets `bottleneck`/`dequeue` events by
`packet-src`, giving bytes/sec per flow plus a `total` series — the rate each
flow actually got at the bottleneck, which is what fairness is read from. The
existing `bytes-available` is in-order delivery to the application and stalls
while a loss is being recovered (382 of 1138 increments were zero on one lossy
run, with an 86 ms stall followed by a 52 kB jump), so it distorts exactly the
signal being compared.

Bucket defaults to `--length / 200`, overridable with `--bucket`. The RTT would
be the more natural unit but it is per-flow (`-d`), whereas the bucket has to be
a single value for the chart. `--throughput` is rejected together with
`--queue`; lifting `--queue`'s single-flow restriction is follow-up.

Flow labels are now derived from the order the clients are created rather than
the order they are first seen, which mislabelled flows started at different
times (`-s`) — again, precisely the competing-flow setup.

```
BINARY_DIR=build ruby t/simulator-plot.rb -c pico --network=bdp20 \
  --length=20 --throughput -- a -s 0 -- b -s 5
```

## Verification
- `-r 0 / 0.01 / 0.05 / 0.1` × `reno`/`pico` × with/without `-R`: 16/16 pass,
  all of which crashed before; ASan-clean
- two flows with differing options now get distinct contexts (`0x140008410` vs
  `0x140014bb0`; both `0x16f776590` before)
- the command above: `a` holds ~115 kB/s alone, settling to 38/90 kB/s once `b`
  joins, with `total` pinned at 128 kB/s ≈ link capacity
- 200 buckets at `--length=20`, 20 with `--bucket=1`; all three validations fire
- delivered mode unchanged; both of #658's verification commands still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
