### PR TITLE
Follow-up to #680: compute PTO using max(4 * rttvar, kGranularity)

### DIFF
--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -253,7 +253,7 @@ inline void quicly_rtt_update(quicly_rtt_t *rtt, uint32_t latest_rtt, uint32_t a
 
 inline uint32_t quicly_rtt_get_pto(quicly_rtt_t *rtt, uint32_t max_ack_delay, uint32_t min_pto)
 {
-    return (uint32_t)(rtt->smoothed + (rtt->variance != 0 ? rtt->variance * 4 : (float)min_pto)) + max_ack_delay;
+    return (uint32_t)(rtt->smoothed + (rtt->variance * 4 >= min_pto ? rtt->variance * 4 : min_pto)) + max_ack_delay;
 }
 
 inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, uint32_t initial_rtt, const uint16_t *max_ack_delay,


### PR DESCRIPTION
Follow-up to #680.

RFC 9002 Section 6.2.1 defines PTO as

    smoothed_rtt + max(4 * rttvar, kGranularity) + max_ack_delay

and states that the PTO period MUST be at least kGranularity. quicly instead wrote:

```c
rtt->smoothed + (rtt->variance != 0 ? rtt->variance * 4 : min_pto) + max_ack_delay
```

substituting `min_pto` (kGranularity, 1ms by default) only when rttvar is exactly zero.

That was equivalent to the `max` while rttvar was an integer: a non-zero integer rttvar gives `4 * rttvar >= 4`, never below the 1ms default, and rttvar == 0 selects `min_pto` directly. No integer value distinguishes the two forms, which is presumably why the spelling survived.

#680 changed rttvar to `float`, admitting values in `(0, 0.25)` - precisely the range the integer type excluded. There `4 * rttvar < 1ms` and the conditional returns the smaller term, so PTO can fall below kGranularity at the default configuration.

The same change also fixes a pre-existing deviation: with `min_pto` configured above 4ms, the conditional returns `4 * rttvar` where the RFC asks for `min_pto`. That one predates #680 and needs a non-default configuration.

### How much this matters

Not much. The error is bounded by kGranularity, so at most 1ms, against a PTO that normally also includes `max_ack_delay` (25ms by default). The paths that pass `max_ack_delay = 0` are the handshake and speculative probes, and `quicly_loss_on_alarm` already floors the speculative duration at `min_pto`. This is a conformance fix, not a defect anyone is likely to have observed.

### Testing

The suite passes; 1 failure in 25 runs, matching the residual flake rate of the regions recalibrated in #680. That is only evidence of no regression, though - on the paths `t/lossy.c` exercises, rttvar stays well above 0.25 and the corrected branch is never taken. No test covers the low-jitter case.

### Note

`min_pto` serves as kGranularity here, while `quicly_loss_on_alarm` also uses it as a floor on the whole alarm duration. Those are distinct concepts in RFC 9002; this PR leaves them as one field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
