### PR TITLE
remove unneeded NULL check in `do_receive`

### DIFF
--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -7696,7 +7696,7 @@ static quicly_error_t do_receive(quicly_conn_t *conn, struct sockaddr *dest_addr
         QUICLY_PROBE(ELICIT_PATH_MIGRATION, conn, conn->stash.now, path_index);
         QUICLY_LOG_CONN(elicit_path_migration, conn, { PTLS_LOG_ELEMENT_UNSIGNED(path_index, path_index); });
     }
-    if (*space != NULL && conn->super.state < QUICLY_STATE_CLOSING) {
+    if (conn->super.state < QUICLY_STATE_CLOSING) {
         if ((ret = record_receipt(*space, pn, packet->ecn, is_ack_only, conn->stash.now - (receive_delay >= 0 ? receive_delay : 0),
                                   &conn->egress.send_ack_at, &conn->super.stats.num_packets.received_out_of_order)) != 0)
             goto Exit;


### PR DESCRIPTION
*space != NULL check is redundant with the current lifecycle.

space is assigned only after the corresponding PN space is confirmed non-null (lib/quicly.c:7546). Payload processing cannot discard the active space:

- Handshake packets may discard the Initial space, not their own.
- HANDSHAKE_DONE is 1-RTT and discards the Handshake space, not Application (lib/quicly.c:7008).
- The active Initial or Handshake space is discarded only after record_receipt (lib/quicly.c:7705).
- Application space is freed only when freeing the connection.