### PR TITLE
Update Cubic to RFC 9438, update pico's fast convergence friendliness factor

### DIFF
--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -140,13 +140,17 @@ typedef struct st_quicly_cc_t {
              */
             double k;
             /**
-             * Last cwnd value before the latest congestion event.
+             * Effective W_max retained from the latest congestion event.
              */
             uint32_t w_max;
             /**
-             * W_max value from the previous congestion event.
+             * Congestion window before the reduction at the latest congestion event.
              */
-            uint32_t w_last_max;
+            uint32_t cwnd_prior;
+            /**
+             * Reno-friendly congestion window estimate.
+             */
+            double w_est;
             /**
              * Timestamp of the latest congestion event.
              */

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -38,26 +38,31 @@ static cubic_float_t calc_cubic_t(const quicly_cc_t *cc, int64_t now)
     return clock_delta / 1000; /* ms -> s */
 }
 
-/* RFC 8312, Equation 1; using bytes as unit instead of MSS */
-static uint32_t calc_w_cubic(const quicly_cc_t *cc, cubic_float_t t_sec, uint32_t max_udp_payload_size)
+/* RFC 9438, Figure 1; using bytes as unit instead of MSS */
+static cubic_float_t calc_w_cubic(const quicly_cc_t *cc, cubic_float_t t_sec, uint32_t max_udp_payload_size)
 {
     cubic_float_t tk = t_sec - cc->state.cubic.k;
     return (QUICLY_CUBIC_C * (tk * tk * tk) * max_udp_payload_size) + cc->state.cubic.w_max;
 }
 
-/* RFC 8312, Equation 2 */
-/* K depends solely on W_max, so we update both together on congestion events */
-static void update_cubic_k(quicly_cc_t *cc, uint32_t max_udp_payload_size)
+/* RFC 9438, Figure 2 */
+static void update_cubic_k(quicly_cc_t *cc, uint32_t cwnd_epoch, uint32_t max_udp_payload_size)
 {
-    cubic_float_t w_max_mss = cc->state.cubic.w_max / (cubic_float_t)max_udp_payload_size;
-    cc->state.cubic.k = cbrt(w_max_mss * ((1 - QUICLY_CUBIC_BETA) / QUICLY_CUBIC_C));
+    if (cc->state.cubic.w_max > cwnd_epoch) {
+        cubic_float_t window_delta_mss = (cc->state.cubic.w_max - cwnd_epoch) / (cubic_float_t)max_udp_payload_size;
+        cc->state.cubic.k = cbrt(window_delta_mss / QUICLY_CUBIC_C);
+    } else {
+        cc->state.cubic.k = 0;
+    }
 }
 
-/* RFC 8312, Equation 4; using bytes as unit instead of MSS */
-static uint32_t calc_w_est(const quicly_cc_t *cc, cubic_float_t t_sec, cubic_float_t rtt_sec, uint32_t max_udp_payload_size)
+/* RFC 9438, Figure 4; using bytes as unit instead of MSS */
+static uint32_t update_w_est(quicly_cc_t *cc, uint32_t bytes, uint32_t max_udp_payload_size)
 {
-    return (cc->state.cubic.w_max * QUICLY_CUBIC_BETA) +
-           ((3 * (1 - QUICLY_CUBIC_BETA) / (1 + QUICLY_CUBIC_BETA)) * (t_sec / rtt_sec) * max_udp_payload_size);
+    cubic_float_t alpha =
+        cc->state.cubic.w_est >= cc->state.cubic.cwnd_prior ? 1 : 3 * (1 - QUICLY_CUBIC_BETA) / (1 + QUICLY_CUBIC_BETA);
+    cc->state.cubic.w_est += alpha * bytes / cc->cwnd * max_udp_payload_size;
+    return cc->state.cubic.w_est < UINT32_MAX ? cc->state.cubic.w_est : UINT32_MAX;
 }
 
 /* TODO: Avoid increase if sender was application limited. */
@@ -87,22 +92,22 @@ static void cubic_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t 
     cubic_float_t t_sec = calc_cubic_t(cc, now);
     cubic_float_t rtt_sec = loss->rtt.smoothed / (cubic_float_t)1000; /* ms -> s */
 
