### PR TITLE
[pico] impleent ABE

### DIFF
--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -540,7 +540,9 @@ inline void quicly_cc_rapid_start_on_recovery(struct st_quicly_cc_rapid_start_t 
 #undef ENTRY
     };
 
-    *cwnd -= factors[rs->recovery.by_ecn].ack * bytes_acked + factors[rs->recovery.by_ecn].loss * bytes_lost;
+    uint32_t reduction = factors[rs->recovery.by_ecn].ack * bytes_acked + factors[rs->recovery.by_ecn].loss * bytes_lost;
+    assert(reduction <= *cwnd && "CWND never underflows");
+    *cwnd -= reduction;
     if (*cwnd < rs->recovery.cwnd_floor)
         *cwnd = rs->recovery.cwnd_floor;
 }

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -38,11 +38,20 @@ extern "C" {
 #include "quicly/loss.h"
 
 #define QUICLY_MIN_CWND 2
-#define QUICLY_RENO_BETA 0.7
+/**
+ * Beta used when a packet is lost; to achieve fairness with Cubic, 0.7 is used throughout.
+ */
+#define QUICLY_BETA_LOSS 0.7
+/**
+ * Beta used when congestion is signalled by ECN-CE alone; 0.85 is the value recommended by RFC 8511 for congestion controllers
+ * using 0.7 as the loss-based factor.
+ */
+#define QUICLY_BETA_ECN 0.85
 
+/* factors defined by Rapid Start (see the I-D) */
 #define QUICLY_RAPID_START_K (2. / 3)
-#define QUICLY_RAPID_START_ACK_FACTOR (QUICLY_RAPID_START_K * (1 - QUICLY_RENO_BETA))
-#define QUICLY_RAPID_START_LOSS_FACTOR (QUICLY_RENO_BETA + QUICLY_RAPID_START_ACK_FACTOR)
+#define QUICLY_RAPID_START_ACK_FACTOR(beta) (QUICLY_RAPID_START_K * (1 - (beta)))
+#define QUICLY_RAPID_START_LOSS_FACTOR(beta) ((beta) + QUICLY_RAPID_START_ACK_FACTOR(beta))
 
 /**
  * Holds pointers to concrete congestion control implementation functions.
@@ -54,8 +63,8 @@ typedef const struct st_quicly_cc_type_t quicly_cc_type_t;
  */
 struct st_quicly_cc_rapid_start_t {
     /**
-     * Until when the newest sample (i.e., `rtt_samples[0]`) is to be updated. 0 if rapid start is disabled. Once loss is observed,
-     * this field is set to -1 and `cwnd_floor` is sed.
+     * Until when the newest sample (i.e., `rtt_samples[0]`) is to be updated. 0 if rapid start is disabled. Once congestion is
+     * observed, this field is set to -1 and `recovery` is used.
      */
     int64_t newest_rtt_sample_until;
     union {
@@ -65,9 +74,18 @@ struct st_quicly_cc_rapid_start_t {
          */
         uint32_t rtt_samples[4];
         /**
-         * Retains the lower limit CWND can be reduced during the first recovery phase.
+         * Values retained for the duration of the first recovery period.
          */
-        uint32_t cwnd_floor;
+        struct {
+            /**
+             * The cause of the recovery entry. Different factors are used based on the cause.
+             */
+            unsigned by_ecn : 1;
+            /**
+             * Retains the lower limit CWND can be reduced.
+             */
+            uint32_t cwnd_floor;
+        } recovery;
     };
 };
 
@@ -321,9 +339,10 @@ static void quicly_cc_rapid_start_update_rtt(struct st_quicly_cc_rapid_start_t *
  */
 static int quicly_cc_rapid_start_use_3x(struct st_quicly_cc_rapid_start_t *rs, const quicly_rtt_t *rtt);
 /**
- *
+ * Ends rapid start and enters the first recovery period.
  */
-static void quicly_cc_rapid_start_on_first_lost(struct st_quicly_cc_rapid_start_t *rs, uint32_t *cwnd, uint32_t cwnd_floor);
+static void quicly_cc_rapid_start_on_first_lost(struct st_quicly_cc_rapid_start_t *rs, uint32_t *cwnd, int by_ecn,
+                                                uint32_t cwnd_floor);
 /**
  * During the first recovery period, updates CWND. Must only be called during the first recovery period.
  */
@@ -387,9 +406,9 @@ inline void quicly_cc_jumpstart_on_acked(quicly_cc_t *cc, int in_recovery, uint3
     if (in_recovery) {
         /* Propotional Rate Reduction: if a loss is observed due to jumpstart, CWND is adjusted so that it would become bytes that
          * passed through to the client during the jumpstart phase of exactly 1 RTT, when the last ACK for the jumpstart phase is
-         * received */
-        if (is_jumpstart_ack && cc->cwnd < cc->jumpstart.bytes_acked * QUICLY_RENO_BETA)
-            cc->cwnd = cc->jumpstart.bytes_acked * QUICLY_RENO_BETA;
+         * received (TODO use QUICLY_BETA_ECN?) */
+        if (is_jumpstart_ack && cc->cwnd < cc->jumpstart.bytes_acked * QUICLY_BETA_LOSS)
+            cc->cwnd = cc->jumpstart.bytes_acked * QUICLY_BETA_LOSS;
         return;
     }
 
@@ -482,21 +501,26 @@ inline int quicly_cc_rapid_start_use_3x(struct st_quicly_cc_rapid_start_t *rs, c
     return floor <= threshold;
 }
 
-inline void quicly_cc_rapid_start_on_first_lost(struct st_quicly_cc_rapid_start_t *rs, uint32_t *cwnd, uint32_t cwnd_floor)
+inline void quicly_cc_rapid_start_on_first_lost(struct st_quicly_cc_rapid_start_t *rs, uint32_t *cwnd, int by_ecn,
+                                                uint32_t cwnd_floor)
 {
     if (rs->newest_rtt_sample_until == 0)
         return;
 
     assert(rs->newest_rtt_sample_until > 0);
     rs->newest_rtt_sample_until = -1;
+    rs->recovery.by_ecn = by_ecn != 0;
 
-    rs->cwnd_floor = *cwnd * (1. / 3) * QUICLY_RENO_BETA;
-    if (rs->cwnd_floor < cwnd_floor)
-        rs->cwnd_floor = cwnd_floor;
+    double beta = rs->recovery.by_ecn ? QUICLY_BETA_ECN : QUICLY_BETA_LOSS;
 
-    *cwnd *= QUICLY_RAPID_START_LOSS_FACTOR;
-    if (*cwnd < rs->cwnd_floor)
-        *cwnd = rs->cwnd_floor;
+    rs->recovery.cwnd_floor = *cwnd * (1. / 3) * beta;
+    if (rs->recovery.cwnd_floor < cwnd_floor)
+        rs->recovery.cwnd_floor = cwnd_floor;
+
+    /* the silence factor is identical to the loss factor */
+    *cwnd *= QUICLY_RAPID_START_LOSS_FACTOR(beta);
+    if (*cwnd < rs->recovery.cwnd_floor)
+        *cwnd = rs->recovery.cwnd_floor;
 }
 
 inline void quicly_cc_rapid_start_on_recovery(struct st_quicly_cc_rapid_start_t *rs, uint32_t *cwnd, uint32_t bytes_acked,
@@ -507,9 +531,18 @@ inline void quicly_cc_rapid_start_on_recovery(struct st_quicly_cc_rapid_start_t 
 
     assert(rs->newest_rtt_sample_until == -1);
 
-    *cwnd -= QUICLY_RAPID_START_ACK_FACTOR * bytes_acked + QUICLY_RAPID_START_LOSS_FACTOR * bytes_lost;
-    if (*cwnd < rs->cwnd_floor)
-        *cwnd = rs->cwnd_floor;
+    static const struct {
+        double ack, loss;
+    } factors[] = {
+#define ENTRY(beta) {QUICLY_RAPID_START_ACK_FACTOR(beta), QUICLY_RAPID_START_LOSS_FACTOR(beta)}
+        ENTRY(QUICLY_BETA_LOSS),
+        ENTRY(QUICLY_BETA_ECN),
+#undef ENTRY
+    };
+
+    *cwnd -= factors[rs->recovery.by_ecn].ack * bytes_acked + factors[rs->recovery.by_ecn].loss * bytes_lost;
+    if (*cwnd < rs->recovery.cwnd_floor)
+        *cwnd = rs->recovery.cwnd_floor;
 }
 
 #ifdef __cplusplus

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -27,35 +27,37 @@
 /**
  * Calculates the increase ratio to be used in congestion avoidance phase.
  */
-static uint32_t calc_bytes_per_mtu_increase(uint32_t cwnd, uint32_t rtt, uint32_t mtu)
+static uint32_t calc_bytes_per_mtu_increase(uint32_t cwnd, uint32_t rtt, uint32_t mtu, double beta)
 {
     /* Reno: CWND size after reduction */
-    uint32_t reno = cwnd * QUICLY_RENO_BETA;
+    uint32_t reno = cwnd * beta;
 
     /* Cubic: Cubic reaches original CWND (i.e., Wmax) in K seconds, therefore:
-     *   amount_to_increase = 0.3 * Wmax
+     *   amount_to_increase = (1 - beta) * Wmax
      *   amount_to_be_acked = K * Wmax / RTT_at_Wmax
      * where
-     *   K = (0.3 / 0.4 * Wmax / MTU)^(1/3)
+     *   K = ((1 - beta) / 0.4 * Wmax / MTU)^(1/3)
      *
      * Hence:
      *   bytes_per_mtu_increase = amount_to_be_acked / amount_to_increase * MTU
-     *     = (K * Wmax / RTT_at_Wmax) / (0.3 * Wmax) * MTU
-     *     = K * MTU / (0.3 * RTT_at_Wmax)
+     *     = (K * Wmax / RTT_at_Wmax) / ((1 - beta) * Wmax) * MTU
+     *     = K * MTU / ((1 - beta) * RTT_at_Wmax)
      *
      * In addition, we have to adjust the value to take fast convergence into account. On a path with stable capacity, 50% of
-     * congestion events adjust Wmax to 0.85x of before calculating K. If that happens, the modified K (K') is:
+     * congestion events adjust Wmax to (1 + beta) / 2 (i.e., 0.85x when beta is 0.7) of before calculating K. If that happens, the
+     * modified K (K') is:
      *
-     *   K' = (0.3 / 0.4 * 0.85 * Wmax / MTU)^(1/3) = 0.85^(1/3) * K
+     *   K' = ((1 - beta) / 0.4 * (1 + beta) / 2 * Wmax / MTU)^(1/3) = ((1 + beta) / 2)^(1/3) * K
      *
-     * where K' represents the time to reach 0.85 * Wmax. As the cubic curve is point symmetric at the point where this curve
-     * reaches 0.85 * Wmax, it would take 2 * K' seconds to reach Wmax.
+     * where K' represents the time to reach (1 + beta) / 2 * Wmax. As the cubic curve is point symmetric at the point where this
+     * curve reaches (1 + beta) / 2 * Wmax, it would take 2 * K' seconds to reach Wmax.
      *
      * Therefore, by amortizing the two modes, the congestion period of Cubic with fast convergence is calculated as:
      *
-     *   bytes_per_mtu_increase = ((1 + 0.85^(1/3) * 2) / 2) * K * MTU / (0.3 * RTT_at_Wmax)
+     *   bytes_per_mtu_increase = ((1 + ((1 + beta) / 2)^(1/3) * 2) / 2) * K * MTU / ((1 - beta) * RTT_at_Wmax)
      */
-    uint32_t cubic = 1.447 / 0.3 * 1000 * cbrt(0.3 / 0.4 * cwnd / mtu) / rtt * mtu;
+    double fast_convergence_adjust = (1 + cbrt((1 + beta) / 2) * 2) / 2; /* 1.447 when beta is 0.7 */
+    uint32_t cubic = fast_convergence_adjust / (1 - beta) * 1000 * cbrt((1 - beta) / 0.4 * cwnd / mtu) / rtt * mtu;
 
     return reno < cubic ? reno : cubic;
 }
@@ -125,6 +127,8 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
         return;
     }
 
+    double beta = bytes == 0 ? QUICLY_BETA_ECN : QUICLY_BETA_LOSS;
+
     /* Zero-byte congestion reports are ECN signals, not lost packets. They still enter recovery below, but cannot be undone by
      * late ACKs because no packet was deemed lost. */
     if (bytes != 0) {
@@ -167,14 +171,17 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
             if (bdp < cc->cwnd_initial)
                 bdp = cc->cwnd_initial;
         }
-        cc->state.pico.bytes_per_mtu_increase = calc_bytes_per_mtu_increase(bdp, loss->rtt.smoothed, max_udp_payload_size);
+        cc->state.pico.bytes_per_mtu_increase = calc_bytes_per_mtu_increase(bdp, loss->rtt.smoothed, max_udp_payload_size, beta);
     }
 
     /* Reduce congestion window. At the end of Slow Start, 0.5x is used, because the 1 RTT delay in ACK causes the sender to
-     * overshoot by 2x (note: after 0.5x reduction, CWND is still as large as BDP+QUEUE, so further reduction is preferable).
+     * overshoot by 2x (note: after 0.5x reduction, CWND is still as large as BDP+QUEUE, so further reduction is preferable). That
+     * 2x overshoot builds up regardless of if congestion is signalled by a CE mark or by a packet loss, therefore `beta` is not
+     * used here.
      *
-     * In rapid start, upon the first loss we multiply CWND by QUICLY_RAPID_START_LOSS_FACTOR (0.9x when beta is 0.7), then reduce
-     * proportionally to the bytes acked and deemed lost during recovery, with a lower bound of 1/3 * beta.
+     * In rapid start, upon the first congestion signal we multiply CWND by QUICLY_RAPID_START_LOSS_FACTOR (0.9x when beta is 0.7,
+     * 0.95x when it is 0.85), then reduce proportionally to the bytes acked and deemed lost during recovery, with a lower bound of
+     * 1/3 * beta.
      * Rationale: at a small loss, reducing by beta mirrors CA's single signal behavior. With up to ~67% loss (typical for 3x
      * growth under tail-drop), CWND upon loss detection is 3 * (BDP + Q); therefore clamping to 1/3 * beta reproduces the CA
      * target. For loss >67% (i.e., beyond queue overflow), we keep the lower bound to avoid over-shrinking. */
@@ -183,12 +190,12 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
             uint32_t base = cc->cwnd_initial;
             if (base < cc->jumpstart.bytes_acked)
                 base = cc->jumpstart.bytes_acked;
-            quicly_cc_rapid_start_on_first_lost(&cc->rapid_start, &cc->cwnd, base * 0.5);
+            quicly_cc_rapid_start_on_first_lost(&cc->rapid_start, &cc->cwnd, bytes == 0, base * 0.5);
         } else {
             cc->cwnd *= 0.5;
         }
     } else {
-        cc->cwnd *= QUICLY_RENO_BETA;
+        cc->cwnd *= beta;
     }
 
 ClampMinAndUpdateMetrics:
@@ -241,7 +248,7 @@ static void pico_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
 static void pico_init_pico_state(quicly_cc_t *cc, uint32_t stash)
 {
     cc->state.pico.stash = stash;
-    cc->state.pico.bytes_per_mtu_increase = cc->cwnd * QUICLY_RENO_BETA; /* use Reno, for simplicity */
+    cc->state.pico.bytes_per_mtu_increase = cc->cwnd * QUICLY_BETA_LOSS; /* use Reno, for simplicity */
 }
 
 static void pico_reset(quicly_cc_t *cc, uint32_t initcwnd)

--- a/lib/cc-reno.c
+++ b/lib/cc-reno.c
@@ -80,7 +80,7 @@ void quicly_cc_reno_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t
     }
 
     /* Reduce congestion window. */
