### PR TITLE
Fix smoothed RTT being stuck up to 7ms below the actual RTT

### DIFF
--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -70,7 +70,7 @@ typedef struct quicly_loss_conf_t {
     }
 
 /**
- * Holds RTT variables. We use this structure differently from the specification:
+ * Holds RTT variables in the unit of milliseconds. We use this structure differently from the specification:
  * * if the first sample has been obtained should be checked by doing: `latest != 0`
  * * smoothed and variance are available even before the first RTT sample is obtained
  */
@@ -80,13 +80,14 @@ typedef struct quicly_rtt_t {
      */
     uint32_t minimum;
     /**
-     * Current smoothed RTT value.
+     * Current smoothed RTT value. The type has been changed to float because the EWMA advances by (latest - smoothed) / 8 per
+     * sample. If it is int, latest would be ignored unless latest - smoothed > 7.
      */
-    uint32_t smoothed;
+    float smoothed;
     /**
-     * Current estimate of RTT variance.
+     * Current estimate of RTT variance, also in float.
      */
-    uint32_t variance;
+    float variance;
     /**
      * Value of the latest RTT sample.
      */
@@ -219,7 +220,7 @@ inline void quicly_rtt_init(quicly_rtt_t *rtt, const quicly_loss_conf_t *conf, u
     rtt->minimum = UINT32_MAX;
     rtt->latest = 0;
     rtt->smoothed = initial_rtt;
-    rtt->variance = initial_rtt / 2;
+    rtt->variance = initial_rtt / 2.f;
 }
 
 inline void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t latest_rtt, uint32_t ack_delay)
@@ -240,18 +241,19 @@ inline void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t latest_rtt, uint32_t a
     /* update smoothed_rtt and rttvar */
     if (is_first_sample) {
         rtt->smoothed = rtt->latest;
-        rtt->variance = rtt->latest / 2;
+        rtt->variance = rtt->latest / 2.f;
     } else {
-        uint32_t absdiff = rtt->smoothed >= rtt->latest ? rtt->smoothed - rtt->latest : rtt->latest - rtt->smoothed;
-        rtt->variance = (rtt->variance * 3 + absdiff) / 4;
-        rtt->smoothed = (rtt->smoothed * 7 + rtt->latest) / 8;
+        float latest = (float)rtt->latest;
+        float absdiff = rtt->smoothed >= latest ? rtt->smoothed - latest : latest - rtt->smoothed;
+        rtt->variance = rtt->variance * 0.75f + absdiff * 0.25f;
+        rtt->smoothed = rtt->smoothed * 0.875f + latest * 0.125f;
     }
     assert(rtt->smoothed != 0);
 }
 
 inline uint32_t quicly_rtt_get_pto(quicly_rtt_t *rtt, uint32_t max_ack_delay, uint32_t min_pto)
 {
-    return rtt->smoothed + (rtt->variance != 0 ? rtt->variance * 4 : min_pto) + max_ack_delay;
+    return (uint32_t)(rtt->smoothed + (rtt->variance != 0 ? rtt->variance * 4 : (float)min_pto)) + max_ack_delay;
 }
 
 inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, const uint16_t *max_ack_delay,
@@ -386,7 +388,6 @@ inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly
     if (ack_delay_millisecs > *r->max_ack_delay)
         ack_delay_millisecs = *r->max_ack_delay;
     quicly_rtt_update(&r->rtt, (uint32_t)(now - sent_at), ack_delay_millisecs);