-    uint32_t w_cubic = calc_w_cubic(cc, t_sec, max_udp_payload_size);
-    uint32_t w_est = calc_w_est(cc, t_sec, rtt_sec, max_udp_payload_size);
+    cubic_float_t w_cubic = calc_w_cubic(cc, t_sec, max_udp_payload_size);
+    uint32_t w_est = update_w_est(cc, bytes, max_udp_payload_size);
 
     if (w_cubic < w_est) {
-        /* RFC 8312, Section 4.2; TCP-Friendly Region */
-        /* Prevent cwnd from shrinking if W_est is reduced due to RTT increase */
-        if (w_est > cc->cwnd)
-            cc->cwnd = w_est;
+        /* RFC 9438, Section 4.3; Reno-Friendly Region */
+        cc->cwnd = w_est;
     } else {
-        /* RFC 8312, Section 4.3/4.4; CUBIC Region */
+        /* RFC 9438, Sections 4.4 and 4.5; Concave and Convex Regions */
         cubic_float_t w_cubic_target = calc_w_cubic(cc, t_sec + rtt_sec, max_udp_payload_size);
-        /* After fast convergence W_max < W_last_max holds, and hence W_cubic(0) = beta * W_max < beta * W_last_max = cwnd.
-         * cwnd could thus shrink without this check (but only after fast convergence). */
-        if (w_cubic_target > cc->cwnd)
-            /* (W_cubic(t+RTT) - cwnd)/cwnd * MSS = (W_cubic(t+RTT)/cwnd - 1) * MSS */
-            cc->cwnd = quicly_u32_add_saturating(cc->cwnd, ((w_cubic_target / cc->cwnd) - 1) * max_udp_payload_size);
+        /* RFC 9438, Section 4.2 bounds target to make the increase non-decreasing and slower than slow start. */
+        if (w_cubic_target < cc->cwnd)
+            w_cubic_target = cc->cwnd;
+        if (w_cubic_target > 1.5 * cc->cwnd)
+            w_cubic_target = 1.5 * cc->cwnd;
+        /* (W_cubic(t+RTT) - cwnd)/cwnd * MSS = (W_cubic(t+RTT)/cwnd - 1) * MSS */
+        cc->cwnd = quicly_u32_add_saturating(cc->cwnd, ((w_cubic_target / cc->cwnd) - 1) * max_udp_payload_size);
     }
 
     if (cc->cwnd_maximum < cc->cwnd)
@@ -130,23 +135,21 @@ static void cubic_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
     }
 
     cc->state.cubic.avoidance_start = now;
-    cc->state.cubic.w_max = cc->cwnd;
+    cc->state.cubic.cwnd_prior = cc->cwnd;
 
-    /* RFC 8312, Section 4.6; Fast Convergence */
-    /* w_last_max is initialized to zero; therefore this condition is false when exiting slow start */
-    if (cc->state.cubic.w_max < cc->state.cubic.w_last_max) {
-        cc->state.cubic.w_last_max = cc->state.cubic.w_max;
-        cc->state.cubic.w_max *= (1.0 + QUICLY_CUBIC_BETA) / 2.0;
-    } else {
-        cc->state.cubic.w_last_max = cc->state.cubic.w_max;
-    }
-    update_cubic_k(cc, max_udp_payload_size);
+    /* RFC 9438, Section 4.7; compare cwnd with the effective W_max retained from the previous congestion event. */
+    if (cc->cwnd < cc->state.cubic.w_max)
+        cc->state.cubic.w_max = cc->cwnd * ((1.0 + QUICLY_CUBIC_BETA) / 2.0);
+    else
+        cc->state.cubic.w_max = cc->cwnd;
 
-    /* RFC 8312, Section 4.5; Multiplicative Decrease */
+    /* RFC 9438, Section 4.6; Multiplicative Decrease */
     cc->cwnd *= cc->ssthresh == UINT32_MAX ? 0.5 : QUICLY_CUBIC_BETA; /* without HyStart++, we overshoot by 2x in slowstart */
     if (cc->cwnd < QUICLY_MIN_CWND * max_udp_payload_size)
         cc->cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
     cc->ssthresh = cc->cwnd;