-    cc->cwnd *= cc->ssthresh == UINT32_MAX ? 0.5 : QUICLY_RENO_BETA; /* without HyStart++, we overshoot by 2x in slowstart */
+    cc->cwnd *= cc->ssthresh == UINT32_MAX ? 0.5 : QUICLY_BETA_LOSS; /* without HyStart++, we overshoot by 2x in slowstart */
     if (cc->cwnd < QUICLY_MIN_CWND * max_udp_payload_size)
         cc->cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
     cc->ssthresh = cc->cwnd;

--- a/t/cc.c
+++ b/t/cc.c
@@ -137,6 +137,76 @@ static void test_pico_undo_jumpstart_loss(void)
     ok(!quicly_cc_in_jumpstart(&cc));
 }
 
+/**
+ * Compares CWND against a value calculated using floating point arithmetic, tolerating an off-by-one; the compiler is allowed to
+ * evaluate the same expression differently between translation units (e.g., by contracting a multiply-add into an FMA).
+ */
+static int cwnd_is(uint32_t actual, double expected)
+{
+    uint32_t truncated = (uint32_t)expected;
+    return actual == truncated || actual == truncated + 1 || actual + 1 == truncated;
+}
+
+static void test_pico_ecn(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 10 * mtu;
+
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0);
+
+    /* exit slow start by observing a packet loss */
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    ok(cc.cwnd == initcwnd / 2);
+    ok(cc.num_ecn_loss_episodes == 0);
+    uint32_t cwnd_in_ca = cc.cwnd;
+
+    /* a CE mark (i.e., zero-byte congestion report) reduces CWND by QUICLY_BETA_ECN rather than by QUICLY_BETA_LOSS */
+    cc.type->cc_on_lost(&cc, &loss, 0, 20, 30, 1100, mtu);
+    ok(cc.num_loss_episodes == 2);
+    ok(cc.num_ecn_loss_episodes == 1);
+    ok(cwnd_is(cc.cwnd, cwnd_in_ca * QUICLY_BETA_ECN));
+    ok(cc.ssthresh == cc.cwnd);
+    ok(cc.state.pico.undo.num_packets_lost == 0); /* CE marks cannot be undone by late ACKs */
+    /* the increase rate follows the factor being used; here, Reno's 1 MTU per RTT, i.e. per post-reduction CWND bytes acked */
+    ok(cc.state.pico.bytes_per_mtu_increase == cc.cwnd);
+
+    /* a packet loss reduces CWND by QUICLY_BETA_LOSS */
+    uint32_t cwnd_before_loss = cc.cwnd;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 30, 40, 1200, mtu);
+    ok(cc.num_ecn_loss_episodes == 1);
+    ok(cwnd_is(cc.cwnd, cwnd_before_loss * QUICLY_BETA_LOSS));
+}
+
+static void test_pico_ecn_rapid_start(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 10 * mtu;
+
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0);
+    cc.type->enable_rapid_start(&cc, 900);
+
+    /* upon a CE mark, the silence factor derived from QUICLY_BETA_ECN (i.e., 0.95x) is applied */
+    cc.type->cc_on_lost(&cc, &loss, 0, 10, 20, 1000, mtu);
+    ok(cc.rapid_start.newest_rtt_sample_until == -1);
+    ok(cc.rapid_start.recovery.by_ecn);
+    ok(cwnd_is(cc.cwnd, initcwnd * QUICLY_RAPID_START_LOSS_FACTOR(QUICLY_BETA_ECN)));
+    uint32_t cwnd_entering_recovery = cc.cwnd;
+
+    /* during the recovery period, CWND is reduced by ack_factor (0.1x) per byte newly acked */
+    cc.type->cc_on_acked(&cc, &loss, 4 * mtu, 15, 8 * mtu, 1, 20, 1100, mtu);
+    ok(cwnd_is(cc.cwnd, cwnd_entering_recovery - QUICLY_RAPID_START_ACK_FACTOR(QUICLY_BETA_ECN) * (4 * mtu)));
+    uint32_t cwnd_after_ack = cc.cwnd;
+
+    /* a packet loss detected within the same recovery period is accounted using loss_factor (0.95x), the factor being retained
+     * from when the recovery period was entered, even though the episode is no longer counted as an ECN-only one */
+    cc.type->cc_on_lost(&cc, &loss, mtu, 16, 20, 1100, mtu);
+    ok(cc.num_loss_episodes == 1);
+    ok(cc.num_ecn_loss_episodes == 0);
+    ok(cwnd_is(cc.cwnd, cwnd_after_ack - QUICLY_RAPID_START_LOSS_FACTOR(QUICLY_BETA_ECN) * mtu));
+}
+
 static void test_rapid_start(void)
 {
     struct st_quicly_cc_rapid_start_t rs;
@@ -177,4 +247,6 @@ void test_cc(void)
     subtest("pico-undo-multiple-losses", test_pico_undo_multiple_losses);
     subtest("pico-undo-rapid-start-loss", test_pico_undo_rapid_start_loss);
     subtest("pico-undo-jumpstart-loss", test_pico_undo_jumpstart_loss);
+    subtest("pico-ecn", test_pico_ecn);
+    subtest("pico-ecn-rapid-start", test_pico_ecn_rapid_start);
 }