-
 }
 
 inline quicly_error_t quicly_loss_on_alarm(quicly_loss_t *r, int64_t now, uint32_t max_ack_delay, int is_1rtt_only,

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -27,7 +27,7 @@
 /**
  * Calculates the increase ratio to be used in congestion avoidance phase.
  */
-static uint32_t calc_bytes_per_mtu_increase(uint32_t cwnd, uint32_t rtt, uint32_t mtu, double beta)
+static uint32_t calc_bytes_per_mtu_increase(uint32_t cwnd, double rtt, uint32_t mtu, double beta)
 {
     /* Reno: CWND size after reduction */
     uint32_t reno = cwnd * beta;

--- a/lib/loss.c
+++ b/lib/loss.c
@@ -19,6 +19,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+#include <math.h>
 #include "quicly/loss.h"
 
 quicly_error_t quicly_loss_init_sentmap_iter(quicly_loss_t *loss, quicly_sentmap_iter_t *iter, int64_t now, uint32_t max_ack_delay,
@@ -57,10 +58,8 @@ quicly_error_t quicly_loss_detect_loss(quicly_loss_t *loss, int64_t now, uint32_
     /* This function ensures that the value returned in loss_time is when the next application timer should be set for loss
      * detection. if no timer is required, loss_time is set to INT64_MAX. */
 
-    const uint32_t delay_until_lost = ((loss->rtt.latest > loss->rtt.smoothed ? loss->rtt.latest : loss->rtt.smoothed) *
-                                           (1024 + loss->thresholds.time_based_percentile) +
-                                       1023) /
-                                      1024;
+    const float rtt_for_threshold = loss->rtt.latest > loss->rtt.smoothed ? (float)loss->rtt.latest : loss->rtt.smoothed;
+    const uint32_t delay_until_lost = (uint32_t)ceilf(rtt_for_threshold * (1024 + loss->thresholds.time_based_percentile) / 1024);
     quicly_sentmap_iter_t iter;
     const quicly_sent_packet_t *sent;
     quicly_error_t ret;

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2141,8 +2141,8 @@ static quicly_error_t promote_path(quicly_conn_t *conn, size_t path_index)
 
     /* reset RTT estimate, adopting SRTT of the original path as initial RTT (TODO calculate RTT based on path challenge RT) */
     quicly_rtt_init(&conn->egress.loss.rtt, &conn->super.ctx->loss,
-                    conn->egress.loss.rtt.smoothed < conn->super.ctx->loss.default_initial_rtt
-                        ? conn->egress.loss.rtt.smoothed
+                    (uint32_t)conn->egress.loss.rtt.smoothed < conn->super.ctx->loss.default_initial_rtt
+                        ? (uint32_t)conn->egress.loss.rtt.smoothed
                         : conn->super.ctx->loss.default_initial_rtt);
 
     /* reset ratemeter */
@@ -3653,7 +3653,7 @@ static uint32_t calc_pacer_send_rate(quicly_conn_t *conn)
         multiplier = 2;
     }
 
-    return quicly_pacer_calc_send_rate(multiplier, conn->egress.cc.cwnd, conn->egress.loss.rtt.smoothed);
+    return quicly_pacer_calc_send_rate(multiplier, conn->egress.cc.cwnd, (uint32_t)conn->egress.loss.rtt.smoothed);
 }
 
 static int should_send_datagram_frame(quicly_conn_t *conn)
@@ -5537,12 +5537,13 @@ static quicly_error_t do_send(quicly_conn_t *conn, quicly_send_context_t *s)
     }
     /* handle handshake timeouts */
     if ((conn->initial != NULL || conn->handshake != NULL) &&
-        conn->created_at + (uint64_t)conn->super.ctx->handshake_timeout_rtt_multiplier * conn->egress.loss.rtt.smoothed <=
+        conn->created_at + (int64_t)(conn->super.ctx->handshake_timeout_rtt_multiplier * conn->egress.loss.rtt.smoothed) <=
             conn->stash.now) {
-        QUICLY_PROBE(HANDSHAKE_TIMEOUT, conn, conn->stash.now, conn->stash.now - conn->created_at, conn->egress.loss.rtt.smoothed);
+        QUICLY_PROBE(HANDSHAKE_TIMEOUT, conn, conn->stash.now, conn->stash.now - conn->created_at,
+                     (uint32_t)conn->egress.loss.rtt.smoothed);
         QUICLY_LOG_CONN(handshake_timeout, conn, {
             PTLS_LOG_ELEMENT_SIGNED(elapsed, conn->stash.now - conn->created_at);
-            PTLS_LOG_ELEMENT_UNSIGNED(rtt_smoothed, conn->egress.loss.rtt.smoothed);
+            PTLS_LOG_ELEMENT_UNSIGNED(rtt_smoothed, (uint32_t)conn->egress.loss.rtt.smoothed);
         });
         conn->super.stats.num_handshake_timeouts++;
         goto CloseNow;
@@ -5588,7 +5589,8 @@ static quicly_error_t do_send(quicly_conn_t *conn, quicly_send_context_t *s)
     }
 
     /* disable ECN if zero packets where acked in the first 3 PTO of the connection during which all sent packets are ECT(0) */
-    if (conn->egress.ecn.state == QUICLY_ECN_PROBING && conn->created_at + conn->egress.loss.rtt.smoothed * 3 < conn->stash.now) {
+    if (conn->egress.ecn.state == QUICLY_ECN_PROBING &&
+        conn->created_at + (int64_t)(conn->egress.loss.rtt.smoothed * 3) < conn->stash.now) {
         update_ecn_state(conn, QUICLY_ECN_OFF);
         /* TODO reset CC? */
     }

--- a/misc/probe2trace.pl
+++ b/misc/probe2trace.pl
@@ -60,8 +60,8 @@ struct st_first_octet_t {
 
 struct quicly_rtt_t {
     uint32_t minimum;
-    uint32_t smoothed;
-    uint32_t variance;
+    float smoothed;
+    float variance;
     uint32_t latest;
 };
 
@@ -124,12 +124,13 @@ for my $probe (@probes) {
             } elsif ($arch eq 'darwin') {
                 push @ap, map{"*(uint32_t *)copyin(arg$i + $_, 4)"} qw(0 4 12);
             } else {
-                push @ap, map{"arg${i}->$_"} qw(minimum smoothed latest);
+                push @ap, "arg${i}->minimum", "(uint32_t)(arg${i}->smoothed + 0.5)", "arg${i}->latest";
             }
         } elsif ($type eq 'struct st_quicly_stats_t *') {
             # build an array of [field-names => type-specifiers]
             my @fields;
-            push @fields, map {["rtt.$_" => '%u']} qw(minimum smoothed variance);
+            push @fields, ["rtt.minimum" => '%u'], ["rtt.smoothed" => '%u', '(uint32_t)'],
+                          ["rtt.variance" => '%u', '(uint32_t)'];
             push @fields, map {["cc.$_" => '%u']} qw(cwnd ssthresh cwnd_initial cwnd_exiting_slow_start cwnd_minimum cwnd_maximum num_loss_episodes);
             push @fields, map {["num_packets.$_" => $arch eq 'embedded' ? '%" PRIu64 "' : '%llu']} qw(sent ack_received lost lost_time_threshold late_acked received decryption_failed);
             push @fields, map {["num_bytes.$_" => $arch eq 'embedded' ? '%" PRIu64 "' : '%llu']} qw(sent received);
@@ -140,9 +141,9 @@ for my $probe (@probes) {
             # generate @fmt, @ap
             push @fmt, map {my $n = $_->[0]; $n =~ tr/./_/; sprintf '"%s":%s', $n, $_->[1]} @fields;
             if ($arch eq 'linux') {
-                push @ap, map{"((struct st_quicly_stats_t *)arg$i)->" . $_->[0]} @fields;
+                push @ap, map{($_->[2] // '') . "((struct st_quicly_stats_t *)arg$i)->" . $_->[0]} @fields;
             } else {
-                push @ap, map{"arg${i}->" . $_->[0]} @fields;
+                push @ap, map{($_->[2] // '') . "arg${i}->" . $_->[0]} @fields;
             }
             # special handling of cc.type
             push @fmt, '"cc_type":"%s"';

--- a/t/lossy.c
+++ b/t/lossy.c
@@ -425,49 +425,49 @@ static void test_downstream(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    subtest("down-stats-75%", loss_check_stats, time_spent, 3, 5131, 17227, 2644, 3280, 12824);
+    subtest("down-stats-75%", loss_check_stats, time_spent, 6, 8900, 21000, 2720, 3450, 15200);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);
         subtest("50%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    subtest("down-stats-50%", loss_check_stats, time_spent, 0, 792, 1104, 484, 484, 1526);
+    subtest("down-stats-50%", loss_check_stats, time_spent, 0, 750, 1190, 485, 485, 1526);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 4);
         subtest("25%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    subtest("down-stats-25%", loss_check_stats, time_spent, 0, 225, 244, 230, 230, 408);
+    subtest("down-stats-25%", loss_check_stats, time_spent, 0, 223, 267, 230, 230, 478);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 10);
         subtest("10%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    subtest("down-stats-10%", loss_check_stats, time_spent, 0, 114, 142, 80, 80, 298);
+    subtest("down-stats-10%", loss_check_stats, time_spent, 0, 109, 153, 80, 80, 330);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 20);
         subtest("5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    subtest("down-stats-5%", loss_check_stats, time_spent, 0, 103, 118, 80, 80, 230);
+    subtest("down-stats-5%", loss_check_stats, time_spent, 0, 98, 126, 80, 80, 260);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 40);
         subtest("2.5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    subtest("down-stats-2.5%", loss_check_stats, time_spent, 0, 85, 103, 80, 80, 190);
+    subtest("down-stats-2.5%", loss_check_stats, time_spent, 0, 85, 110, 80, 80, 220);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 64);
         subtest("1.6%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    subtest("down-stats-1.6%", loss_check_stats, time_spent, 0, 86, 91.1, 80, 80, 80);
+    subtest("down-stats-1.6%", loss_check_stats, time_spent, 0, 82, 97, 80, 80, 80);
 }
 
 static void test_bidirectional(void)
@@ -482,7 +482,7 @@ static void test_bidirectional(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    subtest("bidi-stats-75%", loss_check_stats, time_spent, 18, 203900, 223090, 65015, 84162, 633710);
+    subtest("bidi-stats-75%", loss_check_stats, time_spent, 20, 180000, 233000, 61800, 88400, 690000);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);
@@ -490,7 +490,7 @@ static void test_bidirectional(void)
         subtest("50%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    subtest("bidi-stats-50%", loss_check_stats, time_spent, 0, 4612, 5713, 886, 1175, 9269);
+    subtest("bidi-stats-50%", loss_check_stats, time_spent, 0, 4865, 5850, 1064, 1285, 9600);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 4);
@@ -498,7 +498,7 @@ static void test_bidirectional(void)
         subtest("25%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    subtest("bidi-stats-25%", loss_check_stats, time_spent, 0, 269, 285, 230, 284, 478);
+    subtest("bidi-stats-25%", loss_check_stats, time_spent, 0, 251, 327, 185, 300, 715);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 10);
@@ -506,7 +506,7 @@ static void test_bidirectional(void)
         subtest("10%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    subtest("bidi-stats-10%", loss_check_stats, time_spent, 0, 121, 137, 80, 80, 230);
+    subtest("bidi-stats-10%", loss_check_stats, time_spent, 0, 122, 171, 80, 80, 330);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 20);
@@ -514,7 +514,7 @@ static void test_bidirectional(void)
         subtest("5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    subtest("bidi-stats-5%", loss_check_stats, time_spent, 0, 101, 110, 80, 80, 190);
+    subtest("bidi-stats-5%", loss_check_stats, time_spent, 0, 97, 122, 80, 80, 260);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 40);
@@ -522,7 +522,7 @@ static void test_bidirectional(void)
         subtest("2.5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    subtest("bidi-stats-2.5%", loss_check_stats, time_spent, 0, 95, 97, 80, 80, 190);
+    subtest("bidi-stats-2.5%", loss_check_stats, time_spent, 0, 89, 105, 80, 80, 220);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 64);
@@ -530,7 +530,7 @@ static void test_bidirectional(void)
         subtest("1.6%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    subtest("bidi-stats-1.6%", loss_check_stats, time_spent, 0, 86, 91, 80, 80, 80);
+    subtest("bidi-stats-1.6%", loss_check_stats, time_spent, 0, 81, 99, 80, 80, 80);
 }
 
 void test_lossy(void)


### PR DESCRIPTION
`quicly_rtt_t::smoothed` was held as an integer number of milliseconds and updated as:

```c
rtt->smoothed = (rtt->smoothed * 7 + rtt->latest) / 8;
```

The EWMA advances by `(latest - smoothed) / 8` per sample. In whole milliseconds that increment truncates to zero unless `latest >= smoothed + 8`, so the estimate stops climbing once it is within 8ms of the true RTT and stays there. `variance` has the same problem via `(variance * 3 + absdiff) / 4`.

This is not a slow-convergence issue; it is a fixed point. On a simulated path with a 120ms RTT, 274-369 consecutive samples all reading 118-120ms left `smoothed` pinned at 113 for the entire connection. The gap is exactly 7ms regardless of the path, because it is a property of the arithmetic rather than of the RTT:

| path (base + queue) | actual RTT | smoothed |
| --- | --- | --- |
| 30ms + 50ms | 80ms | 73ms |
| 40ms + 80ms | 120ms | 113ms |
| 60ms + 120ms | 180ms | 173ms |

The error is therefore relatively worse on shorter paths - 8.8% at 80ms.

`smoothed` feeds PTO, the time threshold of loss detection, the pacer, CUBIC's `W_cubic(t + RTT)` lookahead and Pico's increase rate, so everything derived from it inherited the bias.

It was found while working on #678, which adds Cuback, an ACK-driven variant of CUBIC that converts acknowledged bytes into curve time using `bdp / srtt`. The stalled `smoothed` inflated that rate by 6-9%, making Cuback's clock run slow and leaving it at a measurably lower equilibrium window than CUBIC on the same path. The fix here is independent of #678 and stands on its own, but it removes that discrepancy: with it, Cuback reaches parity with CUBIC on all the paths tested.

### Fix

Hold `smoothed` and `variance` as `float`. The unit stays milliseconds, so call sites are unchanged in meaning; those wanting whole milliseconds cast explicitly, while those already computing in floating point - CUBIC's lookahead, Pico's increase rate, and `delay_until_lost` - now use the precise value. Note that `float` must not reach variadic functions without a cast, which is why the probes and `PTLS_LOG_ELEMENT_UNSIGNED` gained one.

Fixed point with a 1/256ms integer representation was considered instead. It works equally well numerically, but `float` avoids the range cliff (a `uint32_t` in 1/256ms tops out at 4.66 hours), needs no `uint64_t` intermediates, and keeps the stats and the public struct in their natural unit.

### Behavioral change

PTO becomes slightly longer, because `variance` no longer stalls below its true value. Loss recovery therefore engages later than before - correctly so. The completion-time regions in `t/lossy.c` were recalibrated over 40 runs; two of them (`down-stats-75%` in particular, whose mean varies 2x between runs) turned out to be considerably noisier than the previous constants implied. The suite passes 20/20 runs with the new regions.

### Follow-ups not included here

- `misc/probe2trace.pl`'s `linux` and `darwin` arches format the `rtt` probe with `%u` in-probe and hardcode struct offsets, so they need the probe to pass scalars rather than `struct quicly_rtt_t *`. Only the `tracer` arch, the one this repository builds, is updated here.
- `quicly_stats_t::rtt` still embeds `quicly_rtt_t`, so `smoothed` and `variance` are now `float` in the public struct. Consumers that assign them to an integer, or cast as the mixed-width `QUICLY_STATS_FOREACH` fields already require, are unaffected; ones that pass them to a variadic function expecting an integer will need a cast, as three call sites inside quicly did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