+    cc->state.cubic.w_est = cc->cwnd;
+    update_cubic_k(cc, cc->cwnd, max_udp_payload_size);
 
     if (cc->cwnd_minimum > cc->cwnd)
         cc->cwnd_minimum = cc->cwnd;

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -43,19 +43,21 @@ static uint32_t calc_bytes_per_mtu_increase(uint32_t cwnd, uint32_t rtt, uint32_
      *     = (K * Wmax / RTT_at_Wmax) / (0.3 * Wmax) * MTU
      *     = K * MTU / (0.3 * RTT_at_Wmax)
      *
-     * In addition, we have to adjust the value to take fast convergence into account. On a path with stable capacity, 50% of
-     * congestion events adjust Wmax to 0.85x of before calculating K. If that happens, the modified K (K') is:
+     * In addition, we have to adjust the value to take fast convergence into account. When competition causes congestion peaks to
+     * decline gradually, fast-convergence and normal epochs are expected to alternate: a peak below the retained Wmax triggers fast
+     * convergence, while the resulting Wmax of 0.85x makes the next peak a normal event unless it declines by more than 15%.
      *
-     *   K' = (0.3 / 0.4 * 0.85 * Wmax / MTU)^(1/3) = 0.85^(1/3) * K
+     * When fast convergence occurs, Wmax becomes 0.85x while cwnd_epoch remains 0.7x. The modified K (K') is therefore:
      *
-     * where K' represents the time to reach 0.85 * Wmax. As the cubic curve is point symmetric at the point where this curve
-     * reaches 0.85 * Wmax, it would take 2 * K' seconds to reach Wmax.
+     *   K' = ((0.85 - 0.7) / 0.4 * Wmax / MTU)^(1/3) = 0.5^(1/3) * K
      *
-     * Therefore, by amortizing the two modes, the congestion period of Cubic with fast convergence is calculated as:
+     * where K' represents the time to reach 0.85 * Wmax. As the cubic curve is point symmetric around that point, reaching the
+     * original Wmax takes 2 * K'. Amortizing one fast-convergence period and one normal period gives:
      *
-     *   bytes_per_mtu_increase = ((1 + 0.85^(1/3) * 2) / 2) * K * MTU / (0.3 * RTT_at_Wmax)
+     *   bytes_per_mtu_increase = ((1 + 0.5^(1/3) * 2) / 2) * K * MTU / (0.3 * RTT_at_Wmax)
+     *                          ~= 1.293700525984 * K * MTU / (0.3 * RTT_at_Wmax)
      */
-    uint32_t cubic = 1.447 / 0.3 * 1000 * cbrt(0.3 / 0.4 * cwnd / mtu) / rtt * mtu;
+    uint32_t cubic = 1.293700525984 / 0.3 * 1000 * cbrt(0.3 / 0.4 * cwnd / mtu) / rtt * mtu;
 
     return reno < cubic ? reno : cubic;
 }

--- a/t/cc.c
+++ b/t/cc.c
@@ -137,6 +137,51 @@ static void test_pico_undo_jumpstart_loss(void)
     ok(!quicly_cc_in_jumpstart(&cc));
 }
 
+static void test_cubic_fast_convergence(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 100 * mtu;
+
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0);
+
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    ok(cc.state.cubic.w_max == 100 * mtu);
+
+    cc.cwnd = 90 * mtu;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 1100, mtu);
+    ok(cc.state.cubic.w_max == 90 * mtu * 85 / 100);
+
+    /* The effective W_max is 76.5 MTUs, so an 80-MTU congestion window does not trigger fast convergence again. */
+    cc.cwnd = 80 * mtu;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 30, 40, 1200, mtu);
+    ok(cc.state.cubic.w_max == 80 * mtu);
+    ok(cc.state.cubic.cwnd_prior == 80 * mtu);
+    ok(cc.state.cubic.w_est == cc.cwnd);
+}
+
+static void test_cubic_target_bounds(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 10 * mtu;
+
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0);
+    cc.ssthresh = cc.cwnd;
+    cc.state.cubic.w_max = cc.cwnd;
+    cc.state.cubic.w_est = cc.cwnd;
+    cc.state.cubic.cwnd_prior = cc.cwnd;
+
+    cc.type->cc_on_acked(&cc, &loss, mtu, 1, cc.cwnd, 1, 2, 1000000, mtu);
+    ok(cc.cwnd == initcwnd + mtu / 2);
+
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0);
+    cc.ssthresh = cc.cwnd;
+    cc.state.cubic.w_max = cc.cwnd / 2;
+    cc.type->cc_on_acked(&cc, &loss, mtu, 1, cc.cwnd, 1, 2, 0, mtu);
+    ok(cc.cwnd == initcwnd);
+}
+
 static void test_rapid_start(void)
 {
     struct st_quicly_cc_rapid_start_t rs;
@@ -173,6 +218,8 @@ static void test_rapid_start(void)
 void test_cc(void)
 {
     subtest("rapid-start", test_rapid_start);
+    subtest("cubic-fast-convergence", test_cubic_fast_convergence);
+    subtest("cubic-target-bounds", test_cubic_target_bounds);
     subtest("pico-undo-loss", test_pico_undo_loss);
     subtest("pico-undo-multiple-losses", test_pico_undo_multiple_losses);
     subtest("pico-undo-rapid-start-loss", test_pico_undo_rapid_start_loss);


### PR DESCRIPTION
RFC 8312 defines K assuming that the post-loss congestion window is beta * W_max. Fast convergence, however, reduces W_max to 0.85 * peak while the actual congestion window remains 0.70 * peak, violating that assumption.
```
peak       = P
W_max      = 0.85P
cwnd       = 0.70P
old K³ × C = 0.30 × W_max = 0.255P
```
The problem was that this K formula implicitly places the beginning of the cubic curve at:
```
β × W_max = 0.70 × 0.85P = 0.595P
```

but the actual post-loss cwnd was 0.70P. The curve therefore started below the real congestion window, and the old safeguard suppressed growth until it caught up.

RFC 9438 instead derives K from the actual gap:
```
new K³ × C = W_max - cwnd
           = 0.85P - 0.70P
           = 0.15P
```

and the PR adjusts the code accordingly. Note that this form is what is deployed in real world (by Linux, Apple, etc.).

Pico’s CUBIC-friendliness factor is also updated to reflect the corrected fast-convergence trajectory.