--- a/t/jumpstart.c
+++ b/t/jumpstart.c
@@ -111,7 +111,7 @@ static void do_test_jumpstart(quicly_init_cc_t *init)
                 {TEST_JUMPSTART_ACTION_LOST, 1200, 3},
                 {TEST_JUMPSTART_ACTION_END},
             },
-            15 * 1200 * QUICLY_RENO_BETA);
+            15 * 1200 * QUICLY_BETA_LOSS);
 
     /* regardless of how much we lose, we never go down below 1/2 IW */
     subtest("lower bound", test_jumpstart_pattern, init,

--- a/t/simulator-plot.rb
+++ b/t/simulator-plot.rb
@@ -228,6 +228,8 @@ cc = "pico"
 length = 1.0
 network_name = "DSL"
 show_queue = false
+aqm = nil
+isolate = false
 throughput = false
 bucket = nil
 output_prefix = "simulator"
@@ -250,6 +252,8 @@ OptionParser.new do |opt|
     network_name = v
   end
   opt.on("--queue") { show_queue = true }
+  opt.on("-A SPEC") { |v| aqm = v }
+  opt.on("-F") { isolate = true }
   opt.on("--throughput") { throughput = true }
   opt.on("--bucket=SECONDS", Float) { |v| bucket = v }
   opt.on("--output=PREFIX") { |v| output_prefix = v }
@@ -281,6 +285,9 @@ cmd = [
   "-l", length.to_s,
   "-c", cc
 ]
+# `-A` and `-F` are global options of the simulator, and the global part of the command line is the part this script builds
+cmd.push("-A", aqm) if aqm
+cmd.push("-F") if isolate
 flows.each do |_label, flow_opts|
   cmd << "--"
   cmd.concat(flow_opts)

--- a/t/simulator.c
+++ b/t/simulator.c
@@ -157,7 +157,8 @@ struct net_random_loss {
  * `NET_AQM_CODEL` combined with isolation.
  * `NET_AQM_STEP` marks every ECT packet whose sojourn time exceeds `target`. It is not a discipline that anybody deploys; being
  * deterministic, it tells exactly when a CE mark is supposed to be emitted.
- * `NET_AQM_CODEL` is CoDel (RFC 8289).
+ * `NET_AQM_CODEL` is CoDel (RFC 8289), following the ECN handling of the Linux implementation; the pseudocode of the RFC only
+ * drops, whereas the packet that is marked is delivered.
  */
 struct net_aqm {
     enum { NET_AQM_NONE, NET_AQM_STEP, NET_AQM_CODEL } type;
@@ -412,7 +413,7 @@ static struct net_packet *net_codel_take(struct net_bottleneck *self, struct net
     packet = net_queue_dequeue(queue);
     self->size -= packet->size;
 
-    /* the queue is not considered standing while it holds less than one packet worth of bytes */
+    /* the queue is not considered standing while it holds less than one packet worth of bytes; the quantum stands in for the MTU */
     if (now - packet->enter_at < self->target || queue->size <= NET_BOTTLENECK_QUANTUM) {
         queue->codel.above_target_since = 0;
     } else if (queue->codel.above_target_since == 0) {
@@ -442,19 +443,23 @@ static struct net_packet *net_codel_dequeue(struct net_bottleneck *self, struct 
         if (!ok_to_mark) {
             queue->codel.marking = 0;
         } else {
-            while (now >= queue->codel.mark_next) {
+            while (queue->codel.marking && now >= queue->codel.mark_next) {
                 ++queue->codel.count;
-                queue->codel.mark_next = net_codel_mark_next(self, queue->codel.mark_next, queue->codel.count);
-                if (net_bottleneck_mark(self, packet))
+                /* a packet that can be marked is delivered, the schedule being advanced all the same */
+                if (net_bottleneck_mark(self, packet)) {
+                    queue->codel.mark_next = net_codel_mark_next(self, queue->codel.mark_next, queue->codel.count);
                     break;
+                }
                 net_bottleneck_drop(self, packet);
                 if ((packet = net_codel_take(self, queue, &ok_to_mark)) == NULL) {
                     queue->codel.marking = 0;
                     return NULL;
                 }
+                /* the schedule is advanced only while the queue is still standing; leaving the state must not push it back */
                 if (!ok_to_mark) {
                     queue->codel.marking = 0;
-                    break;
+                } else {
+                    queue->codel.mark_next = net_codel_mark_next(self, queue->codel.mark_next, queue->codel.count);
                 }
             }
         }

--- a/t/simulator.c
+++ b/t/simulator.c
@@ -86,9 +86,52 @@ struct net_packet {
     uint8_t bytes[1];
 };
 
+/**
+ * A lossy FIFO of packets. Every queue of the simulator is one of these; the discipline that determines when (and if) a packet
+ * leaves is carried as part of it, rather than being a type of its own.
+ */
 struct net_queue {
     struct net_packet *first, **append_at;
     size_t size;
+    /**
+     * Number of bytes the queue is still allowed to send in the current round, and which of the two rounds it belongs to. Used
+     * when the queue is one of several being served by deficit round robin; queues that have just become active are served
+     * before the ones that have been, as fq_codel does.
+     */
+    int32_t deficit;
+    enum { NET_QUEUE_INACTIVE, NET_QUEUE_NEW, NET_QUEUE_OLD } sched;
+    /**
+     * The discipline; the union carries whatever that discipline needs.
+     */
+    enum { NET_QUEUE_PLAIN, NET_QUEUE_DELAY, NET_QUEUE_STEP, NET_QUEUE_CODEL } type;
+    union {
+        /**
+         * NET_QUEUE_DELAY: the duration for which each packet is withheld.
+         */
+        double delay;
+        /**
+         * NET_QUEUE_CODEL: the state of CoDel.
+         */
+        struct {
+            /**
+             * Time at which the sojourn time is going to have been above target for `interval`; zero if it is below target.
+             */
+            double above_target_since;
+            /**
+             * Time at which the next packet is to be marked (or dropped), while in the marking state.
+             */
+            double mark_next;
+            /**
+             * Number of packets marked since entering the marking state, and the value it had when the state was left the
+             * previous time.
+             */
+            uint32_t count, last_count;
+            /**
+             * If being in the marking state.
+             */
+            int marking;
+        } codel;
+    };
 };
 
 struct net_node {
@@ -101,7 +144,6 @@ struct net_delay {
     struct net_node super;
     struct net_node *next_node;
     struct net_queue queue;
-    double delay;
 };
 
 struct net_random_loss {
@@ -111,22 +153,47 @@ struct net_random_loss {
 };
 
 /**
- * The AQM being run by the bottleneck. `NET_AQM_STEP` marks every ECT packet whose sojourn time exceeds `target`; it is not a
- * realistic discipline, but being deterministic it tells exactly when a CE mark is supposed to be emitted.
+ * The discipline the queues of the bottleneck run. It is orthogonal to whether the flows are isolated; fq_codel (RFC 8290) is
+ * `NET_AQM_CODEL` combined with isolation.
+ * `NET_AQM_STEP` marks every ECT packet whose sojourn time exceeds `target`. It is not a discipline that anybody deploys; being
+ * deterministic, it tells exactly when a CE mark is supposed to be emitted.
+ * `NET_AQM_CODEL` is CoDel (RFC 8289).
  */
 struct net_aqm {
-    enum { NET_AQM_NONE, NET_AQM_STEP } type;
+    enum { NET_AQM_NONE, NET_AQM_STEP, NET_AQM_CODEL } type;
     double target;
+    double interval;
 };
+
+/**
+ * Maximum number of queues of the bottleneck. When the flows are isolated there is one for each of them, and as the endpoints are
+ * given addresses sequentially, the address is used as the index.
+ */
+#define NET_BOTTLENECK_MAX_QUEUES 20
+/**
+ * Number of bytes a queue is allowed to send in one round of deficit round robin.
+ */
+#define NET_BOTTLENECK_QUANTUM 1514
 
 struct net_bottleneck {
     struct net_node super;
     struct net_node *next_node;
-    struct net_queue queue;
+    /**
+     * The queues. `num_queues` is one unless the flows are isolated, in which case the packets are placed into the queue that
+     * corresponds to their sender.
+     */
+    struct net_queue queues[NET_BOTTLENECK_MAX_QUEUES];
+    size_t num_queues;
+    /**
+     * Total number of bytes being held, and the size of the buffer that holds them.
+     */
+    size_t size, capacity;
     double next_emit_at;
     double bytes_per_sec;
-    size_t capacity;
-    struct net_aqm aqm;
+    /**
+     * Parameters of the discipline the queues run; shared by all of them, unlike the state each queue keeps.
+     */
+    double target, interval;
 };
 
 struct net_endpoint {
@@ -188,14 +255,14 @@ static void net_delay_forward(struct net_node *_self, struct net_packet *packet)
 static double net_delay_next_run_at(struct net_node *_self)
 {
     struct net_delay *self = (struct net_delay *)_self;
-    return self->queue.first != NULL ? self->queue.first->enter_at + self->delay : INFINITY;
+    return self->queue.first != NULL ? self->queue.first->enter_at + self->queue.delay : INFINITY;
 }
 
 static void net_delay_run(struct net_node *_self)
 {
     struct net_delay *self = (struct net_delay *)_self;
 
-    while (self->queue.first != NULL && self->queue.first->enter_at + self->delay <= now) {
+    while (self->queue.first != NULL && self->queue.first->enter_at + self->queue.delay <= now) {
         struct net_packet *packet = net_queue_dequeue(&self->queue);
         self->next_node->forward_(self->next_node, packet);
     }
@@ -205,8 +272,7 @@ static void net_delay_init(struct net_delay *self, double delay)
 {
     *self = (struct net_delay){
         .super = {net_delay_forward, net_delay_next_run_at, net_delay_run},
-        .queue = {.append_at = &self->queue.first},
-        .delay = delay,
+        .queue = {.append_at = &self->queue.first, .type = NET_QUEUE_DELAY, .delay = delay},
     };
 }
 
@@ -240,22 +306,7 @@ static void net_random_loss_init(struct net_random_loss *self, double loss_ratio
 static void net_bottleneck_print_stats(struct net_bottleneck *self, const char *event, struct net_packet *packet)
 {
     printf("{\"bottleneck\": \"%s\", \"at\": %f, \"queue-size\": %zu, \"packet-src\": %" PRIu32 ", \"packet-size\": %zu}\n", event,
-           now, self->queue.size, ntohl(packet->src->addr.sin.sin_addr.s_addr), packet->size);
-}
-
-static void net_bottleneck_forward(struct net_node *_self, struct net_packet *packet)
-{
-    struct net_bottleneck *self = (struct net_bottleneck *)_self;
-
-    /* drop the packet if the queue is full */
-    if (self->queue.size + packet->size > self->capacity) {
-        net_bottleneck_print_stats(self, "drop", packet);
-        net_packet_destroy(packet);
-        return;
-    }
-
-    net_bottleneck_print_stats(self, "enqueue", packet);
-    net_queue_enqueue(&self->queue, packet);
+           now, self->size, ntohl(packet->src->addr.sin.sin_addr.s_addr), packet->size);
 }
 
 #define NET_ECN_NOT_ECT 0
@@ -279,28 +330,228 @@ static int net_bottleneck_mark(struct net_bottleneck *self, struct net_packet *p
     return 1;
 }
 
-static void net_bottleneck_run_aqm(struct net_bottleneck *self, struct net_packet *packet)
+static void net_bottleneck_drop(struct net_bottleneck *self, struct net_packet *packet)
 {
-    switch (self->aqm.type) {
-    case NET_AQM_STEP:
-        /* Mark-only; packets that are not ECN-capable are left to the tail drop that happens when the queue becomes full. This
-         * discipline exists for observing the ECN signalling path, not for being a faithful AQM. */
-        if (now - packet->enter_at > self->aqm.target)
-            net_bottleneck_mark(self, packet);
-        break;
-    default:
-        break;
+    net_bottleneck_print_stats(self, "drop", packet);
+    net_packet_destroy(packet);
+}
+
+/**
+ * Returns the queue the packet belongs to; all of them share one when the flows are not isolated.
+ */
+static struct net_queue *net_bottleneck_classify(struct net_bottleneck *self, struct net_packet *packet)
+{
+    if (self->num_queues == 1)
+        return &self->queues[0];
+
+    uint32_t index = ntohl(packet->src->addr.sin.sin_addr.s_addr);
+    assert(index < self->num_queues && "the endpoints are given addresses sequentially, starting from one");
+    return &self->queues[index];
+}
+
+static struct net_queue *net_bottleneck_longest(struct net_bottleneck *self)
+{
+    struct net_queue *longest = &self->queues[0];
+
+    for (size_t i = 1; i < self->num_queues; ++i)
+        if (self->queues[i].size > longest->size)
+            longest = &self->queues[i];
+
+    return longest;
+}
+
+static void net_bottleneck_forward(struct net_node *_self, struct net_packet *packet)
+{
+    struct net_bottleneck *self = (struct net_bottleneck *)_self;
+    struct net_queue *queue = net_bottleneck_classify(self, packet);
+
+    /* a queue that has been idle becomes a new one, obtaining the right to send one quantum before the old ones do */
+    if (queue->sched == NET_QUEUE_INACTIVE) {
+        queue->deficit = NET_BOTTLENECK_QUANTUM;
+        queue->sched = NET_QUEUE_NEW;
+    }
+
+    /* When the buffer is full, room is made by dropping from the head of the longest queue, so that a flow that does not slow
+     * down cannot push the others out. Should the arrival belong to that queue itself there is nothing to be protected, hence it
+     * is refused; that is what always happens when the flows are not isolated. */
+    while (self->size + packet->size > self->capacity) {
+        struct net_queue *longest = net_bottleneck_longest(self);
+        if (longest == queue || longest->first == NULL) {
+            net_bottleneck_drop(self, packet);
+            return;
+        }
+        struct net_packet *victim = net_queue_dequeue(longest);
+        self->size -= victim->size;
+        net_bottleneck_drop(self, victim);
+    }
+
+    net_bottleneck_print_stats(self, "enqueue", packet);
+    net_queue_enqueue(queue, packet);
+    self->size += packet->size;
+}
+
+static double net_codel_mark_next(struct net_bottleneck *self, double from, uint32_t count)
+{
+    return from + self->interval / sqrt((double)count);
+}
+
+/**
+ * Takes the packet at the head of the queue, telling if CoDel considers the queue to have been standing for long enough that the
+ * sender has to be told to slow down.
+ */
+static struct net_packet *net_codel_take(struct net_bottleneck *self, struct net_queue *queue, int *ok_to_mark)
+{
+    struct net_packet *packet;
+
+    *ok_to_mark = 0;
+
+    if (queue->first == NULL) {
+        queue->codel.above_target_since = 0;
+        return NULL;
+    }
+    packet = net_queue_dequeue(queue);
+    self->size -= packet->size;
+
+    /* the queue is not considered standing while it holds less than one packet worth of bytes */
+    if (now - packet->enter_at < self->target || queue->size <= NET_BOTTLENECK_QUANTUM) {
+        queue->codel.above_target_since = 0;
+    } else if (queue->codel.above_target_since == 0) {
+        queue->codel.above_target_since = now + self->interval;
+    } else if (now >= queue->codel.above_target_since) {
+        *ok_to_mark = 1;
+    }
+
+    return packet;
+}
+
+/**
+ * Dequeues one packet from the queue being given, running CoDel. Packets that are ECN-capable are marked and delivered; the ones
+ * that are not are dropped, there being no other way of telling their sender to slow down.
+ */
+static struct net_packet *net_codel_dequeue(struct net_bottleneck *self, struct net_queue *queue)
+{
+    struct net_packet *packet;
+    int ok_to_mark;
+
+    if ((packet = net_codel_take(self, queue, &ok_to_mark)) == NULL) {
+        queue->codel.marking = 0;
+        return NULL;
+    }
+
+    if (queue->codel.marking) {
+        if (!ok_to_mark) {
+            queue->codel.marking = 0;
+        } else {
+            while (now >= queue->codel.mark_next) {
+                ++queue->codel.count;
+                queue->codel.mark_next = net_codel_mark_next(self, queue->codel.mark_next, queue->codel.count);
+                if (net_bottleneck_mark(self, packet))
+                    break;
+                net_bottleneck_drop(self, packet);
+                if ((packet = net_codel_take(self, queue, &ok_to_mark)) == NULL) {
+                    queue->codel.marking = 0;
+                    return NULL;
+                }
+                if (!ok_to_mark) {
+                    queue->codel.marking = 0;
+                    break;
+                }
+            }
+        }
+    } else if (ok_to_mark) {
+        if (!net_bottleneck_mark(self, packet)) {
+            net_bottleneck_drop(self, packet);
+            if ((packet = net_codel_take(self, queue, &ok_to_mark)) == NULL)
+                return NULL;
+        }
+        queue->codel.marking = 1;
+        /* if the queue was left recently, resume from the rate that was being used back then */
+        uint32_t delta = queue->codel.count - queue->codel.last_count;
+        queue->codel.count = delta > 1 && now - queue->codel.mark_next < 16 * self->interval ? delta : 1;
+        queue->codel.mark_next = net_codel_mark_next(self, now, queue->codel.count);
+        queue->codel.last_count = queue->codel.count;
+    }
+
+    return packet;
+}
+
+/**
+ * Dequeues one packet from the queue being given, applying whichever discipline it runs.
+ */
+static struct net_packet *net_bottleneck_dequeue_one(struct net_bottleneck *self, struct net_queue *queue)
+{
+    struct net_packet *packet;
+
+    if (queue->type == NET_QUEUE_CODEL)
+        return net_codel_dequeue(self, queue);
+
+    if (queue->first == NULL)
+        return NULL;
+    packet = net_queue_dequeue(queue);
+    self->size -= packet->size;
+
+    /* mark-only; the packets that are not ECN-capable are left to the drop that happens when the buffer becomes full */
+    if (queue->type == NET_QUEUE_STEP && now - packet->enter_at > self->target)
+        net_bottleneck_mark(self, packet);
+
+    return packet;
+}
+
+/**
+ * Picks the queue to be served by deficit round robin, then dequeues one packet from it. The queues being few, they are scanned
+ * rather than being kept in the lists that the real implementations of fq_codel maintain.
+ */
+static struct net_packet *net_bottleneck_dequeue(struct net_bottleneck *self)
+{
+    while (1) {
+        struct net_queue *found = NULL;
+
+        /* serve the queues that have just become active before the ones that have been */
+        for (int sched = NET_QUEUE_NEW; sched <= NET_QUEUE_OLD && found == NULL; ++sched)
+            for (size_t i = 0; i < self->num_queues; ++i)
+                if (self->queues[i].sched == sched && self->queues[i].deficit > 0) {
+                    found = &self->queues[i];
+                    break;
+                }
+
+        if (found == NULL) {
+            /* none of the active queues is allowed to send; start the next round, unless there is nothing to send at all */
+            int any = 0;
+            for (size_t i = 0; i < self->num_queues; ++i) {
+                if (self->queues[i].sched != NET_QUEUE_INACTIVE) {
+                    self->queues[i].deficit += NET_BOTTLENECK_QUANTUM;
+                    any = 1;
+                }
+            }
+            if (!any)
+                return NULL;
+            continue;
+        }
+
+        struct net_packet *packet;
+        if ((packet = net_bottleneck_dequeue_one(self, found)) == NULL) {
+            /* a new queue that has become empty becomes an old one rather than going idle, so that it does not obtain the
+             * priority given to the new ones again as soon as it receives the next packet */
+            found->sched = found->sched == NET_QUEUE_NEW ? NET_QUEUE_OLD : NET_QUEUE_INACTIVE;
+            continue;
+        }
+
+        found->deficit -= (int32_t)packet->size;
+        return packet;
     }
 }
 
 static double net_bottleneck_next_run_at(struct net_node *_self)
 {
     struct net_bottleneck *self = (struct net_bottleneck *)_self;
+    double emit_at = INFINITY;
 
-    if (self->queue.first == NULL)
+    for (size_t i = 0; i < self->num_queues; ++i)
+        if (self->queues[i].first != NULL && self->queues[i].first->enter_at < emit_at)
+            emit_at = self->queues[i].first->enter_at;
+
+    if (emit_at == INFINITY)
         return INFINITY;
-
-    double emit_at = self->queue.first->enter_at;
     if (emit_at < self->next_emit_at)
         emit_at = self->next_emit_at;
 
@@ -315,8 +566,9 @@ static void net_bottleneck_run(struct net_node *_self)
         return;
 
     /* detach packet */
-    struct net_packet *packet = net_queue_dequeue(&self->queue);
-    net_bottleneck_run_aqm(self, packet);
+    struct net_packet *packet;
+    if ((packet = net_bottleneck_dequeue(self)) == NULL)
+        return;
     net_bottleneck_print_stats(self, "dequeue", packet);
 
     /* update next emission timer */
@@ -326,15 +578,35 @@ static void net_bottleneck_run(struct net_node *_self)
     self->next_node->forward_(self->next_node, packet);
 }
 
-static void net_bottleneck_init(struct net_bottleneck *self, double bytes_per_sec, double capacity_in_sec, struct net_aqm aqm)
+static void net_bottleneck_init(struct net_bottleneck *self, double bytes_per_sec, double capacity_in_sec, struct net_aqm aqm,
+                                int isolate_flows)
 {
     *self = (struct net_bottleneck){
-        .super = {net_bottleneck_forward, net_bottleneck_next_run_at, net_bottleneck_run},
-        .queue = {.append_at = &self->queue.first},
-        .bytes_per_sec = bytes_per_sec,
+        .num_queues = isolate_flows ? NET_BOTTLENECK_MAX_QUEUES : 1,
         .capacity = (size_t)(bytes_per_sec * capacity_in_sec),
-        .aqm = aqm,
+        .bytes_per_sec = bytes_per_sec,
+        .target = aqm.target,
+        .interval = aqm.interval,
+        .super = {net_bottleneck_forward, net_bottleneck_next_run_at, net_bottleneck_run},
     };
+
+    int queue_type;
+    switch (aqm.type) {
+    case NET_AQM_STEP:
+        queue_type = NET_QUEUE_STEP;
+        break;
+    case NET_AQM_CODEL:
+        queue_type = NET_QUEUE_CODEL;
+        break;
+    default:
+        queue_type = NET_QUEUE_PLAIN;
+        break;
+    }
+
+    for (size_t i = 0; i < self->num_queues; ++i) {
+        self->queues[i].append_at = &self->queues[i].first;
+        self->queues[i].type = queue_type;
+    }
 }
 
 static quicly_cid_plaintext_t next_quic_cid;
@@ -523,9 +795,12 @@ static void usage(const char *cmd)
            "  -l <seconds>        number of seconds to simulate (default: 100)\n"
            "  -p                  turns on pacing\n"
            "  -q <seconds>        max depth of the bottleneck queue (default: 0.1)\n"
-           "  -A <aqm>            AQM of the bottleneck: `none` (default) or `step[:target]`,\n"
-           "                      the latter marking CE on the packets whose sojourn time\n"
-           "                      exceeds target seconds (default: 0.005)\n"
+           "  -A <aqm>            queue discipline of the bottleneck: `none` (default),\n"
+           "                      `step[:target]` marking CE on the packets whose sojourn\n"
+           "                      time exceeds target seconds (default: 0.005), or\n"
+           "                      `codel[:target[:interval]]` (defaults: 0.005, 0.1)\n"
+           "  -F                  gives each flow a queue of its own; `-A codel -F` is\n"
+           "                      fq_codel\n"
            "  -r <probability>    adds random loss at given probability (default: 0)\n"
            "  -R                  turns on rapid start\n"
            "  -s <seconds>        delay until the sender is added to the simulation\n"
@@ -568,15 +843,25 @@ static int parse_aqm(const char *spec, struct net_aqm *aqm)
             return 0;
         return 1;
     }
+    if (strncmp(spec, "codel", 5) == 0 && (spec[5] == '\0' || spec[5] == ':')) {
+        *aqm = (struct net_aqm){.type = NET_AQM_CODEL, .target = 0.005, .interval = 0.1};
+        if (spec[5] == ':') {
+            if (sscanf(spec + 6, "%lf:%lf", &aqm->target, &aqm->interval) < 1)
+                return 0;
+            if (aqm->target <= 0 || aqm->interval <= 0)
+                return 0;
+        }
+        return 1;
+    }
     return 0;
 }
 
 static int parse_options(int argc, char **argv, quicly_context_t *quicctx, double *delay, double *start, double *bw, double *depth,
-                         double *length, double *random_loss, struct net_aqm *aqm, FILE **trace_fp)
+                         double *length, double *random_loss, struct net_aqm *aqm, int *isolate_flows, FILE **trace_fp)
 {
     reset_getopt_state();
     int ch;
-    while ((ch = getopt(argc, argv, "A:c:b:d:Ei:j:l:pq:r:Rs:th")) != -1) {
+    while ((ch = getopt(argc, argv, "A:c:b:d:EFi:j:l:pq:r:Rs:th")) != -1) {
 
         switch (ch) {
         case 'c': {
@@ -660,6 +945,13 @@ static int parse_options(int argc, char **argv, quicly_context_t *quicctx, doubl
                 fprintf(stderr, "invalid random loss rate: %s\n", optarg);
                 return 0;
             }
+            break;
+        case 'F':
+            if (isolate_flows == NULL) {
+                fprintf(stderr, "-%c is a global option and cannot be used inside a flow block\n", ch);
+                return 0;
+            }
+            *isolate_flows = 1;
             break;
         case 'E':
             quicctx->enable_ratio.ecn = 0;
@@ -805,6 +1097,7 @@ int main(int argc, char **argv)
 
     /* parse args */
     struct net_aqm aqm = {.type = NET_AQM_NONE};
+    int isolate_flows = 0;
     double delay = 0.1, bw = 1e6, depth = 0.1, start = 0, random_loss = 0;
     double length = 100;
     int first_sep = find_next_separator(argc, argv, 1);
@@ -816,7 +1109,8 @@ int main(int argc, char **argv)
     }
 
     argv[first_sep] = NULL;
-    if (!parse_options(first_sep, argv, &quicctx, &delay, &start, &bw, &depth, &length, &random_loss, &aqm, &quicly_trace_fp))
+    if (!parse_options(first_sep, argv, &quicctx, &delay, &start, &bw, &depth, &length, &random_loss, &aqm, &isolate_flows,
+                       &quicly_trace_fp))
         exit(1);
     argv[first_sep] = "--";
 
@@ -837,7 +1131,7 @@ int main(int argc, char **argv)
             if (seg_end < argc)
                 argv[seg_end] = NULL;
 
-            if (!parse_options(flow_argc, flow_argv, flow_ctx, &flow_delay, &flow_start, NULL, NULL, NULL, NULL, NULL, NULL))
+            if (!parse_options(flow_argc, flow_argv, flow_ctx, &flow_delay, &flow_start, NULL, NULL, NULL, NULL, NULL, NULL, NULL))
                 exit(1);
             flow_argv[0] = saved_argv0;
             if (seg_end < argc)
@@ -872,7 +1166,7 @@ int main(int argc, char **argv)
     }
 
     /* setup bottleneck */
-    net_bottleneck_init(&bottleneck_node, bw, depth, aqm);
+    net_bottleneck_init(&bottleneck_node, bw, depth, aqm, isolate_flows);
     bottleneck_node.next_node = &server_node.node.super;
     *node_insert_at++ = &bottleneck_node.super;
 

--- a/t/simulator.c
+++ b/t/simulator.c
@@ -73,6 +73,10 @@ struct net_packet {
      */
     double enter_at;
     /**
+     * ECN codepoint being carried by the IP header; the AQM of the bottleneck turns ECT(0) into CE when congestion is observed
+     */
+    uint8_t ecn;
+    /**
      * size of the packet
      */
     size_t size;
@@ -106,6 +110,15 @@ struct net_random_loss {
     double loss_ratio;
 };
 
+/**
+ * The AQM being run by the bottleneck. `NET_AQM_STEP` marks every ECT packet whose sojourn time exceeds `target`; it is not a
+ * realistic discipline, but being deterministic it tells exactly when a CE mark is supposed to be emitted.
+ */
+struct net_aqm {
+    enum { NET_AQM_NONE, NET_AQM_STEP } type;
+    double target;
+};
+
 struct net_bottleneck {
     struct net_node super;
     struct net_node *next_node;
@@ -113,6 +126,7 @@ struct net_bottleneck {
     double next_emit_at;
     double bytes_per_sec;
     size_t capacity;
+    struct net_aqm aqm;
 };
 
 struct net_endpoint {
@@ -126,7 +140,7 @@ struct net_endpoint {
     quicly_context_t *accept_ctx;
 };
 
-static struct net_packet *net_packet_create(struct net_endpoint *src, quicly_address_t *dest, ptls_iovec_t vec)
+static struct net_packet *net_packet_create(struct net_endpoint *src, quicly_address_t *dest, ptls_iovec_t vec, uint8_t ecn)
 {
     struct net_packet *p = malloc(offsetof(struct net_packet, bytes) + vec.len);
 
@@ -134,6 +148,7 @@ static struct net_packet *net_packet_create(struct net_endpoint *src, quicly_add
     p->src = src;
     p->dest = *dest;
     p->enter_at = now;
+    p->ecn = ecn;
     p->size = vec.len;
     memcpy(p->bytes, vec.base, vec.len);
 
@@ -243,6 +258,41 @@ static void net_bottleneck_forward(struct net_node *_self, struct net_packet *pa
     net_queue_enqueue(&self->queue, packet);
 }
 
+#define NET_ECN_NOT_ECT 0
+#define NET_ECN_ECT1 1
+#define NET_ECN_ECT0 2
+#define NET_ECN_CE 3
+
+/**
+ * Turns ECT into CE, returning if the packet is ECN-capable. Packets that are not ECN-capable have to be dropped instead, as there
+ * is no way of signalling congestion to their sender.
+ */
+static int net_bottleneck_mark(struct net_bottleneck *self, struct net_packet *packet)
+{
+    if (packet->ecn == NET_ECN_NOT_ECT)
+        return 0;
+
+    if (packet->ecn != NET_ECN_CE) {
+        packet->ecn = NET_ECN_CE;
+        net_bottleneck_print_stats(self, "mark", packet);
+    }
+    return 1;
+}
+
+static void net_bottleneck_run_aqm(struct net_bottleneck *self, struct net_packet *packet)
+{
+    switch (self->aqm.type) {
+    case NET_AQM_STEP:
+        /* Mark-only; packets that are not ECN-capable are left to the tail drop that happens when the queue becomes full. This
+         * discipline exists for observing the ECN signalling path, not for being a faithful AQM. */
+        if (now - packet->enter_at > self->aqm.target)
+            net_bottleneck_mark(self, packet);
+        break;
+    default:
+        break;
+    }
+}
+
 static double net_bottleneck_next_run_at(struct net_node *_self)
 {
     struct net_bottleneck *self = (struct net_bottleneck *)_self;
@@ -266,6 +316,7 @@ static void net_bottleneck_run(struct net_node *_self)
 
     /* detach packet */
     struct net_packet *packet = net_queue_dequeue(&self->queue);
+    net_bottleneck_run_aqm(self, packet);
     net_bottleneck_print_stats(self, "dequeue", packet);
 
     /* update next emission timer */
@@ -275,13 +326,14 @@ static void net_bottleneck_run(struct net_node *_self)
     self->next_node->forward_(self->next_node, packet);
 }
 
-static void net_bottleneck_init(struct net_bottleneck *self, double bytes_per_sec, double capacity_in_sec)
+static void net_bottleneck_init(struct net_bottleneck *self, double bytes_per_sec, double capacity_in_sec, struct net_aqm aqm)
 {
     *self = (struct net_bottleneck){
         .super = {net_bottleneck_forward, net_bottleneck_next_run_at, net_bottleneck_run},
         .queue = {.append_at = &self->queue.first},
         .bytes_per_sec = bytes_per_sec,
         .capacity = (size_t)(bytes_per_sec * capacity_in_sec),
+        .aqm = aqm,
     };
 }
 
@@ -298,6 +350,7 @@ static void net_endpoint_forward(struct net_node *_self, struct net_packet *pack
         if (quicly_decode_packet(self->conns[0].quic != NULL ? quicly_get_context(self->conns[0].quic) : self->accept_ctx, &qp,
                                  packet->bytes, packet->size, &off) == SIZE_MAX)
             break;
+        qp.ecn = packet->ecn; /* the value is reset by `quicly_decode_packet`, as it is provided by the IP stack */
         /* find the matching connection, or where new state should be created */
         struct net_endpoint_conn *conn;
         for (conn = self->conns; conn->quic != NULL; ++conn)
@@ -355,9 +408,10 @@ static void net_endpoint_run(struct net_node *_self)
         uint8_t buf[PTLS_ELEMENTSOF(datagrams) * 1500];
         int ret;
         if ((ret = quicly_send(conn->quic, &dest, &src, datagrams, &num_datagrams, buf, sizeof(buf))) == 0) {
+            uint8_t ecn = quicly_send_get_ecn_bits(conn->quic);
             for (size_t i = 0; i < num_datagrams; ++i) {
                 struct net_packet *packet =
-                    net_packet_create(self, &dest, ptls_iovec_init(datagrams[i].iov_base, datagrams[i].iov_len));
+                    net_packet_create(self, &dest, ptls_iovec_init(datagrams[i].iov_base, datagrams[i].iov_len), ecn);
                 conn->egress->forward_(conn->egress, packet);
             }
         } else {
@@ -464,10 +518,14 @@ static void usage(const char *cmd)
            "  -d <delay_secs>     delay added between the sender and the botteneck\n"
            "                      (default: 0.1)\n"
            "  -i <packets>        sets initial CWND (default: %" PRIu32 ")\n"
+           "  -E                  turns off ECN, which is otherwise used by every flow\n"
            "  -j <packets>        enables use of jumpstart using given window size\n"
            "  -l <seconds>        number of seconds to simulate (default: 100)\n"
            "  -p                  turns on pacing\n"
            "  -q <seconds>        max depth of the bottleneck queue (default: 0.1)\n"
+           "  -A <aqm>            AQM of the bottleneck: `none` (default) or `step[:target]`,\n"
+           "                      the latter marking CE on the packets whose sojourn time\n"
+           "                      exceeds target seconds (default: 0.005)\n"
            "  -r <probability>    adds random loss at given probability (default: 0)\n"
            "  -R                  turns on rapid start\n"
            "  -s <seconds>        delay until the sender is added to the simulation\n"
@@ -495,24 +553,51 @@ static int find_next_separator(int argc, char **argv, int start)
     return argc;
 }
 
+/**
+ * Parses the AQM spec, which is `none` or `step[:target_in_seconds]`.
+ */
+static int parse_aqm(const char *spec, struct net_aqm *aqm)
+{
+    if (strcmp(spec, "none") == 0) {
+        *aqm = (struct net_aqm){.type = NET_AQM_NONE};
+        return 1;
+    }
+    if (strncmp(spec, "step", 4) == 0 && (spec[4] == '\0' || spec[4] == ':')) {
+        *aqm = (struct net_aqm){.type = NET_AQM_STEP, .target = 0.005};
+        if (spec[4] == ':' && (sscanf(spec + 5, "%lf", &aqm->target) != 1 || aqm->target <= 0))
+            return 0;
+        return 1;
+    }
+    return 0;
+}
+
 static int parse_options(int argc, char **argv, quicly_context_t *quicctx, double *delay, double *start, double *bw, double *depth,
-                         double *length, double *random_loss, FILE **trace_fp)
+                         double *length, double *random_loss, struct net_aqm *aqm, FILE **trace_fp)
 {
     reset_getopt_state();
     int ch;
-    while ((ch = getopt(argc, argv, "c:b:d:i:j:l:pq:r:Rs:th")) != -1) {
+    while ((ch = getopt(argc, argv, "A:c:b:d:Ei:j:l:pq:r:Rs:th")) != -1) {
+
         switch (ch) {
-        case 'c':
-            {
-                quicly_cc_type_t **cc;
-                for (cc = quicly_cc_all_types; *cc != NULL; ++cc)
-                    if (strcmp((*cc)->name, optarg) == 0)
-                        break;
-                if (*cc == NULL) {
-                    fprintf(stderr, "unknown congestion controller: %s\n", optarg);
-                    return 0;
-                }
-                quicctx->init_cc = (*cc)->cc_init;
+        case 'c': {
+            quicly_cc_type_t **cc;
+            for (cc = quicly_cc_all_types; *cc != NULL; ++cc)
+                if (strcmp((*cc)->name, optarg) == 0)
+                    break;
+            if (*cc == NULL) {
+                fprintf(stderr, "unknown congestion controller: %s\n", optarg);
+                return 0;
+            }
+            quicctx->init_cc = (*cc)->cc_init;
+        } break;
+        case 'A':
+            if (aqm == NULL) {
+                fprintf(stderr, "-%c is a global option and cannot be used inside a flow block\n", ch);
+                return 0;
+            }
+            if (!parse_aqm(optarg, aqm)) {
+                fprintf(stderr, "invalid AQM: %s\n", optarg);
+                return 0;
             }
             break;
         case 'b':
@@ -575,6 +660,9 @@ static int parse_options(int argc, char **argv, quicly_context_t *quicctx, doubl
                 fprintf(stderr, "invalid random loss rate: %s\n", optarg);
                 return 0;
             }
+            break;
+        case 'E':
+            quicctx->enable_ratio.ecn = 0;
             break;
         case 'R':
             quicctx->enable_ratio.rapid_start = 255;
@@ -716,6 +804,7 @@ int main(int argc, char **argv)
     *node_insert_at++ = &server_node.node.super;
 
     /* parse args */
+    struct net_aqm aqm = {.type = NET_AQM_NONE};
     double delay = 0.1, bw = 1e6, depth = 0.1, start = 0, random_loss = 0;
     double length = 100;
     int first_sep = find_next_separator(argc, argv, 1);
@@ -727,7 +816,7 @@ int main(int argc, char **argv)
     }
 
     argv[first_sep] = NULL;
-    if (!parse_options(first_sep, argv, &quicctx, &delay, &start, &bw, &depth, &length, &random_loss, &quicly_trace_fp))
+    if (!parse_options(first_sep, argv, &quicctx, &delay, &start, &bw, &depth, &length, &random_loss, &aqm, &quicly_trace_fp))
         exit(1);
     argv[first_sep] = "--";
 
@@ -748,7 +837,7 @@ int main(int argc, char **argv)
             if (seg_end < argc)
                 argv[seg_end] = NULL;
 
-            if (!parse_options(flow_argc, flow_argv, flow_ctx, &flow_delay, &flow_start, NULL, NULL, NULL, NULL, NULL))
+            if (!parse_options(flow_argc, flow_argv, flow_ctx, &flow_delay, &flow_start, NULL, NULL, NULL, NULL, NULL, NULL))
                 exit(1);
             flow_argv[0] = saved_argv0;
             if (seg_end < argc)
@@ -783,7 +872,7 @@ int main(int argc, char **argv)
     }
 
     /* setup bottleneck */
-    net_bottleneck_init(&bottleneck_node, bw, depth);
+    net_bottleneck_init(&bottleneck_node, bw, depth, aqm);
     bottleneck_node.next_node = &server_node.node.super;
     *node_insert_at++ = &bottleneck_node.super;
 


### PR DESCRIPTION
This PR implements RFC 8511 (TCP Alternative Backoff with ECN) for pico; the beta chosen for CE is 0.85, as we use 0.7 for packet losses.

The PR also adds -F (flow isolation) and -A (AQM algorithm) options to the simulator; it can simulate fq_codel with `-F -A codel`.
As to the AQM algorithm, currently supported ones are: `codel` and `step` (mark everything when the queue is above threshold).

The chart below is the interaction with Rapid Start; first congestion is reported via a packet loss, because Codel marks packets only if the queue was occupied for longer than 100ms, which is much longer than the path RTT of a typical DSL connection. However, once exiting startup, congestions are reported via CE marks, and there is no retransmits (look at the blue line).
<img width="1217" height="1074" alt="Screenshot 2026-08-11 at 7 27 25" src="https://github.com/user-attachments/assets/420b5958-6da0-444a-b098-2581de095f8f" />

The 2nd chart shows the bandwidth occupation on a DSL network with fq_codel. Pico with ECN turned on gets slightly more bandwidth than that with ECN turned off; this difference is due to the different betas (0.85 on CE vs 0.7 on congestion). The RTT of the simulated network is 30ms, and codel reports congestion (either via CE or drop) when the buffer is >=5ms. If codel drops a packet and CWND is reduced to 0.7x of the original, the sender cannot fulfill the bottleneck (i.e., `(30 + 5) * 0.7 = 24.5 < 30`). Conversely, when codel marks a packet, CWND is reduced only to 0.85x, and the sender continues to fulfill the bottleneck (`(30 + 5) * 0.85 = 29.75 ~ 30`).
<img width="1173" height="1075" alt="Screenshot 2026-08-11 at 7 27 37" src="https://github.com/user-attachments/assets/f811886d-80a5-4b03-82c2-ef541914cf51" />
