### PR TITLE
Accelerated Bottleneck Bandwidth Adaptation (ABBA) for CUBIC and Cuback

### DIFF
--- a/include/quicly.h
+++ b/include/quicly.h
@@ -156,7 +156,7 @@ QUICLY_CALLBACK_TYPE(quicly_error_t, generate_resumption_token, quicly_conn_t *c
  * called to initialize a congestion controller for a new connection.
  * should in turn call one of the quicly_cc_*_init functions from cc.h with customized parameters.
  */
-QUICLY_CALLBACK_TYPE(void, init_cc, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance, int64_t now);
+QUICLY_CALLBACK_TYPE(void, init_cc, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, unsigned accel_adaptation, int64_t now);
 /**
  * reference counting.
  * delta must be either 1 or -1.
@@ -390,9 +390,9 @@ struct st_quicly_context_t {
      */
     unsigned normalize_cc_mtu : 1;
     /**
-     * if congestion control should tolerate random loss
+     * controls accelerated bottleneck bandwidth adaptation; see `QUICLY_CC_ACCEL_ADAPTATION_*`
      */
-    unsigned random_loss_tolerance : 1;
+    unsigned accel_adaptation : 2;
     /**
      *
      */

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -156,7 +156,7 @@ QUICLY_CALLBACK_TYPE(quicly_error_t, generate_resumption_token, quicly_conn_t *c
  * called to initialize a congestion controller for a new connection.
  * should in turn call one of the quicly_cc_*_init functions from cc.h with customized parameters.
  */
-QUICLY_CALLBACK_TYPE(void, init_cc, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int64_t now);
+QUICLY_CALLBACK_TYPE(void, init_cc, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance, int64_t now);
 /**
  * reference counting.
  * delta must be either 1 or -1.
@@ -389,6 +389,10 @@ struct st_quicly_context_t {
      * the default contexts
      */
     unsigned normalize_cc_mtu : 1;
+    /**
+     * if congestion control should tolerate random loss
+     */
+    unsigned random_loss_tolerance : 1;
     /**
      *
      */

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -140,9 +140,10 @@ struct st_quicly_cc_accelerated_increase_t {
      */
     uint32_t min_rtt_previous_period;
     /**
-     * Latest time at which the smoothed RTT was at least halfway between the minimum RTT and `full_rtt`.
+     * Latest time at which a high queue was indicated by ECN-CE or by the smoothed RTT reaching halfway between the minimum RTT
+     * and `full_rtt`.
      */
-    int64_t last_high_rtt_at;
+    int64_t last_high_queue_at;
     /**
      * Expected time in milliseconds for the active congestion-avoidance trajectory to produce a high-RTT observation.
      */

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -124,6 +124,28 @@ struct st_quicly_cc_cuback_t {
 };
 
 /**
+ * State used to accelerate CWND increase after Random Loss Tolerance is enabled.
+ */
+struct st_quicly_cc_accelerated_increase_t {
+    /**
+     * Queue-overflow RTT observed when calibration slow start encountered a packet loss, or zero before an observation is obtained.
+     */
+    uint32_t qortt;
+    /**
+     * Latest CWND cap established for accelerated increase, or zero when no cap is available.
+     */
+    uint32_t target_cwnd;
+    /**
+     * Beginning of the current path-change observation interval, or zero when no interval is active.
+     */
+    int64_t observation_start;
+    /**
+     * Maximum smoothed RTT observed during the current path-change observation interval.
+     */
+    float max_smoothed_rtt;
+};
+
+/**
  * State used by the Cubic policy implemented by cc-pico.c; see `quicly_cc_type_cubic`.
  */
 struct st_quicly_cc_cubic_t {
@@ -160,28 +182,6 @@ struct st_quicly_cc_cubic_t {
      * Whether the sender is currently CC-limited.
      */
     unsigned cc_limited : 1;
-    /**
-     * State used by CUBIC's random loss tolerance.
-     */
-    struct {
-        /**
-         * Queue-overflow RTT observed when calibration slow start encountered a packet loss, or zero before an observation is
-         * obtained.
-         */
-        uint32_t qortt;
-        /**
-         * CWND immediately before the latest CA loss, up to which accelerated recovery is permitted. Zero when inactive.
-         */
-        uint32_t recovery_target;
-        /**
-         * Beginning of the current path-change observation interval, or zero when no interval is active.
-         */
-        int64_t observation_start;
-        /**
-         * Maximum smoothed RTT observed during the current path-change observation interval.
-         */
-        float max_smoothed_rtt;
-    } random_loss;
 };
 
 typedef struct st_quicly_cc_t {
@@ -238,6 +238,10 @@ typedef struct st_quicly_cc_t {
                 struct st_quicly_cc_cubic_t cubic;
             };
             /**
+             * Accelerated increase state shared by Cuback and Cubic.
+             */
+            struct st_quicly_cc_accelerated_increase_t accel;
+            /**
              * State to undo a recovery episode when all packets deemed lost are later acknowledged. The packet number range being
              * tracked for undo is: start_pn <= pn < recovery_end. `num_packets_lost` counts packets in that range that were
              * declared lost and have not yet been late-ACKed. Other fields retain the values to be restored when
@@ -249,6 +253,7 @@ typedef struct st_quicly_cc_t {
                 uint32_t cwnd;
                 uint32_t ssthresh;
                 uint32_t bytes_to_mtu_increase;
+                struct st_quicly_cc_accelerated_increase_t accel;
                 union {
                     uint32_t bytes_per_mtu_increase;
                     struct st_quicly_cc_cuback_t cuback;

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -141,7 +141,7 @@ struct st_quicly_cc_cuback_t {
 /**
  * State used to accelerate CWND increase when bottleneck bandwidth adaptation is enabled.
  */
-struct st_quicly_cc_accelerated_increase_t {
+struct st_quicly_cc_accel_adaptation_t {
     /**
      * Smoothed RTT observed upon exiting a recovery entered from calibration slow start, or zero before that recovery exits.
      */
@@ -260,7 +260,7 @@ typedef struct st_quicly_cc_t {
             /**
              * Accelerated increase state shared by Cuback and Cubic.
              */
-            struct st_quicly_cc_accelerated_increase_t accel;
+            struct st_quicly_cc_accel_adaptation_t accel;
             /**
              * State to undo a recovery episode when all packets deemed lost are later acknowledged. The packet number range being
              * tracked for undo is: start_pn <= pn < recovery_end. `num_packets_lost` counts packets in that range that were
@@ -273,7 +273,7 @@ typedef struct st_quicly_cc_t {
                 uint32_t cwnd;
                 uint32_t ssthresh;
                 uint32_t bytes_to_mtu_increase;
-                struct st_quicly_cc_accelerated_increase_t accel;
+                struct st_quicly_cc_accel_adaptation_t accel;
                 union {
                     uint32_t bytes_per_mtu_increase;
                     struct st_quicly_cc_cuback_t cuback;

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -160,6 +160,28 @@ struct st_quicly_cc_cubic_t {
      * Whether the sender is currently CC-limited.
      */
     unsigned cc_limited : 1;
+    /**
+     * State used by CUBIC's random loss tolerance.
+     */
+    struct {
+        /**
+         * Queue-overflow RTT observed when calibration slow start encountered a packet loss, or zero before an observation is
+         * obtained.
+         */
+        uint32_t qortt;
+        /**
+         * CWND immediately before the latest CA loss, up to which accelerated recovery is permitted. Zero when inactive.
+         */
+        uint32_t recovery_target;
+        /**
+         * Beginning of the current path-change observation interval, or zero when no interval is active.
+         */
+        int64_t observation_start;
+        /**
+         * Maximum smoothed RTT observed during the current path-change observation interval.
+         */
+        float max_smoothed_rtt;
+    } random_loss;
 };
 
 typedef struct st_quicly_cc_t {
@@ -187,6 +209,10 @@ typedef struct st_quicly_cc_t {
      * Whether growth is normalized to QUICLY_CC_REFERENCE_MTU.
      */
     unsigned normalize_mtu : 1;
+    /**
+     * Whether Random Loss Tolerance is enabled for this connection.
+     */
+    unsigned random_loss_tolerance : 1;
     /**
      * State information specific to the congestion controller implementation.
      */

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -132,11 +132,6 @@ struct st_quicly_cc_accelerated_increase_t {
      */
     float full_rtt;
     /**
-     * CWND that accelerated increase first recovers toward, or zero when acceleration is unavailable. Increase may continue at
-     * the minimum rate until reaching this value divided by the ordinary loss beta.
-     */
-    uint32_t target_cwnd;
-    /**
      * Minimum RTT observed during the current period between congestion events, or zero before an RTT has been observed.
      */
     uint32_t min_rtt_current_period;

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -128,9 +128,9 @@ struct st_quicly_cc_cuback_t {
  */
 struct st_quicly_cc_accelerated_increase_t {
     /**
-     * Queue-overflow RTT observed when calibration slow start encountered a packet loss, or zero before an observation is obtained.
+     * Smoothed RTT observed upon exiting a recovery entered from calibration slow start, or zero before that recovery exits.
      */
-    uint32_t qortt;
+    float full_rtt;
     /**
      * CWND that accelerated increase first recovers toward, or zero when acceleration is unavailable. Increase may continue at
      * the minimum rate until reaching this value divided by the ordinary loss beta.

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -132,7 +132,8 @@ struct st_quicly_cc_accelerated_increase_t {
      */
     uint32_t qortt;
     /**
-     * Latest CWND cap established for accelerated increase, or zero when no cap is available.
+     * CWND that accelerated increase first recovers toward, or zero when acceleration is unavailable. Increase may continue at
+     * the minimum rate until reaching this value divided by the ordinary loss beta.
      */
     uint32_t target_cwnd;
     /**

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -57,6 +57,21 @@ extern "C" {
  */
 #define QUICLY_BETA_ECN 0.85
 
+/**
+ * Accelerate whenever the adaptive RTT gate permits it, bypassing the full-queue RTT guard.
+ */
+#define QUICLY_CC_ACCEL_ADAPTATION_INCREASE_ALWAYS 0x1
+/**
+ * Observe the full-queue RTT and recalibrate it when the path characteristics might have changed. Unless
+ * `QUICLY_CC_ACCEL_ADAPTATION_INCREASE_ALWAYS` is also set, the observation guards accelerated increase.
+ */
+#define QUICLY_CC_ACCEL_ADAPTATION_RECALIBRATE 0x2
+/**
+ * Default for accelerated adaptation: use fullRTT to conservatively decide when to increase faster than CUBIC, while
+ * recalibration helps regain bandwidth when random loss is frequent.
+ */
+#define QUICLY_CC_ACCEL_ADAPTATION_ON QUICLY_CC_ACCEL_ADAPTATION_RECALIBRATE
+
 /* factors defined by Rapid Start (see the I-D) */
 #define QUICLY_RAPID_START_K (2. / 3)
 #define QUICLY_RAPID_START_ACK_FACTOR(beta) (QUICLY_RAPID_START_K * (1 - (beta)))
@@ -124,7 +139,7 @@ struct st_quicly_cc_cuback_t {
 };
 
 /**
- * State used to accelerate CWND increase after Random Loss Tolerance is enabled.
+ * State used to accelerate CWND increase when bottleneck bandwidth adaptation is enabled.
  */
 struct st_quicly_cc_accelerated_increase_t {
     /**
@@ -215,9 +230,9 @@ typedef struct st_quicly_cc_t {
      */
     unsigned normalize_mtu : 1;
     /**
-     * Whether Random Loss Tolerance is enabled for this connection.
+     * Controls accelerated bottleneck bandwidth adaptation; see `QUICLY_CC_ACCEL_ADAPTATION_*`.
      */
-    unsigned random_loss_tolerance : 1;
+    unsigned accel_adaptation : 2;
     /**
      * State information specific to the congestion controller implementation.
      */

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -137,6 +137,14 @@ struct st_quicly_cc_accelerated_increase_t {
      */
     uint32_t target_cwnd;
     /**
+     * Minimum RTT observed during the current congestion-avoidance period, or zero before an RTT has been observed.
+     */
+    uint32_t min_rtt_in_ca;
+    /**
+     * Minimum RTT observed during the preceding congestion-avoidance period, or zero when no such observation is available.
+     */
+    uint32_t min_rtt_in_previous_ca;
+    /**
      * Beginning of the current path-change observation interval, or zero when no interval is active.
      */
     int64_t observation_start;

--- a/include/quicly/cc.h
+++ b/include/quicly/cc.h
@@ -137,21 +137,21 @@ struct st_quicly_cc_accelerated_increase_t {
      */
     uint32_t target_cwnd;
     /**
-     * Minimum RTT observed during the current congestion-avoidance period, or zero before an RTT has been observed.
+     * Minimum RTT observed during the current period between congestion events, or zero before an RTT has been observed.
      */
-    uint32_t min_rtt_in_ca;
+    uint32_t min_rtt_current_period;
     /**
-     * Minimum RTT observed during the preceding congestion-avoidance period, or zero when no such observation is available.
+     * Minimum RTT observed during the preceding period between congestion events, or zero when no such observation is available.
      */
-    uint32_t min_rtt_in_previous_ca;
+    uint32_t min_rtt_previous_period;
     /**
-     * Beginning of the current path-change observation interval, or zero when no interval is active.
+     * Latest time at which the smoothed RTT was at least halfway between the minimum RTT and `full_rtt`.
      */
-    int64_t observation_start;
+    int64_t last_high_rtt_at;
     /**
-     * Maximum smoothed RTT observed during the current path-change observation interval.
+     * Expected time in milliseconds for the active congestion-avoidance trajectory to produce a high-RTT observation.
      */
-    float max_smoothed_rtt;
+    uint32_t high_rtt_interval;
 };
 
 /**

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -206,7 +206,8 @@ static int cubic_on_switch(quicly_cc_t *cc)
     return 0;
 }
 
-static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int64_t now)
+static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance,
+                       int64_t now)
 {
     cubic_reset(cc, initcwnd, normalize_mtu);
 }

--- a/lib/cc-cubic.c
+++ b/lib/cc-cubic.c
@@ -206,7 +206,7 @@ static int cubic_on_switch(quicly_cc_t *cc)
     return 0;
 }
 
-static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance,
+static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, unsigned accel_adaptation,
                        int64_t now)
 {
     cubic_reset(cc, initcwnd, normalize_mtu);

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -381,6 +381,64 @@ static void cubic_on_congestion(struct st_quicly_cc_cubic_t *state, uint32_t cwn
     state->cwnd_prior = cwnd_prior;
 }
 
+static void cubic_random_loss_reset_observation(struct st_quicly_cc_cubic_t *state)
+{
+    state->random_loss.observation_start = 0;
+    state->random_loss.max_smoothed_rtt = 0;
+}
+
+static void cubic_random_loss_enter_calibration(quicly_cc_t *cc)
+{
+    struct st_quicly_cc_cubic_t *state = &cc->state.pico.cubic;
+
+    state->w_est = 0;
+    state->epoch_start = 0;
+    state->k = NAN;
+    state->cwnd_prior = 0;
+    state->fast_convergence = 0;
+    state->by_ecn = 0;
+    state->random_loss.recovery_target = 0;
+    cubic_random_loss_reset_observation(state);
+    cc->state.pico.bytes_to_mtu_increase = 0;
+    cc->ssthresh = UINT32_MAX;
+}
+
+static void cubic_random_loss_observe_path(quicly_cc_t *cc, const quicly_loss_t *loss, int64_t now)
+{
+    struct st_quicly_cc_cubic_t *state = &cc->state.pico.cubic;
+
+    if (!cc->random_loss_tolerance || cc->cwnd < cc->ssthresh || state->random_loss.qortt == 0 ||
+        loss->rtt.minimum == UINT32_MAX || state->epoch_start == 0 || isnan(state->k) || state->k <= 0)
+        return;
+
+    if (!state->cc_limited) {
+        cubic_random_loss_reset_observation(state);
+        return;
+    }
+
+    if (state->random_loss.observation_start == 0) {
+        state->random_loss.observation_start = now;
+        state->random_loss.max_smoothed_rtt = loss->rtt.smoothed;
+        return;
+    }
+    if (state->random_loss.max_smoothed_rtt < loss->rtt.smoothed)
+        state->random_loss.max_smoothed_rtt = loss->rtt.smoothed;
+
+    /* After twice the time in which a non-losing CUBIC competitor could have reached the observed queue overflow, failure to
+     * reach half of that queue indicates that the path might have changed. Recalibrate qoRTT by returning to slow start without
+     * resetting CWND. */
+    double interval = 2 * state->k * fast_cbrt((double)state->random_loss.qortt / loss->rtt.minimum) * 1000;
+    if (now - state->random_loss.observation_start < interval)
+        return;
+
+    if (state->random_loss.max_smoothed_rtt < ((double)loss->rtt.minimum + state->random_loss.qortt) / 2) {
+        cubic_random_loss_enter_calibration(cc);
+    } else {
+        state->random_loss.observation_start = now;
+        state->random_loss.max_smoothed_rtt = loss->rtt.smoothed;
+    }
+}
+
 /**
  * Calculates the size of the next ACK interval from the current congestion-control state.
  */
@@ -445,8 +503,36 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
             state->k = NAN;
         }
         uint32_t reference_mtu = cc->normalize_mtu ? QUICLY_CC_REFERENCE_MTU : max_udp_payload_size;
-        cubic_on_acked(state, &cc->cwnd, cc->ssthresh, bytes, cc_limited, loss->rtt.smoothed, now, max_udp_payload_size,
+        /* Advance the ordinary CUBIC trajectory even while accelerating recovery. When the loss is plausibly random, use half the
+         * current relative distance to the pre-loss CWND as the per-ACK growth coefficient, with a 2.5% floor as the distance becomes
+         * small. Otherwise, adopt CUBIC only when it has grown beyond the current CWND. */
+        uint32_t cwnd_before_ack = cc->cwnd, cubic_cwnd = cc->cwnd;
+        cubic_on_acked(state, &cubic_cwnd, cc->ssthresh, bytes, cc_limited, loss->rtt.smoothed, now, max_udp_payload_size,
                        reference_mtu);
+
+        if (cc->random_loss_tolerance && bytes != 0 && cc_limited && state->random_loss.recovery_target != 0 &&
+            state->random_loss.qortt > quicly_u32_add_saturating(loss->rtt.minimum, 10) &&
+            loss->rtt.latest < quicly_u32_add_saturating(loss->rtt.minimum, 2) &&
+            cwnd_before_ack < state->random_loss.recovery_target) {
+            uint32_t distance = state->random_loss.recovery_target - cwnd_before_ack;
+            uint32_t accelerated_increase = (uint64_t)bytes * distance / ((uint64_t)cwnd_before_ack * 2);
+            uint32_t minimum_increase = bytes / 40;
+            if (accelerated_increase < minimum_increase)
+                accelerated_increase = minimum_increase;
+            uint32_t accelerated_cwnd = quicly_u32_add_saturating(cwnd_before_ack, accelerated_increase);
+            if (accelerated_cwnd > state->random_loss.recovery_target)
+                accelerated_cwnd = state->random_loss.recovery_target;
+            cc->cwnd = cubic_cwnd < accelerated_cwnd ? accelerated_cwnd : cubic_cwnd;
+        } else {
+            cc->cwnd = cubic_cwnd < cwnd_before_ack ? cwnd_before_ack : cubic_cwnd;
+        }
+        if (cc->cwnd >= state->random_loss.recovery_target)
+            state->random_loss.recovery_target = 0;
+
+        if (cc_limited)
+            cubic_random_loss_observe_path(cc, loss, now);
+        else
+            cubic_random_loss_reset_observation(state);
         goto Cleanup;
     }
 
@@ -507,7 +593,11 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
         pico_on_acked(cc, loss, 0, cc->recovery_end, (uint32_t)loss->sentmap.bytes_in_flight, 0, next_pn, now,
                       max_udp_payload_size);
 
-    double beta = cc->type == &quicly_cc_type_reno ? QUICLY_BETA_RENO : (bytes == 0 ? QUICLY_BETA_ECN : QUICLY_BETA_LOSS);
+    uint32_t cwnd_at_loss = cc->cwnd;
+    int qortt_observation = cc->type == &quicly_cc_type_cubic && cc->random_loss_tolerance && bytes != 0 && cc->cwnd < cc->ssthresh;
+    int random_loss_recovery = cc->type == &quicly_cc_type_cubic && cc->random_loss_tolerance && bytes != 0 &&
+                               cc->state.pico.cubic.random_loss.qortt != 0 && !qortt_observation;
+    double beta = cc->type == &quicly_cc_type_reno ? QUICLY_BETA_RENO : bytes == 0 ? QUICLY_BETA_ECN : QUICLY_BETA_LOSS;
 
     /* Zero-byte congestion reports are ECN signals, not lost packets. They still enter recovery below, but cannot be undone by
      * late ACKs because no packet was deemed lost. */
@@ -538,6 +628,21 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
     cc->recovery_end = next_pn;
     ++cc->num_loss_episodes;
 
+    if (cc->type == &quicly_cc_type_cubic && cc->random_loss_tolerance) {
+        struct st_quicly_cc_cubic_t *state = &cc->state.pico.cubic;
+        /* A CA packet loss with a qoRTT observation receives the tentative reduction below and sets the recovery cap to the
+         * pre-loss CWND. A loss reached by calibration slow start instead replaces the scalar qoRTT observation. */
+        cubic_random_loss_reset_observation(state);
+        if (random_loss_recovery) {
+            state->random_loss.recovery_target = cwnd_at_loss;
+        } else {
+            state->random_loss.recovery_target = 0;
+        }
+        if (qortt_observation) {
+            state->random_loss.qortt = loss->rtt.latest;
+        }
+    }
+
     /* end of slow start */
     if (cc->cwnd_exiting_slow_start == 0) {
         assert(cc->ssthresh == UINT32_MAX);
@@ -550,7 +655,7 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
 
     /* estimate BDP (usually from CWND before reduction) */
     uint32_t bdp = cc->cwnd;
-    if (cc->num_loss_episodes == 1) {
+    if (cc->num_loss_episodes == 1 && !qortt_observation) {
         if (quicly_cc_is_jumpstart_ack(cc, lost_pn)) {
             bdp = cc->jumpstart.bytes_acked;
         } else if (quicly_cc_rapid_start_is_enabled(&cc->rapid_start)) {
@@ -645,7 +750,9 @@ static void pico_on_late_ack(quicly_cc_t *cc, uint64_t pn, int64_t now)
     if (--cc->state.pico.undo.num_packets_lost != 0)
         return;
 
-    int was_in_startup = cc->state.pico.undo.ssthresh == UINT32_MAX;
+    int was_in_startup = cc->state.pico.undo.ssthresh == UINT32_MAX &&
+                         !(cc->type == &quicly_cc_type_cubic && cc->random_loss_tolerance &&
+                           cc->state.pico.undo.cubic.random_loss.qortt != 0);
     cc->cwnd = cc->state.pico.undo.cwnd;
     cc->ssthresh = cc->state.pico.undo.ssthresh;
     cc->state.pico.bytes_to_mtu_increase = cc->state.pico.undo.bytes_to_mtu_increase;
@@ -697,11 +804,12 @@ static void pico_init_pico_state(quicly_cc_t *cc)
     }
 }
 
-static void pico_reset(quicly_cc_t *cc, quicly_cc_type_t *type, uint32_t initcwnd, int normalize_mtu)
+static void pico_reset(quicly_cc_t *cc, quicly_cc_type_t *type, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance)
 {
     *cc = (quicly_cc_t){
         .type = type,
         .normalize_mtu = normalize_mtu,
+        .random_loss_tolerance = random_loss_tolerance,
         .cwnd = initcwnd,
         .cwnd_initial = initcwnd,
         .cwnd_maximum = initcwnd,
@@ -732,7 +840,7 @@ static int switch_to(quicly_cc_t *cc, quicly_cc_type_t *type)
             cc->type = type;
             pico_init_pico_state(cc);
         } else {
-            pico_reset(cc, type, cc->cwnd_initial, cc->normalize_mtu);
+            pico_reset(cc, type, cc->cwnd_initial, cc->normalize_mtu, cc->random_loss_tolerance);
         }
         return 1;
     }
@@ -768,26 +876,32 @@ static void pico_enable_rapid_start(quicly_cc_t *cc, int64_t now)
 static void cubic_update_cc_limited(quicly_cc_t *cc, int cc_limited, int64_t now)
 {
     cubic_set_cc_limited(&cc->state.pico.cubic, cc_limited, now);
+    if (!cc_limited)
+        cubic_random_loss_reset_observation(&cc->state.pico.cubic);
 }
 
-static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int64_t now)
+static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance,
+                      int64_t now)
 {
-    pico_reset(cc, &quicly_cc_type_pico, initcwnd, normalize_mtu);
+    pico_reset(cc, &quicly_cc_type_pico, initcwnd, normalize_mtu, random_loss_tolerance);
 }
 
-static void reno_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int64_t now)
+static void reno_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance,
+                      int64_t now)
 {
-    pico_reset(cc, &quicly_cc_type_reno, initcwnd, normalize_mtu);
+    pico_reset(cc, &quicly_cc_type_reno, initcwnd, normalize_mtu, random_loss_tolerance);
 }
 
-static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int64_t now)
+static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance,
+                       int64_t now)
 {
-    pico_reset(cc, &quicly_cc_type_cubic, initcwnd, normalize_mtu);
+    pico_reset(cc, &quicly_cc_type_cubic, initcwnd, normalize_mtu, random_loss_tolerance);
 }
 
-static void cuback_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int64_t now)
+static void cuback_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance,
+                        int64_t now)
 {
-    pico_reset(cc, &quicly_cc_type_cuback, initcwnd, normalize_mtu);
+    pico_reset(cc, &quicly_cc_type_cuback, initcwnd, normalize_mtu, random_loss_tolerance);
 }
 
 quicly_cc_type_t quicly_cc_type_pico = {"pico",

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -386,10 +386,24 @@ static int accel_enabled(const quicly_cc_t *cc)
     return cc->random_loss_tolerance && (cc->type == &quicly_cc_type_cubic || cc->type == &quicly_cc_type_cuback);
 }
 
+static float calc_smoothed_rtt_before_latest(const quicly_rtt_t *rtt)
+{
+    return rtt->latest != 0 ? (rtt->smoothed * 8 - rtt->latest) / 7 : rtt->smoothed;
+}
+
 static void accel_reset_observation(struct st_quicly_cc_accelerated_increase_t *state)
 {
     state->observation_start = 0;
     state->max_smoothed_rtt = 0;
+}
+
+static void accel_on_recovery_exit(quicly_cc_t *cc, float smoothed_rtt)
+{
+    struct st_quicly_cc_accelerated_increase_t *state = &cc->state.pico.accel;
+
+    if (!accel_enabled(cc) || cc->recovery_end == 0 || state->full_rtt != 0)
+        return;
+    state->full_rtt = smoothed_rtt;
 }
 
 static void accel_enter_calibration(quicly_cc_t *cc)
@@ -424,7 +438,7 @@ static void accel_observe_path(quicly_cc_t *cc, const quicly_rtt_t *rtt, int cc_
 {
     struct st_quicly_cc_accelerated_increase_t *state = &cc->state.pico.accel;
 
-    if (!accel_enabled(cc) || cc->cwnd < cc->ssthresh || state->qortt == 0 || rtt->minimum == UINT32_MAX)
+    if (!accel_enabled(cc) || cc->cwnd < cc->ssthresh || state->full_rtt == 0 || rtt->minimum == UINT32_MAX)
         return;
 
     if (!cc_limited) {
@@ -446,13 +460,13 @@ static void accel_observe_path(quicly_cc_t *cc, const quicly_rtt_t *rtt, int cc_
         state->max_smoothed_rtt = rtt->smoothed;
 
     /* After twice the time in which a non-losing CUBIC competitor could have reached the observed queue overflow, failure to
-     * reach half of that queue indicates that the path might have changed. Recalibrate qoRTT by returning to slow start without
+     * reach half of that queue indicates that the path might have changed. Recalibrate full_rtt by returning to slow start without
      * resetting CWND. */
-    double interval = 2 * k * fast_cbrt((double)state->qortt / rtt->minimum) * 1000;
+    double interval = 2 * k * fast_cbrt((double)state->full_rtt / rtt->minimum) * 1000;
     if (now - state->observation_start < interval)
         return;
 
-    if (state->max_smoothed_rtt < ((double)rtt->minimum + state->qortt) / 2) {
+    if (state->max_smoothed_rtt < ((double)rtt->minimum + state->full_rtt) / 2) {
         accel_enter_calibration(cc);
     } else {
         state->observation_start = now;
@@ -480,7 +494,7 @@ static double accel_calc_increase_ratio(const quicly_cc_t *cc, const quicly_rtt_
             rtt_threshold = previous_ca_threshold;
     }
 
-    if (!accel_enabled(cc) || state->target_cwnd == 0 || state->qortt <= quicly_u32_add_saturating(rtt->minimum, 10) ||
+    if (!accel_enabled(cc) || state->target_cwnd == 0 || state->full_rtt <= quicly_u32_add_saturating(rtt->minimum, 10) ||
         rtt->latest >= rtt_threshold || cc->cwnd >= accel_calc_cwnd_cap(state))
         return 0;
 
@@ -560,6 +574,10 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
         }
         return;
     }
+
+    /* A recovery entered from calibration slow start can supply multiple RTT samples. Adopt their smoothed result here rather than
+     * retaining the single sample adjacent to the congestion signal. */
+    accel_on_recovery_exit(cc, calc_smoothed_rtt_before_latest(&loss->rtt));
 
     quicly_cc_jumpstart_on_acked(cc, 0, bytes, largest_acked, inflight, next_pn);
 
@@ -649,14 +667,18 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
         return;
     }
 
+    /* A new congestion event beyond recovery_end also closes the preceding recovery, even when no intervening ACK invokes
+     * pico_on_acked. */
+    accel_on_recovery_exit(cc, loss->rtt.smoothed);
+
     /* Rapid Start: if recovery exits and the first CC event is a loss instead of an ack, call `pico_on_acked` to reflect recovery
      * exit to Rapid Start and related states, before entering the next recovery period in the following blocks. */
     if (quicly_cc_rapid_start_is_in_recovery(&cc->rapid_start))
         pico_on_acked(cc, loss, 0, cc->recovery_end, (uint32_t)loss->sentmap.bytes_in_flight, 0, next_pn, now,
                       max_udp_payload_size);
 
-    int qortt_observation = accel_enabled(cc) && bytes != 0 && cc->cwnd < cc->ssthresh;
-    int use_accel = accel_enabled(cc) && bytes != 0 && cc->state.pico.accel.qortt != 0 && !qortt_observation;
+    int full_rtt_observation = accel_enabled(cc) && cc->cwnd < cc->ssthresh;
+    int use_accel = accel_enabled(cc) && bytes != 0 && cc->state.pico.accel.full_rtt != 0 && !full_rtt_observation;
     double beta = cc->type == &quicly_cc_type_reno ? QUICLY_BETA_RENO : bytes == 0 ? QUICLY_BETA_ECN : QUICLY_BETA_LOSS;
 
     /* Zero-byte congestion reports are ECN signals, not lost packets. They still enter recovery below, but cannot be undone by
@@ -695,12 +717,13 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
     }
 
     if (accel_enabled(cc)) {
-        /* A loss reached by calibration slow start replaces the scalar qoRTT observation. The accelerated-increase threshold is
-         * derived from the reduced CWND below. */
+        /* A congestion signal reached by calibration slow start schedules full_rtt to adopt smoothed RTT at recovery exit. Waiting
+         * until then incorporates the recovery's RTT samples and also permits ECN to supply the observation. The accelerated-
+         * increase threshold is derived from the reduced CWND below. */
         accel_reset_observation(&cc->state.pico.accel);
         cc->state.pico.accel.target_cwnd = 0;
-        if (qortt_observation)
-            cc->state.pico.accel.qortt = loss->rtt.latest;
+        if (full_rtt_observation)
+            cc->state.pico.accel.full_rtt = 0;
     }
 
     /* end of slow start */
@@ -757,7 +780,7 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
     if (cc->cwnd < QUICLY_MIN_CWND * max_udp_payload_size)
         cc->cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
 
-    if (qortt_observation || use_accel) {
+    if (full_rtt_observation || use_accel) {
         double target_cwnd = cc->cwnd / QUICLY_BETA_LOSS;
         cc->state.pico.accel.target_cwnd = target_cwnd < UINT32_MAX ? target_cwnd : UINT32_MAX;
     }
@@ -815,7 +838,8 @@ static void pico_on_late_ack(quicly_cc_t *cc, uint64_t pn, int64_t now)
     if (--cc->state.pico.undo.num_packets_lost != 0)
         return;
 
-    int was_in_startup = cc->state.pico.undo.ssthresh == UINT32_MAX && !(accel_enabled(cc) && cc->state.pico.undo.accel.qortt != 0);
+    int was_in_startup =
+        cc->state.pico.undo.ssthresh == UINT32_MAX && !(accel_enabled(cc) && cc->state.pico.undo.accel.full_rtt != 0);
     cc->cwnd = cc->state.pico.undo.cwnd;
     cc->ssthresh = cc->state.pico.undo.ssthresh;
     cc->state.pico.bytes_to_mtu_increase = cc->state.pico.undo.bytes_to_mtu_increase;

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -395,7 +395,7 @@ static void accel_on_recovery_end(struct st_quicly_cc_accelerated_increase_t *st
 {
     if (state->full_rtt == 0) {
         state->full_rtt = smoothed_rtt;
-        state->last_high_rtt_at = now;
+        state->last_high_queue_at = now;
     }
 }
 
@@ -439,13 +439,13 @@ static int accel_recalibrate(struct st_quicly_cc_accelerated_increase_t *state, 
     }
 
     if (rtt->smoothed >= ((double)rtt->minimum + state->full_rtt) / 2) {
-        state->last_high_rtt_at = now;
+        state->last_high_queue_at = now;
         return 0;
     }
 
     /* If the smoothed RTT has remained below half of the observed queue for twice the time in which a non-losing competing flow
-     * following the same CA trajectory could have produced another high-RTT observation, the path might have changed. */
-    if (now - state->last_high_rtt_at < 2 * (int64_t)state->high_rtt_interval)
+     * following the same CA trajectory could have produced another high-queue observation, the path might have changed. */
+    if (now - state->last_high_queue_at < 2 * (int64_t)state->high_rtt_interval)
         return 0;
 
     state->high_rtt_interval = 0;
@@ -650,6 +650,9 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
                          int64_t now, uint32_t max_udp_payload_size)
 {
     quicly_cc__update_ecn_episodes(cc, bytes, lost_pn);
+
+    if (accel_enabled(cc) && bytes == 0)
+        cc->state.pico.accel.last_high_queue_at = now;
 
     /* Nothing to do if loss is in recovery window (modulo when exiting rapid start, in which case CWND is further reduced relative
      * to the number of bytes lost. */

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -392,7 +392,7 @@ static float calc_smoothed_rtt_before_latest(const quicly_rtt_t *rtt)
     return rtt->latest != 0 ? (rtt->smoothed * 8 - rtt->latest) / 7 : rtt->smoothed;
 }
 
-static void accel_on_recovery_end(struct st_quicly_cc_accelerated_increase_t *state, float smoothed_rtt, int64_t now)
+static void accel_on_recovery_end(struct st_quicly_cc_accel_adaptation_t *state, float smoothed_rtt, int64_t now)
 {
     if (state->full_rtt == 0) {
         state->full_rtt = smoothed_rtt;
@@ -400,7 +400,7 @@ static void accel_on_recovery_end(struct st_quicly_cc_accelerated_increase_t *st
     }
 }
 
-static void accel_on_acked(struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt, int recovery_ended,
+static void accel_on_acked(struct st_quicly_cc_accel_adaptation_t *state, const quicly_rtt_t *rtt, int recovery_ended,
                            int64_t now)
 {
     /* A recovery entered from calibration slow start can supply multiple RTT samples. Adopt their smoothed result rather than the
@@ -411,7 +411,7 @@ static void accel_on_acked(struct st_quicly_cc_accelerated_increase_t *state, co
         state->min_rtt_current_period = rtt->latest;
 }
 
-static void accel_on_lost(struct st_quicly_cc_accelerated_increase_t *state, int in_startup)
+static void accel_on_lost(struct st_quicly_cc_accel_adaptation_t *state, int in_startup)
 {
     state->min_rtt_previous_period = state->min_rtt_current_period;
     state->min_rtt_current_period = 0;
@@ -420,7 +420,7 @@ static void accel_on_lost(struct st_quicly_cc_accelerated_increase_t *state, int
         state->full_rtt = 0;
 }
 
-static int accel_recalibrate(struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt, uint32_t cwnd_epoch,
+static int accel_recalibrate(struct st_quicly_cc_accel_adaptation_t *state, const quicly_rtt_t *rtt, uint32_t cwnd_epoch,
                              uint32_t reference_mtu, unsigned flags, int64_t now)
 {
     if ((flags & QUICLY_CC_ACCEL_ADAPTATION_RECALIBRATE) == 0 || state->full_rtt == 0)
@@ -465,7 +465,7 @@ static int accel_recalibrate(struct st_quicly_cc_accelerated_increase_t *state, 
  * The increase ratio is max(2ms / RTT threshold, 2.5%). RTT feedback arrives one round late, therefore, assuming an RTT below
  * 100ms, accelerated increase pauses no later than when 4.5ms of queue is built.
  */
-static double accel_calc_increase_ratio(const struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt,
+static double accel_calc_increase_ratio(const struct st_quicly_cc_accel_adaptation_t *state, const quicly_rtt_t *rtt,
                                         unsigned flags)
 {
     /* Skip during initial slow start. */
@@ -494,7 +494,7 @@ static double accel_calc_increase_ratio(const struct st_quicly_cc_accelerated_in
     return ratio;
 }
 
-static uint32_t accel_calc_cubic_cwnd(const struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt,
+static uint32_t accel_calc_cubic_cwnd(const struct st_quicly_cc_accel_adaptation_t *state, const quicly_rtt_t *rtt,
                                       uint32_t cwnd, uint32_t bytes, unsigned flags)
 {
     double ratio = accel_calc_increase_ratio(state, rtt, flags);
@@ -505,7 +505,7 @@ static uint32_t accel_calc_cubic_cwnd(const struct st_quicly_cc_accelerated_incr
     return increased_cwnd < UINT32_MAX ? (uint32_t)increased_cwnd : UINT32_MAX;
 }
 
-static uint32_t accel_bytes_per_mtu_increase(const struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt,
+static uint32_t accel_bytes_per_mtu_increase(const struct st_quicly_cc_accel_adaptation_t *state, const quicly_rtt_t *rtt,
                                              uint32_t mtu, unsigned flags)
 {
     double ratio = accel_calc_increase_ratio(state, rtt, flags);
@@ -871,7 +871,7 @@ static void pico_init_pico_state(quicly_cc_t *cc)
 {
     /* Initialize the state overlaid by each policy implemented in this file. */
     cc->state.pico.bytes_to_mtu_increase = 0;
-    cc->state.pico.accel = (struct st_quicly_cc_accelerated_increase_t){0};
+    cc->state.pico.accel = (struct st_quicly_cc_accel_adaptation_t){0};
     if (cc->type == &quicly_cc_type_cuback) {
         cc->state.pico.cuback = (struct st_quicly_cc_cuback_t){0};
     } else if (cc->type == &quicly_cc_type_cubic) {

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -383,7 +383,8 @@ static void cubic_on_congestion(struct st_quicly_cc_cubic_t *state, uint32_t cwn
 
 static int accel_enabled(const quicly_cc_t *cc)
 {
-    return cc->random_loss_tolerance && (cc->type == &quicly_cc_type_cubic || cc->type == &quicly_cc_type_cuback);
+    return cc->accel_adaptation != 0 &&
+           (cc->type == &quicly_cc_type_cubic || cc->type == &quicly_cc_type_cuback);
 }
 
 static float calc_smoothed_rtt_before_latest(const quicly_rtt_t *rtt)
@@ -420,9 +421,9 @@ static void accel_on_lost(struct st_quicly_cc_accelerated_increase_t *state, int
 }
 
 static int accel_recalibrate(struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt, uint32_t cwnd_epoch,
-                             uint32_t reference_mtu, int64_t now)
+                             uint32_t reference_mtu, unsigned flags, int64_t now)
 {
-    if (state->full_rtt == 0)
+    if ((flags & QUICLY_CC_ACCEL_ADAPTATION_RECALIBRATE) == 0 || state->full_rtt == 0)
         return 0;
 
     if (state->high_rtt_interval == 0) {
@@ -455,7 +456,8 @@ static int accel_recalibrate(struct st_quicly_cc_accelerated_increase_t *state, 
 /**
  * Calculates the accelerated increase ratio. Accelerated increase is used when the queue might have become empty and also has the
  * capacity to grow; specifically when the latest RTT satisfies all of the following conditions:
- * - fullRTT is more than 10ms above minRTT and more than 5% above the latest RTT;
+ * - fullRTT is more than 10ms above minRTT and more than 5% above the latest RTT, unless
+ *   `QUICLY_CC_ACCEL_ADAPTATION_INCREASE_ALWAYS` is set;
  * - the latest RTT is below a threshold derived from the preceding and current periods:
  *   - use (minRTT + previous-period minimum) / 2 to make sure that RTT is being driven down, but do not set the threshold below
  *     minRTT + 2ms;
@@ -463,15 +465,16 @@ static int accel_recalibrate(struct st_quicly_cc_accelerated_increase_t *state, 
  * The increase ratio is max(2ms / RTT threshold, 2.5%). RTT feedback arrives one round late, therefore, assuming an RTT below
  * 100ms, accelerated increase pauses no later than when 4.5ms of queue is built.
  */
-static double accel_calc_increase_ratio(const struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt)
+static double accel_calc_increase_ratio(const struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt,
+                                        unsigned flags)
 {
     /* Skip during initial slow start. */
     if (state->min_rtt_previous_period == 0)
         return 0;
 
     /* Skip if the queue might be too shallow. */
-    if (state->full_rtt <= quicly_u32_add_saturating(rtt->minimum, 10) ||
-        (double)rtt->latest * 1.05 >= state->full_rtt)
+    if ((flags & QUICLY_CC_ACCEL_ADAPTATION_INCREASE_ALWAYS) == 0 &&
+        (state->full_rtt <= quicly_u32_add_saturating(rtt->minimum, 10) || (double)rtt->latest * 1.05 >= state->full_rtt))
         return 0;
 
     uint32_t rtt_threshold = (uint32_t)(((uint64_t)rtt->minimum + state->min_rtt_previous_period) / 2);
@@ -492,9 +495,9 @@ static double accel_calc_increase_ratio(const struct st_quicly_cc_accelerated_in
 }
 
 static uint32_t accel_calc_cubic_cwnd(const struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt,
-                                      uint32_t cwnd, uint32_t bytes)
+                                      uint32_t cwnd, uint32_t bytes, unsigned flags)
 {
-    double ratio = accel_calc_increase_ratio(state, rtt);
+    double ratio = accel_calc_increase_ratio(state, rtt, flags);
     if (ratio == 0)
         return cwnd;
 
@@ -503,9 +506,9 @@ static uint32_t accel_calc_cubic_cwnd(const struct st_quicly_cc_accelerated_incr
 }
 
 static uint32_t accel_bytes_per_mtu_increase(const struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt,
-                                             uint32_t mtu)
+                                             uint32_t mtu, unsigned flags)
 {
-    double ratio = accel_calc_increase_ratio(state, rtt);
+    double ratio = accel_calc_increase_ratio(state, rtt, flags);
     if (ratio == 0)
         return UINT32_MAX;
     double bytes = mtu / ratio;
@@ -583,7 +586,8 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
         cubic_on_acked(state, &new_cwnd, cc->ssthresh, bytes, cc_limited, loss->rtt.smoothed, now, max_udp_payload_size,
                        reference_mtu);
         if (accel_enabled(cc) && bytes != 0 && cc_limited) {
-            uint32_t accelerated_cwnd = accel_calc_cubic_cwnd(&cc->state.pico.accel, &loss->rtt, cc->cwnd, bytes);
+            uint32_t accelerated_cwnd =
+                accel_calc_cubic_cwnd(&cc->state.pico.accel, &loss->rtt, cc->cwnd, bytes, cc->accel_adaptation);
             if (new_cwnd < accelerated_cwnd)
                 new_cwnd = accelerated_cwnd;
         }
@@ -610,7 +614,8 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
         if (cc->state.pico.bytes_to_mtu_increase == 0)
             cc->state.pico.bytes_to_mtu_increase = calc_bytes_per_mtu_increase(cc, loss, max_udp_payload_size);
         if (accel_enabled(cc)) {
-            uint32_t accel_bytes = accel_bytes_per_mtu_increase(&cc->state.pico.accel, &loss->rtt, max_udp_payload_size);
+            uint32_t accel_bytes =
+                accel_bytes_per_mtu_increase(&cc->state.pico.accel, &loss->rtt, max_udp_payload_size, cc->accel_adaptation);
             if (cc->state.pico.bytes_to_mtu_increase > accel_bytes)
                 cc->state.pico.bytes_to_mtu_increase = accel_bytes;
         }
@@ -629,7 +634,7 @@ Cleanup:
      * and return to unbounded slow start to recalibrate full_rtt. */
     if (accel_enabled(cc) && cc->cwnd >= cc->ssthresh && cc_limited &&
         accel_recalibrate(&cc->state.pico.accel, &loss->rtt, cc->ssthresh,
-                          cc->normalize_mtu ? QUICLY_CC_REFERENCE_MTU : max_udp_payload_size, now)) {
+                          cc->normalize_mtu ? QUICLY_CC_REFERENCE_MTU : max_udp_payload_size, cc->accel_adaptation, now)) {
         if (cc->type == &quicly_cc_type_cubic) {
             cc->state.pico.cubic = (struct st_quicly_cc_cubic_t){.k = NAN, .cc_limited = 1};
         } else {
@@ -878,12 +883,12 @@ static void pico_init_pico_state(quicly_cc_t *cc)
     }
 }
 
-static void pico_reset(quicly_cc_t *cc, quicly_cc_type_t *type, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance)
+static void pico_reset(quicly_cc_t *cc, quicly_cc_type_t *type, uint32_t initcwnd, int normalize_mtu, unsigned accel_adaptation)
 {
     *cc = (quicly_cc_t){
         .type = type,
         .normalize_mtu = normalize_mtu,
-        .random_loss_tolerance = random_loss_tolerance,
+        .accel_adaptation = accel_adaptation,
         .cwnd = initcwnd,
         .cwnd_initial = initcwnd,
         .cwnd_maximum = initcwnd,
@@ -914,7 +919,7 @@ static int switch_to(quicly_cc_t *cc, quicly_cc_type_t *type)
             cc->type = type;
             pico_init_pico_state(cc);
         } else {
-            pico_reset(cc, type, cc->cwnd_initial, cc->normalize_mtu, cc->random_loss_tolerance);
+            pico_reset(cc, type, cc->cwnd_initial, cc->normalize_mtu, cc->accel_adaptation);
         }
         return 1;
     }
@@ -952,28 +957,28 @@ static void cubic_update_cc_limited(quicly_cc_t *cc, int cc_limited, int64_t now
     cubic_set_cc_limited(&cc->state.pico.cubic, cc_limited, now);
 }
 
-static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance,
+static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, unsigned accel_adaptation,
                       int64_t now)
 {
-    pico_reset(cc, &quicly_cc_type_pico, initcwnd, normalize_mtu, random_loss_tolerance);
+    pico_reset(cc, &quicly_cc_type_pico, initcwnd, normalize_mtu, accel_adaptation);
 }
 
-static void reno_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance,
+static void reno_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, unsigned accel_adaptation,
                       int64_t now)
 {
-    pico_reset(cc, &quicly_cc_type_reno, initcwnd, normalize_mtu, random_loss_tolerance);
+    pico_reset(cc, &quicly_cc_type_reno, initcwnd, normalize_mtu, accel_adaptation);
 }
 
-static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance,
+static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, unsigned accel_adaptation,
                        int64_t now)
 {
-    pico_reset(cc, &quicly_cc_type_cubic, initcwnd, normalize_mtu, random_loss_tolerance);
+    pico_reset(cc, &quicly_cc_type_cubic, initcwnd, normalize_mtu, accel_adaptation);
 }
 
-static void cuback_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance,
+static void cuback_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, unsigned accel_adaptation,
                         int64_t now)
 {
-    pico_reset(cc, &quicly_cc_type_cuback, initcwnd, normalize_mtu, random_loss_tolerance);
+    pico_reset(cc, &quicly_cc_type_cuback, initcwnd, normalize_mtu, accel_adaptation);
 }
 
 quicly_cc_type_t quicly_cc_type_pico = {"pico",

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -397,13 +397,10 @@ static void accel_reset_observation(struct st_quicly_cc_accelerated_increase_t *
     state->max_smoothed_rtt = 0;
 }
 
-static void accel_on_recovery_exit(quicly_cc_t *cc, float smoothed_rtt)
+static void accel_on_recovery_end(struct st_quicly_cc_accelerated_increase_t *state, float smoothed_rtt)
 {
-    struct st_quicly_cc_accelerated_increase_t *state = &cc->state.pico.accel;
-
-    if (!accel_enabled(cc) || cc->recovery_end == 0 || state->full_rtt != 0)
-        return;
-    state->full_rtt = smoothed_rtt;
+    if (state->full_rtt == 0)
+        state->full_rtt = smoothed_rtt;
 }
 
 static void accel_enter_calibration(quicly_cc_t *cc)
@@ -584,7 +581,8 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
 
     /* A recovery entered from calibration slow start can supply multiple RTT samples. Adopt their smoothed result here rather than
      * retaining the single sample adjacent to the congestion signal. */
-    accel_on_recovery_exit(cc, calc_smoothed_rtt_before_latest(&loss->rtt));
+    if (accel_enabled(cc) && cc->recovery_end != 0)
+        accel_on_recovery_end(&cc->state.pico.accel, calc_smoothed_rtt_before_latest(&loss->rtt));
 
     quicly_cc_jumpstart_on_acked(cc, 0, bytes, largest_acked, inflight, next_pn);
 
@@ -676,7 +674,8 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
 
     /* A new congestion event beyond recovery_end also closes the preceding recovery, even when no intervening ACK invokes
      * pico_on_acked. */
-    accel_on_recovery_exit(cc, loss->rtt.smoothed);
+    if (accel_enabled(cc) && cc->recovery_end != 0)
+        accel_on_recovery_end(&cc->state.pico.accel, loss->rtt.smoothed);
 
     /* Rapid Start: if recovery exits and the first CC event is a loss instead of an ack, call `pico_on_acked` to reflect recovery
      * exit to Rapid Start and related states, before entering the next recovery period in the following blocks. */

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -455,8 +455,7 @@ static int accel_recalibrate(struct st_quicly_cc_accelerated_increase_t *state, 
 /**
  * Calculates the accelerated increase ratio. Accelerated increase is used when the queue might have become empty and also has the
  * capacity to grow; specifically when the latest RTT satisfies all of the following conditions:
- * - fullRTT is more than 10ms above minRTT;
- * - the latest RTT is at least 5% below fullRTT;
+ * - fullRTT is more than 10ms above minRTT and more than 5% above the latest RTT;
  * - the latest RTT is below a threshold derived from the preceding and current periods:
  *   - use (minRTT + previous-period minimum) / 2 to make sure that RTT is being driven down, but do not set the threshold below
  *     minRTT + 2ms;
@@ -724,7 +723,7 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
 
     /* estimate BDP (usually from CWND before reduction) */
     uint32_t bdp = cc->cwnd;
-    if (cc->num_loss_episodes == 1) {
+    if (cc->ssthresh == UINT32_MAX) {
         if (quicly_cc_is_jumpstart_ack(cc, lost_pn)) {
             bdp = cc->jumpstart.bytes_acked;
         } else if (quicly_cc_rapid_start_is_enabled(&cc->rapid_start)) {
@@ -826,7 +825,10 @@ static void pico_on_late_ack(quicly_cc_t *cc, uint64_t pn, int64_t now)
     cc->cwnd = cc->state.pico.undo.cwnd;
     cc->ssthresh = cc->state.pico.undo.ssthresh;
     cc->state.pico.bytes_to_mtu_increase = cc->state.pico.undo.bytes_to_mtu_increase;
+    /* `last_high_queue_at` is a pure observation rather than a reaction being retracted, therefore it is never undone */
+    int64_t last_high_queue_at = cc->state.pico.accel.last_high_queue_at;
     cc->state.pico.accel = cc->state.pico.undo.accel;
+    cc->state.pico.accel.last_high_queue_at = last_high_queue_at;
     if (cc->type == &quicly_cc_type_cuback) {
         cc->state.pico.cuback = cc->state.pico.undo.cuback;
     } else if (cc->type == &quicly_cc_type_cubic) {
@@ -945,13 +947,9 @@ static void pico_enable_rapid_start(quicly_cc_t *cc, int64_t now)
     quicly_cc_init_rapid_start(&cc->rapid_start, now);
 }
 
-static void pico_update_cc_limited(quicly_cc_t *cc, int cc_limited, int64_t now)
+static void cubic_update_cc_limited(quicly_cc_t *cc, int cc_limited, int64_t now)
 {
-    if (cc->type == &quicly_cc_type_cubic) {
-        cubic_set_cc_limited(&cc->state.pico.cubic, cc_limited, now);
-    } else {
-        assert(cc->type == &quicly_cc_type_cuback);
-    }
+    cubic_set_cc_limited(&cc->state.pico.cubic, cc_limited, now);
 }
 
 static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance,
@@ -1012,7 +1010,7 @@ quicly_cc_type_t quicly_cc_type_cubic = {"cubic",
                                          pico_on_late_ack,
                                          quicly_cc_jumpstart_enter,
                                          pico_enable_rapid_start,
-                                         pico_update_cc_limited};
+                                         cubic_update_cc_limited};
 quicly_init_cc_t quicly_cc_cubic_init = {cubic_init};
 
 quicly_cc_type_t quicly_cc_type_cuback = {"cuback",
@@ -1024,8 +1022,7 @@ quicly_cc_type_t quicly_cc_type_cuback = {"cuback",
                                           cuback_on_switch,
                                           pico_on_late_ack,
                                           quicly_cc_jumpstart_enter,
-                                          pico_enable_rapid_start,
-                                          pico_update_cc_limited};
+                                          pico_enable_rapid_start};
 quicly_init_cc_t quicly_cc_cuback_init = {cuback_init};
 
 quicly_cc_type_t *quicly_cc_all_types[] = {&quicly_cc_type_reno, &quicly_cc_type_cubic,  &quicly_cc_type_cubic_legacy,

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -381,62 +381,117 @@ static void cubic_on_congestion(struct st_quicly_cc_cubic_t *state, uint32_t cwn
     state->cwnd_prior = cwnd_prior;
 }
 
-static void cubic_random_loss_reset_observation(struct st_quicly_cc_cubic_t *state)
+static int accel_enabled(const quicly_cc_t *cc)
 {
-    state->random_loss.observation_start = 0;
-    state->random_loss.max_smoothed_rtt = 0;
+    return cc->random_loss_tolerance && (cc->type == &quicly_cc_type_cubic || cc->type == &quicly_cc_type_cuback);
 }
 
-static void cubic_random_loss_enter_calibration(quicly_cc_t *cc)
+static void accel_reset_observation(struct st_quicly_cc_accelerated_increase_t *state)
 {
-    struct st_quicly_cc_cubic_t *state = &cc->state.pico.cubic;
+    state->observation_start = 0;
+    state->max_smoothed_rtt = 0;
+}
 
-    state->w_est = 0;
-    state->epoch_start = 0;
-    state->k = NAN;
-    state->cwnd_prior = 0;
-    state->fast_convergence = 0;
-    state->by_ecn = 0;
-    state->random_loss.recovery_target = 0;
-    cubic_random_loss_reset_observation(state);
+static void accel_enter_calibration(quicly_cc_t *cc)
+{
+    if (cc->type == &quicly_cc_type_cubic) {
+        cc->state.pico.cubic = (struct st_quicly_cc_cubic_t){.k = NAN, .cc_limited = 1};
+    } else {
+        assert(cc->type == &quicly_cc_type_cuback);
+        cc->state.pico.cuback = (struct st_quicly_cc_cuback_t){0};
+    }
+    cc->state.pico.accel.target_cwnd = 0;
+    accel_reset_observation(&cc->state.pico.accel);
     cc->state.pico.bytes_to_mtu_increase = 0;
     cc->ssthresh = UINT32_MAX;
 }
 
-static void cubic_random_loss_observe_path(quicly_cc_t *cc, const quicly_loss_t *loss, int64_t now)
+static double accel_calc_k(const quicly_cc_t *cc, uint32_t reference_mtu)
 {
-    struct st_quicly_cc_cubic_t *state = &cc->state.pico.cubic;
+    if (cc->type == &quicly_cc_type_cubic) {
+        const struct st_quicly_cc_cubic_t *state = &cc->state.pico.cubic;
+        return state->epoch_start != 0 && !isnan(state->k) ? state->k : 0;
+    } else {
+        assert(cc->type == &quicly_cc_type_cuback);
+        const struct st_quicly_cc_cuback_t *state = &cc->state.pico.cuback;
+        double w_max = state->fast_convergence ? cubic_fast_convergence_w_max(state->cwnd_prior, cc->ssthresh) : state->cwnd_prior;
+        return w_max > cc->ssthresh ? fast_cbrt((w_max - cc->ssthresh) / (QUICLY_CUBIC_C * reference_mtu)) : 0;
+    }
+}
 
-    if (!cc->random_loss_tolerance || cc->cwnd < cc->ssthresh || state->random_loss.qortt == 0 ||
-        loss->rtt.minimum == UINT32_MAX || state->epoch_start == 0 || isnan(state->k) || state->k <= 0)
+static void accel_observe_path(quicly_cc_t *cc, const quicly_rtt_t *rtt, int cc_limited, int64_t now,
+                               uint32_t max_udp_payload_size)
+{
+    struct st_quicly_cc_accelerated_increase_t *state = &cc->state.pico.accel;
+
+    if (!accel_enabled(cc) || cc->cwnd < cc->ssthresh || state->qortt == 0 || rtt->minimum == UINT32_MAX)
         return;
 
-    if (!state->cc_limited) {
-        cubic_random_loss_reset_observation(state);
+    if (!cc_limited) {
+        accel_reset_observation(state);
         return;
     }
 
-    if (state->random_loss.observation_start == 0) {
-        state->random_loss.observation_start = now;
-        state->random_loss.max_smoothed_rtt = loss->rtt.smoothed;
+    uint32_t reference_mtu = cc->normalize_mtu ? QUICLY_CC_REFERENCE_MTU : max_udp_payload_size;
+    double k = accel_calc_k(cc, reference_mtu);
+    if (k <= 0)
+        return;
+
+    if (state->observation_start == 0) {
+        state->observation_start = now;
+        state->max_smoothed_rtt = rtt->smoothed;
         return;
     }
-    if (state->random_loss.max_smoothed_rtt < loss->rtt.smoothed)
-        state->random_loss.max_smoothed_rtt = loss->rtt.smoothed;
+    if (state->max_smoothed_rtt < rtt->smoothed)
+        state->max_smoothed_rtt = rtt->smoothed;
 
     /* After twice the time in which a non-losing CUBIC competitor could have reached the observed queue overflow, failure to
      * reach half of that queue indicates that the path might have changed. Recalibrate qoRTT by returning to slow start without
      * resetting CWND. */
-    double interval = 2 * state->k * fast_cbrt((double)state->random_loss.qortt / loss->rtt.minimum) * 1000;
-    if (now - state->random_loss.observation_start < interval)
+    double interval = 2 * k * fast_cbrt((double)state->qortt / rtt->minimum) * 1000;
+    if (now - state->observation_start < interval)
         return;
 
-    if (state->random_loss.max_smoothed_rtt < ((double)loss->rtt.minimum + state->random_loss.qortt) / 2) {
-        cubic_random_loss_enter_calibration(cc);
+    if (state->max_smoothed_rtt < ((double)rtt->minimum + state->qortt) / 2) {
+        accel_enter_calibration(cc);
     } else {
-        state->random_loss.observation_start = now;
-        state->random_loss.max_smoothed_rtt = loss->rtt.smoothed;
+        state->observation_start = now;
+        state->max_smoothed_rtt = rtt->smoothed;
     }
+}
+
+static double accel_calc_increase_ratio(const quicly_cc_t *cc, const quicly_rtt_t *rtt)
+{
+    const struct st_quicly_cc_accelerated_increase_t *state = &cc->state.pico.accel;
+
+    if (!accel_enabled(cc) || state->target_cwnd == 0 || state->qortt <= quicly_u32_add_saturating(rtt->minimum, 10) ||
+        rtt->latest >= quicly_u32_add_saturating(rtt->minimum, 2) || cc->cwnd >= state->target_cwnd)
+        return 0;
+
+    double ratio = (double)(state->target_cwnd - cc->cwnd) / ((double)cc->cwnd * 2);
+    return ratio < 1. / 40 ? 1. / 40 : ratio;
+}
+
+static uint32_t accel_calc_cubic_cwnd(const quicly_cc_t *cc, const quicly_rtt_t *rtt, uint32_t bytes, int cc_limited)
+{
+    if (bytes == 0 || !cc_limited)
+        return cc->cwnd;
+
+    double ratio = accel_calc_increase_ratio(cc, rtt);
+    if (ratio == 0)
+        return cc->cwnd;
+
+    double cwnd = cc->cwnd + bytes * ratio;
+    return cwnd < cc->state.pico.accel.target_cwnd ? (uint32_t)cwnd : cc->state.pico.accel.target_cwnd;
+}
+
+static uint32_t accel_bytes_per_mtu_increase(const quicly_cc_t *cc, const quicly_rtt_t *rtt, uint32_t mtu)
+{
+    double ratio = accel_calc_increase_ratio(cc, rtt);
+    if (ratio == 0)
+        return UINT32_MAX;
+    double bytes = mtu / ratio;
+    return bytes < 1 ? 1 : bytes > UINT32_MAX ? UINT32_MAX : (uint32_t)bytes;
 }
 
 /**
@@ -503,36 +558,12 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
             state->k = NAN;
         }
         uint32_t reference_mtu = cc->normalize_mtu ? QUICLY_CC_REFERENCE_MTU : max_udp_payload_size;
-        /* Advance the ordinary CUBIC trajectory even while accelerating recovery. When the loss is plausibly random, use half the
-         * current relative distance to the pre-loss CWND as the per-ACK growth coefficient, with a 2.5% floor as the distance becomes
-         * small. Otherwise, adopt CUBIC only when it has grown beyond the current CWND. */
-        uint32_t cwnd_before_ack = cc->cwnd, cubic_cwnd = cc->cwnd;
+        /* Advance the ordinary CUBIC trajectory even while accelerating increase, then adopt whichever CWND is greater. */
+        uint32_t accelerated_cwnd = accel_calc_cubic_cwnd(cc, &loss->rtt, bytes, cc_limited);
+        uint32_t cubic_cwnd = cc->cwnd;
         cubic_on_acked(state, &cubic_cwnd, cc->ssthresh, bytes, cc_limited, loss->rtt.smoothed, now, max_udp_payload_size,
                        reference_mtu);
-
-        if (cc->random_loss_tolerance && bytes != 0 && cc_limited && state->random_loss.recovery_target != 0 &&
-            state->random_loss.qortt > quicly_u32_add_saturating(loss->rtt.minimum, 10) &&
-            loss->rtt.latest < quicly_u32_add_saturating(loss->rtt.minimum, 2) &&
-            cwnd_before_ack < state->random_loss.recovery_target) {
-            uint32_t distance = state->random_loss.recovery_target - cwnd_before_ack;
-            uint32_t accelerated_increase = (uint64_t)bytes * distance / ((uint64_t)cwnd_before_ack * 2);
-            uint32_t minimum_increase = bytes / 40;
-            if (accelerated_increase < minimum_increase)
-                accelerated_increase = minimum_increase;
-            uint32_t accelerated_cwnd = quicly_u32_add_saturating(cwnd_before_ack, accelerated_increase);
-            if (accelerated_cwnd > state->random_loss.recovery_target)
-                accelerated_cwnd = state->random_loss.recovery_target;
-            cc->cwnd = cubic_cwnd < accelerated_cwnd ? accelerated_cwnd : cubic_cwnd;
-        } else {
-            cc->cwnd = cubic_cwnd < cwnd_before_ack ? cwnd_before_ack : cubic_cwnd;
-        }
-        if (cc->cwnd >= state->random_loss.recovery_target)
-            state->random_loss.recovery_target = 0;
-
-        if (cc_limited)
-            cubic_random_loss_observe_path(cc, loss, now);
-        else
-            cubic_random_loss_reset_observation(state);
+        cc->cwnd = cubic_cwnd < accelerated_cwnd ? accelerated_cwnd : cubic_cwnd;
         goto Cleanup;
     }
 
@@ -551,17 +582,25 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
 
     /* Apply this ACK to the current interval. One ACK can span multiple intervals. */
     uint32_t bytes_available = bytes;
-    if (cc->state.pico.bytes_to_mtu_increase == 0)
-        cc->state.pico.bytes_to_mtu_increase = calc_bytes_per_mtu_increase(cc, loss, max_udp_payload_size);
-    while (bytes_available >= cc->state.pico.bytes_to_mtu_increase) {
+    while (1) {
+        if (cc->state.pico.bytes_to_mtu_increase == 0)
+            cc->state.pico.bytes_to_mtu_increase = calc_bytes_per_mtu_increase(cc, loss, max_udp_payload_size);
+        /* An ACK interval is the inverse of the increase rate; choosing the shorter interval is therefore equivalent to choosing
+         * the greater of the ordinary increase and accelerated increase. */
+        uint32_t accel_bytes = accel_bytes_per_mtu_increase(cc, &loss->rtt, max_udp_payload_size);
+        if (cc->state.pico.bytes_to_mtu_increase > accel_bytes)
+            cc->state.pico.bytes_to_mtu_increase = accel_bytes;
+        if (bytes_available < cc->state.pico.bytes_to_mtu_increase)
+            break;
         bytes_available -= cc->state.pico.bytes_to_mtu_increase;
         cc->cwnd = quicly_u32_add_saturating(cc->cwnd, max_udp_payload_size);
-        cc->state.pico.bytes_to_mtu_increase = calc_bytes_per_mtu_increase(cc, loss, max_udp_payload_size);
+        cc->state.pico.bytes_to_mtu_increase = 0;
     }
     cc->state.pico.bytes_to_mtu_increase -= bytes_available;
     assert(cc->state.pico.bytes_to_mtu_increase != 0);
 
 Cleanup:
+    accel_observe_path(cc, &loss->rtt, cc_limited, now, max_udp_payload_size);
     if (cc->cwnd_maximum < cc->cwnd)
         cc->cwnd_maximum = cc->cwnd;
     if (quicly_cc_rapid_start_is_in_recovery(&cc->rapid_start))
@@ -593,9 +632,8 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
         pico_on_acked(cc, loss, 0, cc->recovery_end, (uint32_t)loss->sentmap.bytes_in_flight, 0, next_pn, now,
                       max_udp_payload_size);
 
-    int qortt_observation = cc->type == &quicly_cc_type_cubic && cc->random_loss_tolerance && bytes != 0 && cc->cwnd < cc->ssthresh;
-    int random_loss_recovery = cc->type == &quicly_cc_type_cubic && cc->random_loss_tolerance && bytes != 0 &&
-                               cc->state.pico.cubic.random_loss.qortt != 0 && !qortt_observation;
+    int qortt_observation = accel_enabled(cc) && bytes != 0 && cc->cwnd < cc->ssthresh;
+    int use_accel = accel_enabled(cc) && bytes != 0 && cc->state.pico.accel.qortt != 0 && !qortt_observation;
     double beta = cc->type == &quicly_cc_type_reno ? QUICLY_BETA_RENO : bytes == 0 ? QUICLY_BETA_ECN : QUICLY_BETA_LOSS;
 
     /* Zero-byte congestion reports are ECN signals, not lost packets. They still enter recovery below, but cannot be undone by
@@ -611,6 +649,7 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
         }
         cc->state.pico.undo.ssthresh = cc->ssthresh;
         cc->state.pico.undo.bytes_to_mtu_increase = cc->state.pico.bytes_to_mtu_increase;
+        cc->state.pico.undo.accel = cc->state.pico.accel;
         if (cc->type == &quicly_cc_type_cuback) {
             cc->state.pico.undo.cuback = cc->state.pico.cuback;
         } else if (cc->type == &quicly_cc_type_cubic) {
@@ -627,15 +666,13 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
     cc->recovery_end = next_pn;
     ++cc->num_loss_episodes;
 
-    if (cc->type == &quicly_cc_type_cubic && cc->random_loss_tolerance) {
-        struct st_quicly_cc_cubic_t *state = &cc->state.pico.cubic;
-        /* A loss reached by calibration slow start replaces the scalar qoRTT observation. The accelerated recovery threshold is
+    if (accel_enabled(cc)) {
+        /* A loss reached by calibration slow start replaces the scalar qoRTT observation. The accelerated-increase threshold is
          * derived from the reduced CWND below. */
-        cubic_random_loss_reset_observation(state);
-        state->random_loss.recovery_target = 0;
-        if (qortt_observation) {
-            state->random_loss.qortt = loss->rtt.latest;
-        }
+        accel_reset_observation(&cc->state.pico.accel);
+        cc->state.pico.accel.target_cwnd = 0;
+        if (qortt_observation)
+            cc->state.pico.accel.qortt = loss->rtt.latest;
     }
 
     /* end of slow start */
@@ -692,9 +729,9 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
     if (cc->cwnd < QUICLY_MIN_CWND * max_udp_payload_size)
         cc->cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
 
-    if (qortt_observation || random_loss_recovery) {
-        double recovery_target = cc->cwnd / (beta * beta);
-        cc->state.pico.cubic.random_loss.recovery_target = recovery_target < UINT32_MAX ? recovery_target : UINT32_MAX;
+    if (qortt_observation || use_accel) {
+        double target_cwnd = cc->cwnd / (beta * beta);
+        cc->state.pico.accel.target_cwnd = target_cwnd < UINT32_MAX ? target_cwnd : UINT32_MAX;
     }
 
     /* Update policy-specific state using the estimated BDP and reduced CWND.
@@ -750,12 +787,11 @@ static void pico_on_late_ack(quicly_cc_t *cc, uint64_t pn, int64_t now)
     if (--cc->state.pico.undo.num_packets_lost != 0)
         return;
 
-    int was_in_startup = cc->state.pico.undo.ssthresh == UINT32_MAX &&
-                         !(cc->type == &quicly_cc_type_cubic && cc->random_loss_tolerance &&
-                           cc->state.pico.undo.cubic.random_loss.qortt != 0);
+    int was_in_startup = cc->state.pico.undo.ssthresh == UINT32_MAX && !(accel_enabled(cc) && cc->state.pico.undo.accel.qortt != 0);
     cc->cwnd = cc->state.pico.undo.cwnd;
     cc->ssthresh = cc->state.pico.undo.ssthresh;
     cc->state.pico.bytes_to_mtu_increase = cc->state.pico.undo.bytes_to_mtu_increase;
+    cc->state.pico.accel = cc->state.pico.undo.accel;
     if (cc->type == &quicly_cc_type_cuback) {
         cc->state.pico.cuback = cc->state.pico.undo.cuback;
     } else if (cc->type == &quicly_cc_type_cubic) {
@@ -793,6 +829,7 @@ static void pico_init_pico_state(quicly_cc_t *cc)
 {
     /* Initialize the state overlaid by each policy implemented in this file. */
     cc->state.pico.bytes_to_mtu_increase = 0;
+    cc->state.pico.accel = (struct st_quicly_cc_accelerated_increase_t){0};
     if (cc->type == &quicly_cc_type_cuback) {
         cc->state.pico.cuback = (struct st_quicly_cc_cuback_t){0};
     } else if (cc->type == &quicly_cc_type_cubic) {
@@ -873,11 +910,15 @@ static void pico_enable_rapid_start(quicly_cc_t *cc, int64_t now)
     quicly_cc_init_rapid_start(&cc->rapid_start, now);
 }
 
-static void cubic_update_cc_limited(quicly_cc_t *cc, int cc_limited, int64_t now)
+static void pico_update_cc_limited(quicly_cc_t *cc, int cc_limited, int64_t now)
 {
-    cubic_set_cc_limited(&cc->state.pico.cubic, cc_limited, now);
+    if (cc->type == &quicly_cc_type_cubic) {
+        cubic_set_cc_limited(&cc->state.pico.cubic, cc_limited, now);
+    } else {
+        assert(cc->type == &quicly_cc_type_cuback);
+    }
     if (!cc_limited)
-        cubic_random_loss_reset_observation(&cc->state.pico.cubic);
+        accel_reset_observation(&cc->state.pico.accel);
 }
 
 static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance,
@@ -938,7 +979,7 @@ quicly_cc_type_t quicly_cc_type_cubic = {"cubic",
                                          pico_on_late_ack,
                                          quicly_cc_jumpstart_enter,
                                          pico_enable_rapid_start,
-                                         cubic_update_cc_limited};
+                                         pico_update_cc_limited};
 quicly_init_cc_t quicly_cc_cubic_init = {cubic_init};
 
 quicly_cc_type_t quicly_cc_type_cuback = {"cuback",
@@ -950,7 +991,8 @@ quicly_cc_type_t quicly_cc_type_cuback = {"cuback",
                                           cuback_on_switch,
                                           pico_on_late_ack,
                                           quicly_cc_jumpstart_enter,
-                                          pico_enable_rapid_start};
+                                          pico_enable_rapid_start,
+                                          pico_update_cc_limited};
 quicly_init_cc_t quicly_cc_cuback_init = {cuback_init};
 
 quicly_cc_type_t *quicly_cc_all_types[] = {&quicly_cc_type_reno, &quicly_cc_type_cubic,  &quicly_cc_type_cubic_legacy,

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -460,15 +460,23 @@ static void accel_observe_path(quicly_cc_t *cc, const quicly_rtt_t *rtt, int cc_
     }
 }
 
+static uint32_t accel_calc_cwnd_cap(const struct st_quicly_cc_accelerated_increase_t *state)
+{
+    double cap = state->target_cwnd / QUICLY_BETA_LOSS;
+    return cap < UINT32_MAX ? cap : UINT32_MAX;
+}
+
 static double accel_calc_increase_ratio(const quicly_cc_t *cc, const quicly_rtt_t *rtt)
 {
     const struct st_quicly_cc_accelerated_increase_t *state = &cc->state.pico.accel;
 
     if (!accel_enabled(cc) || state->target_cwnd == 0 || state->qortt <= quicly_u32_add_saturating(rtt->minimum, 10) ||
-        rtt->latest >= quicly_u32_add_saturating(rtt->minimum, 2) || cc->cwnd >= state->target_cwnd)
+        rtt->latest >= quicly_u32_add_saturating(rtt->minimum, 2) || cc->cwnd >= accel_calc_cwnd_cap(state))
         return 0;
 
-    double ratio = (double)(state->target_cwnd - cc->cwnd) / ((double)cc->cwnd * 2);
+    double ratio = cc->cwnd < state->target_cwnd
+                       ? (double)(state->target_cwnd - cc->cwnd) / ((double)cc->cwnd * 2)
+                       : 0;
     return ratio < 1. / 40 ? 1. / 40 : ratio;
 }
 
@@ -482,7 +490,8 @@ static uint32_t accel_calc_cubic_cwnd(const quicly_cc_t *cc, const quicly_rtt_t 
         return cc->cwnd;
 
     double cwnd = cc->cwnd + bytes * ratio;
-    return cwnd < cc->state.pico.accel.target_cwnd ? (uint32_t)cwnd : cc->state.pico.accel.target_cwnd;
+    uint32_t cap = accel_calc_cwnd_cap(&cc->state.pico.accel);
+    return cwnd < cap ? (uint32_t)cwnd : cap;
 }
 
 static uint32_t accel_bytes_per_mtu_increase(const quicly_cc_t *cc, const quicly_rtt_t *rtt, uint32_t mtu)
@@ -730,7 +739,7 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
         cc->cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
 
     if (qortt_observation || use_accel) {
-        double target_cwnd = cc->cwnd / (beta * beta);
+        double target_cwnd = cc->cwnd / QUICLY_BETA_LOSS;
         cc->state.pico.accel.target_cwnd = target_cwnd < UINT32_MAX ? target_cwnd : UINT32_MAX;
     }
 

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -469,9 +469,19 @@ static uint32_t accel_calc_cwnd_cap(const struct st_quicly_cc_accelerated_increa
 static double accel_calc_increase_ratio(const quicly_cc_t *cc, const quicly_rtt_t *rtt)
 {
     const struct st_quicly_cc_accelerated_increase_t *state = &cc->state.pico.accel;
+    uint32_t rtt_threshold = quicly_u32_add_saturating(rtt->minimum, 2);
+
+    if (state->min_rtt_in_previous_ca > rtt->minimum) {
+        /* Accommodate a persistent jitter floor without returning to the minimum RTT seen over the entire connection. Half of the
+         * preceding CA period's excess minimum is allowed, with the existing two-millisecond allowance as the lower bound. */
+        uint32_t previous_ca_threshold =
+            rtt->minimum + (state->min_rtt_in_previous_ca - rtt->minimum) / 2;
+        if (rtt_threshold < previous_ca_threshold)
+            rtt_threshold = previous_ca_threshold;
+    }
 
     if (!accel_enabled(cc) || state->target_cwnd == 0 || state->qortt <= quicly_u32_add_saturating(rtt->minimum, 10) ||
-        rtt->latest >= quicly_u32_add_saturating(rtt->minimum, 2) || cc->cwnd >= accel_calc_cwnd_cap(state))
+        rtt->latest >= rtt_threshold || cc->cwnd >= accel_calc_cwnd_cap(state))
         return 0;
 
     double ratio = cc->cwnd < state->target_cwnd
@@ -552,6 +562,10 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
     }
 
     quicly_cc_jumpstart_on_acked(cc, 0, bytes, largest_acked, inflight, next_pn);
+
+    if (accel_enabled(cc) && cc->cwnd >= cc->ssthresh &&
+        (cc->state.pico.accel.min_rtt_in_ca == 0 || cc->state.pico.accel.min_rtt_in_ca > loss->rtt.latest))
+        cc->state.pico.accel.min_rtt_in_ca = loss->rtt.latest;
 
     /* Cubic: unlike other policies, congestion avoidance cannot be driven by bytes_to_mtu_increase. */
     if (cc->type == &quicly_cc_type_cubic && cc->cwnd >= cc->ssthresh) {
@@ -674,6 +688,11 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
 
     cc->recovery_end = next_pn;
     ++cc->num_loss_episodes;
+
+    if (accel_enabled(cc)) {
+        cc->state.pico.accel.min_rtt_in_previous_ca = cc->state.pico.accel.min_rtt_in_ca;
+        cc->state.pico.accel.min_rtt_in_ca = 0;
+    }
 
     if (accel_enabled(cc)) {
         /* A loss reached by calibration slow start replaces the scalar qoRTT observation. The accelerated-increase threshold is

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -460,11 +460,12 @@ static int accel_recalibrate(struct st_quicly_cc_accel_adaptation_t *state, cons
  *   - use (minRTT + previous-period minimum) / 2 to make sure that RTT is being driven down, but do not set the threshold below
  *     minRTT + 2ms;
  *   - when the current-period minimum is available, cap the threshold at that minimum plus 2ms
- * The increase ratio is max(2ms / RTT threshold, 2.5%). RTT feedback arrives one round late, therefore, assuming an RTT below
- * 100ms, accelerated increase pauses no later than when 4.5ms of queue is built.
+ * The increase ratio is max(2ms / RTT threshold, 2.5%), capped at half the increase that would reverse the latest congestion
+ * reduction over one RTT. RTT feedback arrives one round late, therefore, assuming an RTT below 100ms, accelerated increase
+ * pauses no later than when 4.5ms of queue is built.
  */
 static double accel_calc_increase_ratio(const struct st_quicly_cc_accel_adaptation_t *state, const quicly_rtt_t *rtt,
-                                        unsigned flags)
+                                        unsigned flags, int by_ecn)
 {
     /* Skip during initial slow start. */
     if (state->min_rtt_previous_period == 0)
@@ -488,13 +489,17 @@ static double accel_calc_increase_ratio(const struct st_quicly_cc_accel_adaptati
     double ratio = 2. / rtt_threshold;
     if (ratio < 1. / 40)
         ratio = 1. / 40;
+    double beta = by_ecn ? QUICLY_BETA_ECN : QUICLY_BETA_LOSS;
+    double ratio_limit = (1. / beta - 1) / 2;
+    if (ratio > ratio_limit)
+        ratio = ratio_limit;
     return ratio;
 }
 
 static uint32_t accel_calc_cubic_cwnd(const struct st_quicly_cc_accel_adaptation_t *state, const quicly_rtt_t *rtt, uint32_t cwnd,
-                                      uint32_t bytes, unsigned flags)
+                                      uint32_t bytes, unsigned flags, int by_ecn)
 {
-    double ratio = accel_calc_increase_ratio(state, rtt, flags);
+    double ratio = accel_calc_increase_ratio(state, rtt, flags, by_ecn);
     if (ratio == 0)
         return cwnd;
 
@@ -503,9 +508,9 @@ static uint32_t accel_calc_cubic_cwnd(const struct st_quicly_cc_accel_adaptation
 }
 
 static uint32_t accel_bytes_per_mtu_increase(const struct st_quicly_cc_accel_adaptation_t *state, const quicly_rtt_t *rtt,
-                                             uint32_t mtu, unsigned flags)
+                                             uint32_t mtu, unsigned flags, int by_ecn)
 {
-    double ratio = accel_calc_increase_ratio(state, rtt, flags);
+    double ratio = accel_calc_increase_ratio(state, rtt, flags, by_ecn);
     if (ratio == 0)
         return UINT32_MAX;
     double bytes = mtu / ratio;
@@ -584,7 +589,7 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
                        reference_mtu);
         if (accel_enabled(cc) && bytes != 0 && cc_limited) {
             uint32_t accelerated_cwnd =
-                accel_calc_cubic_cwnd(&cc->state.pico.accel, &loss->rtt, cc->cwnd, bytes, cc->accel_adaptation);
+                accel_calc_cubic_cwnd(&cc->state.pico.accel, &loss->rtt, cc->cwnd, bytes, cc->accel_adaptation, state->by_ecn);
             if (new_cwnd < accelerated_cwnd)
                 new_cwnd = accelerated_cwnd;
         }
@@ -612,7 +617,8 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
             cc->state.pico.bytes_to_mtu_increase = calc_bytes_per_mtu_increase(cc, loss, max_udp_payload_size);
         if (accel_enabled(cc)) {
             uint32_t accel_bytes =
-                accel_bytes_per_mtu_increase(&cc->state.pico.accel, &loss->rtt, max_udp_payload_size, cc->accel_adaptation);
+                accel_bytes_per_mtu_increase(&cc->state.pico.accel, &loss->rtt, max_udp_payload_size, cc->accel_adaptation,
+                                             cc->state.pico.cuback.by_ecn);
             if (cc->state.pico.bytes_to_mtu_increase > accel_bytes)
                 cc->state.pico.bytes_to_mtu_increase = accel_bytes;
         }

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -410,16 +410,13 @@ static void accel_on_acked(struct st_quicly_cc_accelerated_increase_t *state, co
         state->min_rtt_current_period = rtt->latest;
 }
 
-static void accel_on_lost(struct st_quicly_cc_accelerated_increase_t *state, int in_startup, uint32_t cwnd)
+static void accel_on_lost(struct st_quicly_cc_accelerated_increase_t *state, int in_startup)
 {
     state->min_rtt_previous_period = state->min_rtt_current_period;
     state->min_rtt_current_period = 0;
-    state->target_cwnd = 0;
     state->high_rtt_interval = 0;
     if (in_startup)
         state->full_rtt = 0;
-    double target_cwnd = cwnd / QUICLY_BETA_LOSS;
-    state->target_cwnd = target_cwnd < UINT32_MAX ? target_cwnd : UINT32_MAX;
 }
 
 static int accel_recalibrate(struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt, uint32_t cwnd_epoch,
@@ -429,8 +426,8 @@ static int accel_recalibrate(struct st_quicly_cc_accelerated_increase_t *state, 
         return 0;
 
     if (state->high_rtt_interval == 0) {
-        assert(state->target_cwnd > cwnd_epoch);
-        double k = fast_cbrt((state->target_cwnd - cwnd_epoch) / (QUICLY_CUBIC_C * reference_mtu));
+        double cwnd_before_reduction = cwnd_epoch / QUICLY_BETA_LOSS;
+        double k = fast_cbrt((cwnd_before_reduction - cwnd_epoch) / (QUICLY_CUBIC_C * reference_mtu));
 
         /* Both policies follow the greater of their cubic and Reno-friendly windows. K implies a window gap of C * K^3 * MTU,
          * hence the Reno-friendly curve covers the gap in C * K^3 / alpha round trips. Use the ordinary-loss alpha because the
@@ -451,67 +448,65 @@ static int accel_recalibrate(struct st_quicly_cc_accelerated_increase_t *state, 
     if (now - state->last_high_rtt_at < 2 * (int64_t)state->high_rtt_interval)
         return 0;
 
-    state->target_cwnd = 0;
     state->high_rtt_interval = 0;
     return 1;
 }
 
-static uint32_t accel_calc_cwnd_cap(const struct st_quicly_cc_accelerated_increase_t *state)
+/**
+ * Calculates the accelerated increase ratio. Accelerated increase is used when the queue might have become empty and also has the
+ * capacity to grow; specifically when the latest RTT satisfies all of the following conditions:
+ * - fullRTT is more than 10ms above minRTT;
+ * - the latest RTT is at least 5% below fullRTT;
+ * - the latest RTT is below a threshold derived from the preceding and current periods:
+ *   - use (minRTT + previous-period minimum) / 2 to make sure that RTT is being driven down, but do not set the threshold below
+ *     minRTT + 2ms;
+ *   - when the current-period minimum is available, cap the threshold at that minimum plus 2ms
+ * The increase ratio is max(2ms / RTT threshold, 2.5%). RTT feedback arrives one round late, therefore, assuming an RTT below
+ * 100ms, accelerated increase pauses no later than when 4.5ms of queue is built.
+ */
+static double accel_calc_increase_ratio(const struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt)
 {
-    double cap = state->target_cwnd / QUICLY_BETA_LOSS;
-    return cap < UINT32_MAX ? cap : UINT32_MAX;
-}
-
-static double accel_calc_increase_ratio(const struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt,
-                                        uint32_t cwnd)
-{
-    uint32_t rtt_threshold = quicly_u32_add_saturating(rtt->minimum, 2);
-
-    if (state->min_rtt_previous_period > rtt->minimum) {
-        /* Accommodate a persistent jitter floor without returning to the minimum RTT seen over the entire connection. Half of the
-         * preceding period's excess minimum is allowed, with the existing two-millisecond allowance as the lower bound. */
-        uint32_t previous_period_threshold =
-            rtt->minimum + (state->min_rtt_previous_period - rtt->minimum) / 2;
-        if (rtt_threshold < previous_period_threshold)
-            rtt_threshold = previous_period_threshold;
-    }
-
-    if (state->target_cwnd == 0 || state->full_rtt <= quicly_u32_add_saturating(rtt->minimum, 10) ||
-        rtt->latest >= rtt_threshold || (double)rtt->latest * 1.05 >= state->full_rtt)
+    /* Skip during initial slow start. */
+    if (state->min_rtt_previous_period == 0)
         return 0;
 
-    double ratio = cwnd < state->target_cwnd ? (double)(state->target_cwnd - cwnd) / ((double)cwnd * 2) : 0;
+    /* Skip if the queue might be too shallow. */
+    if (state->full_rtt <= quicly_u32_add_saturating(rtt->minimum, 10) ||
+        (double)rtt->latest * 1.05 >= state->full_rtt)
+        return 0;
+
+    uint32_t rtt_threshold = (uint32_t)(((uint64_t)rtt->minimum + state->min_rtt_previous_period) / 2);
+    if (rtt_threshold < quicly_u32_add_saturating(rtt->minimum, 2)) {
+        rtt_threshold = quicly_u32_add_saturating(rtt->minimum, 2);
+    } else if (state->min_rtt_current_period != 0 &&
+               rtt_threshold > quicly_u32_add_saturating(state->min_rtt_current_period, 2)) {
+        rtt_threshold = quicly_u32_add_saturating(state->min_rtt_current_period, 2);
+    }
+
+    if (rtt->latest >= rtt_threshold)
+        return 0;
+
+    double ratio = 2. / rtt_threshold;
     if (ratio < 1. / 40)
         ratio = 1. / 40;
-
-    /* Do not consume more than half of the remaining RTT headroom in one RTT. At the five-percent cutoff above, this limit
-     * converges on the minimum acceleration rate of 1/40. */
-    double rtt_ratio = ((double)state->full_rtt / rtt->latest - 1) / 2;
-    return ratio < rtt_ratio ? ratio : rtt_ratio;
+    return ratio;
 }
 
 static uint32_t accel_calc_cubic_cwnd(const struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt,
                                       uint32_t cwnd, uint32_t bytes)
 {
-    uint32_t cap = accel_calc_cwnd_cap(state);
-    if (cwnd >= cap)
-        return cwnd;
-
-    double ratio = accel_calc_increase_ratio(state, rtt, cwnd);
+    double ratio = accel_calc_increase_ratio(state, rtt);
     if (ratio == 0)
         return cwnd;
 
     double increased_cwnd = cwnd + bytes * ratio;
-    return increased_cwnd < cap ? (uint32_t)increased_cwnd : cap;
+    return increased_cwnd < UINT32_MAX ? (uint32_t)increased_cwnd : UINT32_MAX;
 }
 
 static uint32_t accel_bytes_per_mtu_increase(const struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt,
-                                             uint32_t cwnd, uint32_t mtu)
+                                             uint32_t mtu)
 {
-    if (cwnd >= accel_calc_cwnd_cap(state))
-        return UINT32_MAX;
-
-    double ratio = accel_calc_increase_ratio(state, rtt, cwnd);
+    double ratio = accel_calc_increase_ratio(state, rtt);
     if (ratio == 0)
         return UINT32_MAX;
     double bytes = mtu / ratio;
@@ -616,8 +611,7 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
         if (cc->state.pico.bytes_to_mtu_increase == 0)
             cc->state.pico.bytes_to_mtu_increase = calc_bytes_per_mtu_increase(cc, loss, max_udp_payload_size);
         if (accel_enabled(cc)) {
-            uint32_t accel_bytes =
-                accel_bytes_per_mtu_increase(&cc->state.pico.accel, &loss->rtt, cc->cwnd, max_udp_payload_size);
+            uint32_t accel_bytes = accel_bytes_per_mtu_increase(&cc->state.pico.accel, &loss->rtt, max_udp_payload_size);
             if (cc->state.pico.bytes_to_mtu_increase > accel_bytes)
                 cc->state.pico.bytes_to_mtu_increase = accel_bytes;
         }
@@ -770,7 +764,7 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
         cc->cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
 
     if (accel_enabled(cc))
-        accel_on_lost(&cc->state.pico.accel, in_startup, cc->cwnd);
+        accel_on_lost(&cc->state.pico.accel, in_startup);
 
     /* Update policy-specific state using the estimated BDP and reduced CWND.
      *

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -383,8 +383,7 @@ static void cubic_on_congestion(struct st_quicly_cc_cubic_t *state, uint32_t cwn
 
 static int accel_enabled(const quicly_cc_t *cc)
 {
-    return cc->accel_adaptation != 0 &&
-           (cc->type == &quicly_cc_type_cubic || cc->type == &quicly_cc_type_cuback);
+    return cc->accel_adaptation != 0 && (cc->type == &quicly_cc_type_cubic || cc->type == &quicly_cc_type_cuback);
 }
 
 static float calc_smoothed_rtt_before_latest(const quicly_rtt_t *rtt)
@@ -400,8 +399,7 @@ static void accel_on_recovery_end(struct st_quicly_cc_accel_adaptation_t *state,
     }
 }
 
-static void accel_on_acked(struct st_quicly_cc_accel_adaptation_t *state, const quicly_rtt_t *rtt, int recovery_ended,
-                           int64_t now)
+static void accel_on_acked(struct st_quicly_cc_accel_adaptation_t *state, const quicly_rtt_t *rtt, int recovery_ended, int64_t now)
 {
     /* A recovery entered from calibration slow start can supply multiple RTT samples. Adopt their smoothed result rather than the
      * single sample adjacent to the congestion signal. */
@@ -480,8 +478,7 @@ static double accel_calc_increase_ratio(const struct st_quicly_cc_accel_adaptati
     uint32_t rtt_threshold = (uint32_t)(((uint64_t)rtt->minimum + state->min_rtt_previous_period) / 2);
     if (rtt_threshold < quicly_u32_add_saturating(rtt->minimum, 2)) {
         rtt_threshold = quicly_u32_add_saturating(rtt->minimum, 2);
-    } else if (state->min_rtt_current_period != 0 &&
-               rtt_threshold > quicly_u32_add_saturating(state->min_rtt_current_period, 2)) {
+    } else if (state->min_rtt_current_period != 0 && rtt_threshold > quicly_u32_add_saturating(state->min_rtt_current_period, 2)) {
         rtt_threshold = quicly_u32_add_saturating(state->min_rtt_current_period, 2);
     }
 
@@ -494,8 +491,8 @@ static double accel_calc_increase_ratio(const struct st_quicly_cc_accel_adaptati
     return ratio;
 }
 
-static uint32_t accel_calc_cubic_cwnd(const struct st_quicly_cc_accel_adaptation_t *state, const quicly_rtt_t *rtt,
-                                      uint32_t cwnd, uint32_t bytes, unsigned flags)
+static uint32_t accel_calc_cubic_cwnd(const struct st_quicly_cc_accel_adaptation_t *state, const quicly_rtt_t *rtt, uint32_t cwnd,
+                                      uint32_t bytes, unsigned flags)
 {
     double ratio = accel_calc_increase_ratio(state, rtt, flags);
     if (ratio == 0)

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -495,13 +495,20 @@ static double accel_calc_increase_ratio(const quicly_cc_t *cc, const quicly_rtt_
     }
 
     if (!accel_enabled(cc) || state->target_cwnd == 0 || state->full_rtt <= quicly_u32_add_saturating(rtt->minimum, 10) ||
-        rtt->latest >= rtt_threshold || cc->cwnd >= accel_calc_cwnd_cap(state))
+        rtt->latest >= rtt_threshold || (double)rtt->latest * 1.05 >= state->full_rtt ||
+        cc->cwnd >= accel_calc_cwnd_cap(state))
         return 0;
 
     double ratio = cc->cwnd < state->target_cwnd
                        ? (double)(state->target_cwnd - cc->cwnd) / ((double)cc->cwnd * 2)
                        : 0;
-    return ratio < 1. / 40 ? 1. / 40 : ratio;
+    if (ratio < 1. / 40)
+        ratio = 1. / 40;
+
+    /* Do not consume more than half of the remaining RTT headroom in one RTT. At the five-percent cutoff above, this limit
+     * converges on the minimum acceleration rate of 1/40. */
+    double rtt_ratio = ((double)state->full_rtt / rtt->latest - 1) / 2;
+    return ratio < rtt_ratio ? ratio : rtt_ratio;
 }
 
 static uint32_t accel_calc_cubic_cwnd(const quicly_cc_t *cc, const quicly_rtt_t *rtt, uint32_t bytes, int cc_limited)

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -391,84 +391,69 @@ static float calc_smoothed_rtt_before_latest(const quicly_rtt_t *rtt)
     return rtt->latest != 0 ? (rtt->smoothed * 8 - rtt->latest) / 7 : rtt->smoothed;
 }
 
-static void accel_reset_observation(struct st_quicly_cc_accelerated_increase_t *state)
+static void accel_on_recovery_end(struct st_quicly_cc_accelerated_increase_t *state, float smoothed_rtt, int64_t now)
 {
-    state->observation_start = 0;
-    state->max_smoothed_rtt = 0;
+    if (state->full_rtt == 0) {
+        state->full_rtt = smoothed_rtt;
+        state->last_high_rtt_at = now;
+    }
 }
 
-static void accel_on_recovery_end(struct st_quicly_cc_accelerated_increase_t *state, float smoothed_rtt)
+static void accel_on_acked(struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt, int recovery_ended,
+                           int64_t now)
+{
+    /* A recovery entered from calibration slow start can supply multiple RTT samples. Adopt their smoothed result rather than the
+     * single sample adjacent to the congestion signal. */
+    if (recovery_ended)
+        accel_on_recovery_end(state, calc_smoothed_rtt_before_latest(rtt), now);
+    if (state->min_rtt_current_period == 0 || state->min_rtt_current_period > rtt->latest)
+        state->min_rtt_current_period = rtt->latest;
+}
+
+static void accel_on_lost(struct st_quicly_cc_accelerated_increase_t *state, int in_startup, uint32_t cwnd)
+{
+    state->min_rtt_previous_period = state->min_rtt_current_period;
+    state->min_rtt_current_period = 0;
+    state->target_cwnd = 0;
+    state->high_rtt_interval = 0;
+    if (in_startup)
+        state->full_rtt = 0;
+    double target_cwnd = cwnd / QUICLY_BETA_LOSS;
+    state->target_cwnd = target_cwnd < UINT32_MAX ? target_cwnd : UINT32_MAX;
+}
+
+static int accel_recalibrate(struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt, uint32_t cwnd_epoch,
+                             uint32_t reference_mtu, int64_t now)
 {
     if (state->full_rtt == 0)
-        state->full_rtt = smoothed_rtt;
-}
+        return 0;
 
-static void accel_enter_calibration(quicly_cc_t *cc)
-{
-    if (cc->type == &quicly_cc_type_cubic) {
-        cc->state.pico.cubic = (struct st_quicly_cc_cubic_t){.k = NAN, .cc_limited = 1};
-    } else {
-        assert(cc->type == &quicly_cc_type_cuback);
-        cc->state.pico.cuback = (struct st_quicly_cc_cuback_t){0};
-    }
-    cc->state.pico.accel.target_cwnd = 0;
-    accel_reset_observation(&cc->state.pico.accel);
-    cc->state.pico.bytes_to_mtu_increase = 0;
-    cc->ssthresh = UINT32_MAX;
-}
+    if (state->high_rtt_interval == 0) {
+        assert(state->target_cwnd > cwnd_epoch);
+        double k = fast_cbrt((state->target_cwnd - cwnd_epoch) / (QUICLY_CUBIC_C * reference_mtu));
 
-static double accel_calc_k(const quicly_cc_t *cc, uint32_t reference_mtu)
-{
-    if (cc->type == &quicly_cc_type_cubic) {
-        const struct st_quicly_cc_cubic_t *state = &cc->state.pico.cubic;
-        return state->epoch_start != 0 && !isnan(state->k) ? state->k : 0;
-    } else {
-        assert(cc->type == &quicly_cc_type_cuback);
-        const struct st_quicly_cc_cuback_t *state = &cc->state.pico.cuback;
-        double w_max = state->fast_convergence ? cubic_fast_convergence_w_max(state->cwnd_prior, cc->ssthresh) : state->cwnd_prior;
-        return w_max > cc->ssthresh ? fast_cbrt((w_max - cc->ssthresh) / (QUICLY_CUBIC_C * reference_mtu)) : 0;
-    }
-}
-
-static void accel_observe_path(quicly_cc_t *cc, const quicly_rtt_t *rtt, int cc_limited, int64_t now,
-                               uint32_t max_udp_payload_size)
-{
-    struct st_quicly_cc_accelerated_increase_t *state = &cc->state.pico.accel;
-
-    if (!accel_enabled(cc) || cc->cwnd < cc->ssthresh || state->full_rtt == 0 || rtt->minimum == UINT32_MAX)
-        return;
-
-    if (!cc_limited) {
-        accel_reset_observation(state);
-        return;
+        /* Both policies follow the greater of their cubic and Reno-friendly windows. K implies a window gap of C * K^3 * MTU,
+         * hence the Reno-friendly curve covers the gap in C * K^3 / alpha round trips. Use the ordinary-loss alpha because the
+         * competing flow's congestion signal is unknown, start with the shorter return time of the two curves, then retain the
+         * existing cube-root adjustment for the observed queue depth. */
+        double reno = QUICLY_CUBIC_C * k * k * k / cubic_friendly_alpha[0] * state->full_rtt / 1000;
+        double interval = (k < reno ? k : reno) * fast_cbrt((double)state->full_rtt / rtt->minimum) * 1000;
+        state->high_rtt_interval = interval < 1 ? 1 : interval < UINT32_MAX ? interval : UINT32_MAX;
     }
 
-    uint32_t reference_mtu = cc->normalize_mtu ? QUICLY_CC_REFERENCE_MTU : max_udp_payload_size;
-    double k = accel_calc_k(cc, reference_mtu);
-    if (k <= 0)
-        return;
-
-    if (state->observation_start == 0) {
-        state->observation_start = now;
-        state->max_smoothed_rtt = rtt->smoothed;
-        return;
+    if (rtt->smoothed >= ((double)rtt->minimum + state->full_rtt) / 2) {
+        state->last_high_rtt_at = now;
+        return 0;
     }
-    if (state->max_smoothed_rtt < rtt->smoothed)
-        state->max_smoothed_rtt = rtt->smoothed;
 
-    /* After twice the time in which a non-losing CUBIC competitor could have reached the observed queue overflow, failure to
-     * reach half of that queue indicates that the path might have changed. Recalibrate full_rtt by returning to slow start without
-     * resetting CWND. */
-    double interval = 2 * k * fast_cbrt((double)state->full_rtt / rtt->minimum) * 1000;
-    if (now - state->observation_start < interval)
-        return;
+    /* If the smoothed RTT has remained below half of the observed queue for twice the time in which a non-losing competing flow
+     * following the same CA trajectory could have produced another high-RTT observation, the path might have changed. */
+    if (now - state->last_high_rtt_at < 2 * (int64_t)state->high_rtt_interval)
+        return 0;
 
-    if (state->max_smoothed_rtt < ((double)rtt->minimum + state->full_rtt) / 2) {
-        accel_enter_calibration(cc);
-    } else {
-        state->observation_start = now;
-        state->max_smoothed_rtt = rtt->smoothed;
-    }
+    state->target_cwnd = 0;
+    state->high_rtt_interval = 0;
+    return 1;
 }
 
 static uint32_t accel_calc_cwnd_cap(const struct st_quicly_cc_accelerated_increase_t *state)
@@ -477,28 +462,25 @@ static uint32_t accel_calc_cwnd_cap(const struct st_quicly_cc_accelerated_increa
     return cap < UINT32_MAX ? cap : UINT32_MAX;
 }
 
-static double accel_calc_increase_ratio(const quicly_cc_t *cc, const quicly_rtt_t *rtt)
+static double accel_calc_increase_ratio(const struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt,
+                                        uint32_t cwnd)
 {
-    const struct st_quicly_cc_accelerated_increase_t *state = &cc->state.pico.accel;
     uint32_t rtt_threshold = quicly_u32_add_saturating(rtt->minimum, 2);
 
-    if (state->min_rtt_in_previous_ca > rtt->minimum) {
+    if (state->min_rtt_previous_period > rtt->minimum) {
         /* Accommodate a persistent jitter floor without returning to the minimum RTT seen over the entire connection. Half of the
-         * preceding CA period's excess minimum is allowed, with the existing two-millisecond allowance as the lower bound. */
-        uint32_t previous_ca_threshold =
-            rtt->minimum + (state->min_rtt_in_previous_ca - rtt->minimum) / 2;
-        if (rtt_threshold < previous_ca_threshold)
-            rtt_threshold = previous_ca_threshold;
+         * preceding period's excess minimum is allowed, with the existing two-millisecond allowance as the lower bound. */
+        uint32_t previous_period_threshold =
+            rtt->minimum + (state->min_rtt_previous_period - rtt->minimum) / 2;
+        if (rtt_threshold < previous_period_threshold)
+            rtt_threshold = previous_period_threshold;
     }
 
-    if (!accel_enabled(cc) || state->target_cwnd == 0 || state->full_rtt <= quicly_u32_add_saturating(rtt->minimum, 10) ||
-        rtt->latest >= rtt_threshold || (double)rtt->latest * 1.05 >= state->full_rtt ||
-        cc->cwnd >= accel_calc_cwnd_cap(state))
+    if (state->target_cwnd == 0 || state->full_rtt <= quicly_u32_add_saturating(rtt->minimum, 10) ||
+        rtt->latest >= rtt_threshold || (double)rtt->latest * 1.05 >= state->full_rtt)
         return 0;
 
-    double ratio = cc->cwnd < state->target_cwnd
-                       ? (double)(state->target_cwnd - cc->cwnd) / ((double)cc->cwnd * 2)
-                       : 0;
+    double ratio = cwnd < state->target_cwnd ? (double)(state->target_cwnd - cwnd) / ((double)cwnd * 2) : 0;
     if (ratio < 1. / 40)
         ratio = 1. / 40;
 
@@ -508,23 +490,28 @@ static double accel_calc_increase_ratio(const quicly_cc_t *cc, const quicly_rtt_
     return ratio < rtt_ratio ? ratio : rtt_ratio;
 }
 
-static uint32_t accel_calc_cubic_cwnd(const quicly_cc_t *cc, const quicly_rtt_t *rtt, uint32_t bytes, int cc_limited)
+static uint32_t accel_calc_cubic_cwnd(const struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt,
+                                      uint32_t cwnd, uint32_t bytes)
 {
-    if (bytes == 0 || !cc_limited)
-        return cc->cwnd;
+    uint32_t cap = accel_calc_cwnd_cap(state);
+    if (cwnd >= cap)
+        return cwnd;
 
-    double ratio = accel_calc_increase_ratio(cc, rtt);
+    double ratio = accel_calc_increase_ratio(state, rtt, cwnd);
     if (ratio == 0)
-        return cc->cwnd;
+        return cwnd;
 
-    double cwnd = cc->cwnd + bytes * ratio;
-    uint32_t cap = accel_calc_cwnd_cap(&cc->state.pico.accel);
-    return cwnd < cap ? (uint32_t)cwnd : cap;
+    double increased_cwnd = cwnd + bytes * ratio;
+    return increased_cwnd < cap ? (uint32_t)increased_cwnd : cap;
 }
 
-static uint32_t accel_bytes_per_mtu_increase(const quicly_cc_t *cc, const quicly_rtt_t *rtt, uint32_t mtu)
+static uint32_t accel_bytes_per_mtu_increase(const struct st_quicly_cc_accelerated_increase_t *state, const quicly_rtt_t *rtt,
+                                             uint32_t cwnd, uint32_t mtu)
 {
-    double ratio = accel_calc_increase_ratio(cc, rtt);
+    if (cwnd >= accel_calc_cwnd_cap(state))
+        return UINT32_MAX;
+
+    double ratio = accel_calc_increase_ratio(state, rtt, cwnd);
     if (ratio == 0)
         return UINT32_MAX;
     double bytes = mtu / ratio;
@@ -579,16 +566,10 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
         return;
     }
 
-    /* A recovery entered from calibration slow start can supply multiple RTT samples. Adopt their smoothed result here rather than
-     * retaining the single sample adjacent to the congestion signal. */
-    if (accel_enabled(cc) && cc->recovery_end != 0)
-        accel_on_recovery_end(&cc->state.pico.accel, calc_smoothed_rtt_before_latest(&loss->rtt));
-
     quicly_cc_jumpstart_on_acked(cc, 0, bytes, largest_acked, inflight, next_pn);
 
-    if (accel_enabled(cc) && cc->cwnd >= cc->ssthresh &&
-        (cc->state.pico.accel.min_rtt_in_ca == 0 || cc->state.pico.accel.min_rtt_in_ca > loss->rtt.latest))
-        cc->state.pico.accel.min_rtt_in_ca = loss->rtt.latest;
+    if (accel_enabled(cc))
+        accel_on_acked(&cc->state.pico.accel, &loss->rtt, cc->recovery_end != 0, now);
 
     /* Cubic: unlike other policies, congestion avoidance cannot be driven by bytes_to_mtu_increase. */
     if (cc->type == &quicly_cc_type_cubic && cc->cwnd >= cc->ssthresh) {
@@ -604,12 +585,15 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
             state->k = NAN;
         }
         uint32_t reference_mtu = cc->normalize_mtu ? QUICLY_CC_REFERENCE_MTU : max_udp_payload_size;
-        /* Advance the ordinary CUBIC trajectory even while accelerating increase, then adopt whichever CWND is greater. */
-        uint32_t accelerated_cwnd = accel_calc_cubic_cwnd(cc, &loss->rtt, bytes, cc_limited);
-        uint32_t cubic_cwnd = cc->cwnd;
-        cubic_on_acked(state, &cubic_cwnd, cc->ssthresh, bytes, cc_limited, loss->rtt.smoothed, now, max_udp_payload_size,
+        uint32_t new_cwnd = cc->cwnd;
+        cubic_on_acked(state, &new_cwnd, cc->ssthresh, bytes, cc_limited, loss->rtt.smoothed, now, max_udp_payload_size,
                        reference_mtu);
-        cc->cwnd = cubic_cwnd < accelerated_cwnd ? accelerated_cwnd : cubic_cwnd;
+        if (accel_enabled(cc) && bytes != 0 && cc_limited) {
+            uint32_t accelerated_cwnd = accel_calc_cubic_cwnd(&cc->state.pico.accel, &loss->rtt, cc->cwnd, bytes);
+            if (new_cwnd < accelerated_cwnd)
+                new_cwnd = accelerated_cwnd;
+        }
+        cc->cwnd = new_cwnd;
         goto Cleanup;
     }
 
@@ -631,11 +615,12 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
     while (1) {
         if (cc->state.pico.bytes_to_mtu_increase == 0)
             cc->state.pico.bytes_to_mtu_increase = calc_bytes_per_mtu_increase(cc, loss, max_udp_payload_size);
-        /* An ACK interval is the inverse of the increase rate; choosing the shorter interval is therefore equivalent to choosing
-         * the greater of the ordinary increase and accelerated increase. */
-        uint32_t accel_bytes = accel_bytes_per_mtu_increase(cc, &loss->rtt, max_udp_payload_size);
-        if (cc->state.pico.bytes_to_mtu_increase > accel_bytes)
-            cc->state.pico.bytes_to_mtu_increase = accel_bytes;
+        if (accel_enabled(cc)) {
+            uint32_t accel_bytes =
+                accel_bytes_per_mtu_increase(&cc->state.pico.accel, &loss->rtt, cc->cwnd, max_udp_payload_size);
+            if (cc->state.pico.bytes_to_mtu_increase > accel_bytes)
+                cc->state.pico.bytes_to_mtu_increase = accel_bytes;
+        }
         if (bytes_available < cc->state.pico.bytes_to_mtu_increase)
             break;
         bytes_available -= cc->state.pico.bytes_to_mtu_increase;
@@ -646,7 +631,21 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
     assert(cc->state.pico.bytes_to_mtu_increase != 0);
 
 Cleanup:
-    accel_observe_path(cc, &loss->rtt, cc_limited, now, max_udp_payload_size);
+    /* Accelerated increase: if queue buildup is not observed even after twice the time in which a non-losing CUBIC flow should
+     * have rebuilt the queue, the path characteristics might have changed. Retain the current CWND but discard the CA trajectory
+     * and return to unbounded slow start to recalibrate full_rtt. */
+    if (accel_enabled(cc) && cc->cwnd >= cc->ssthresh && cc_limited &&
+        accel_recalibrate(&cc->state.pico.accel, &loss->rtt, cc->ssthresh,
+                          cc->normalize_mtu ? QUICLY_CC_REFERENCE_MTU : max_udp_payload_size, now)) {
+        if (cc->type == &quicly_cc_type_cubic) {
+            cc->state.pico.cubic = (struct st_quicly_cc_cubic_t){.k = NAN, .cc_limited = 1};
+        } else {
+            assert(cc->type == &quicly_cc_type_cuback);
+            cc->state.pico.cuback = (struct st_quicly_cc_cuback_t){0};
+        }
+        cc->state.pico.bytes_to_mtu_increase = 0;
+        cc->ssthresh = UINT32_MAX;
+    }
     if (cc->cwnd_maximum < cc->cwnd)
         cc->cwnd_maximum = cc->cwnd;
     if (quicly_cc_rapid_start_is_in_recovery(&cc->rapid_start))
@@ -675,7 +674,7 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
     /* A new congestion event beyond recovery_end also closes the preceding recovery, even when no intervening ACK invokes
      * pico_on_acked. */
     if (accel_enabled(cc) && cc->recovery_end != 0)
-        accel_on_recovery_end(&cc->state.pico.accel, loss->rtt.smoothed);
+        accel_on_recovery_end(&cc->state.pico.accel, loss->rtt.smoothed, now);
 
     /* Rapid Start: if recovery exits and the first CC event is a loss instead of an ack, call `pico_on_acked` to reflect recovery
      * exit to Rapid Start and related states, before entering the next recovery period in the following blocks. */
@@ -683,9 +682,8 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
         pico_on_acked(cc, loss, 0, cc->recovery_end, (uint32_t)loss->sentmap.bytes_in_flight, 0, next_pn, now,
                       max_udp_payload_size);
 
-    int full_rtt_observation = accel_enabled(cc) && cc->cwnd < cc->ssthresh;
-    int use_accel = accel_enabled(cc) && bytes != 0 && cc->state.pico.accel.full_rtt != 0 && !full_rtt_observation;
-    double beta = cc->type == &quicly_cc_type_reno ? QUICLY_BETA_RENO : bytes == 0 ? QUICLY_BETA_ECN : QUICLY_BETA_LOSS;
+    int in_startup = cc->cwnd < cc->ssthresh;
+    double beta = cc->type == &quicly_cc_type_reno ? QUICLY_BETA_RENO : (bytes == 0 ? QUICLY_BETA_ECN : QUICLY_BETA_LOSS);
 
     /* Zero-byte congestion reports are ECN signals, not lost packets. They still enter recovery below, but cannot be undone by
      * late ACKs because no packet was deemed lost. */
@@ -716,21 +714,6 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
 
     cc->recovery_end = next_pn;
     ++cc->num_loss_episodes;
-
-    if (accel_enabled(cc)) {
-        cc->state.pico.accel.min_rtt_in_previous_ca = cc->state.pico.accel.min_rtt_in_ca;
-        cc->state.pico.accel.min_rtt_in_ca = 0;
-    }
-
-    if (accel_enabled(cc)) {
-        /* A congestion signal reached by calibration slow start schedules full_rtt to adopt smoothed RTT at recovery exit. Waiting
-         * until then incorporates the recovery's RTT samples and also permits ECN to supply the observation. The accelerated-
-         * increase threshold is derived from the reduced CWND below. */
-        accel_reset_observation(&cc->state.pico.accel);
-        cc->state.pico.accel.target_cwnd = 0;
-        if (full_rtt_observation)
-            cc->state.pico.accel.full_rtt = 0;
-    }
 
     /* end of slow start */
     if (cc->cwnd_exiting_slow_start == 0) {
@@ -786,10 +769,8 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
     if (cc->cwnd < QUICLY_MIN_CWND * max_udp_payload_size)
         cc->cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
 
-    if (full_rtt_observation || use_accel) {
-        double target_cwnd = cc->cwnd / QUICLY_BETA_LOSS;
-        cc->state.pico.accel.target_cwnd = target_cwnd < UINT32_MAX ? target_cwnd : UINT32_MAX;
-    }
+    if (accel_enabled(cc))
+        accel_on_lost(&cc->state.pico.accel, in_startup, cc->cwnd);
 
     /* Update policy-specific state using the estimated BDP and reduced CWND.
      *
@@ -844,8 +825,7 @@ static void pico_on_late_ack(quicly_cc_t *cc, uint64_t pn, int64_t now)
     if (--cc->state.pico.undo.num_packets_lost != 0)
         return;
 
-    int was_in_startup =
-        cc->state.pico.undo.ssthresh == UINT32_MAX && !(accel_enabled(cc) && cc->state.pico.undo.accel.full_rtt != 0);
+    int was_initial_startup = cc->num_loss_episodes == 1;
     cc->cwnd = cc->state.pico.undo.cwnd;
     cc->ssthresh = cc->state.pico.undo.ssthresh;
     cc->state.pico.bytes_to_mtu_increase = cc->state.pico.undo.bytes_to_mtu_increase;
@@ -864,7 +844,7 @@ static void pico_on_late_ack(quicly_cc_t *cc, uint64_t pn, int64_t now)
     cc->recovery_end = 0;
     --cc->num_loss_episodes;
     ++cc->num_loss_episodes_undone;
-    if (was_in_startup) {
+    if (was_initial_startup) {
         ++cc->num_loss_episodes_undone_in_startup;
         cc->cwnd_exiting_slow_start = 0;
         cc->exit_slow_start_at = INT64_MAX;
@@ -975,8 +955,6 @@ static void pico_update_cc_limited(quicly_cc_t *cc, int cc_limited, int64_t now)
     } else {
         assert(cc->type == &quicly_cc_type_cuback);
     }
-    if (!cc_limited)
-        accel_reset_observation(&cc->state.pico.accel);
 }
 
 static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int normalize_mtu, int random_loss_tolerance,

--- a/lib/cc-pico.c
+++ b/lib/cc-pico.c
@@ -593,7 +593,6 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
         pico_on_acked(cc, loss, 0, cc->recovery_end, (uint32_t)loss->sentmap.bytes_in_flight, 0, next_pn, now,
                       max_udp_payload_size);
 
-    uint32_t cwnd_at_loss = cc->cwnd;
     int qortt_observation = cc->type == &quicly_cc_type_cubic && cc->random_loss_tolerance && bytes != 0 && cc->cwnd < cc->ssthresh;
     int random_loss_recovery = cc->type == &quicly_cc_type_cubic && cc->random_loss_tolerance && bytes != 0 &&
                                cc->state.pico.cubic.random_loss.qortt != 0 && !qortt_observation;
@@ -630,14 +629,10 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
 
     if (cc->type == &quicly_cc_type_cubic && cc->random_loss_tolerance) {
         struct st_quicly_cc_cubic_t *state = &cc->state.pico.cubic;
-        /* A CA packet loss with a qoRTT observation receives the tentative reduction below and sets the recovery cap to the
-         * pre-loss CWND. A loss reached by calibration slow start instead replaces the scalar qoRTT observation. */
+        /* A loss reached by calibration slow start replaces the scalar qoRTT observation. The accelerated recovery threshold is
+         * derived from the reduced CWND below. */
         cubic_random_loss_reset_observation(state);
-        if (random_loss_recovery) {
-            state->random_loss.recovery_target = cwnd_at_loss;
-        } else {
-            state->random_loss.recovery_target = 0;
-        }
+        state->random_loss.recovery_target = 0;
         if (qortt_observation) {
             state->random_loss.qortt = loss->rtt.latest;
         }
@@ -655,7 +650,7 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
 
     /* estimate BDP (usually from CWND before reduction) */
     uint32_t bdp = cc->cwnd;
-    if (cc->num_loss_episodes == 1 && !qortt_observation) {
+    if (cc->num_loss_episodes == 1) {
         if (quicly_cc_is_jumpstart_ack(cc, lost_pn)) {
             bdp = cc->jumpstart.bytes_acked;
         } else if (quicly_cc_rapid_start_is_enabled(&cc->rapid_start)) {
@@ -696,6 +691,11 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
 
     if (cc->cwnd < QUICLY_MIN_CWND * max_udp_payload_size)
         cc->cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
+
+    if (qortt_observation || random_loss_recovery) {
+        double recovery_target = cc->cwnd / (beta * beta);
+        cc->state.pico.cubic.random_loss.recovery_target = recovery_target < UINT32_MAX ? recovery_target : UINT32_MAX;
+    }
 
     /* Update policy-specific state using the estimated BDP and reduced CWND.
      *

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2147,7 +2147,7 @@ static quicly_error_t promote_path(quicly_conn_t *conn, size_t path_index)
     conn->egress.cc.type->cc_init->cb(
         conn->egress.cc.type->cc_init, &conn->egress.cc,
         quicly_cc_calc_initial_cwnd(conn->super.ctx->initcwnd_packets, conn->egress.max_udp_payload_size),
-        conn->egress.cc.normalize_mtu, conn->super.ctx->random_loss_tolerance, conn->stash.now);
+        conn->super.ctx->normalize_cc_mtu, conn->super.ctx->random_loss_tolerance, conn->stash.now);
     if (conn->super.stats.num_rapid_start != 0 && conn->egress.cc.type->enable_rapid_start != NULL)
         conn->egress.cc.type->enable_rapid_start(&conn->egress.cc, conn->stash.now);
 

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2147,7 +2147,7 @@ static quicly_error_t promote_path(quicly_conn_t *conn, size_t path_index)
     conn->egress.cc.type->cc_init->cb(
         conn->egress.cc.type->cc_init, &conn->egress.cc,
         quicly_cc_calc_initial_cwnd(conn->super.ctx->initcwnd_packets, conn->egress.max_udp_payload_size),
-        conn->egress.cc.normalize_mtu, conn->stash.now);
+        conn->egress.cc.normalize_mtu, conn->super.ctx->random_loss_tolerance, conn->stash.now);
     if (conn->super.stats.num_rapid_start != 0 && conn->egress.cc.type->enable_rapid_start != NULL)
         conn->egress.cc.type->enable_rapid_start(&conn->egress.cc, conn->stash.now);
 
@@ -2860,7 +2860,7 @@ static quicly_conn_t *create_connection(quicly_context_t *ctx, uint32_t protocol
     conn->egress.send_ack_at = INT64_MAX;
     conn->egress.send_probe_at = INT64_MAX;
     conn->super.ctx->init_cc->cb(conn->super.ctx->init_cc, &conn->egress.cc, initcwnd, conn->super.ctx->normalize_cc_mtu,
-                                 conn->stash.now);
+                                 conn->super.ctx->random_loss_tolerance, conn->stash.now);
     if (conn->egress.cc.type->enable_rapid_start != NULL &&
         enable_with_ratio255(conn->super.ctx->enable_ratio.rapid_start, conn->super.ctx->tls->random_bytes)) {
         conn->egress.cc.type->enable_rapid_start(&conn->egress.cc, conn->stash.now);

--- a/lib/quicly.c
+++ b/lib/quicly.c
@@ -2147,7 +2147,7 @@ static quicly_error_t promote_path(quicly_conn_t *conn, size_t path_index)
     conn->egress.cc.type->cc_init->cb(
         conn->egress.cc.type->cc_init, &conn->egress.cc,
         quicly_cc_calc_initial_cwnd(conn->super.ctx->initcwnd_packets, conn->egress.max_udp_payload_size),
-        conn->super.ctx->normalize_cc_mtu, conn->super.ctx->random_loss_tolerance, conn->stash.now);
+        conn->super.ctx->normalize_cc_mtu, conn->super.ctx->accel_adaptation, conn->stash.now);
     if (conn->super.stats.num_rapid_start != 0 && conn->egress.cc.type->enable_rapid_start != NULL)
         conn->egress.cc.type->enable_rapid_start(&conn->egress.cc, conn->stash.now);
 
@@ -2860,7 +2860,7 @@ static quicly_conn_t *create_connection(quicly_context_t *ctx, uint32_t protocol
     conn->egress.send_ack_at = INT64_MAX;
     conn->egress.send_probe_at = INT64_MAX;
     conn->super.ctx->init_cc->cb(conn->super.ctx->init_cc, &conn->egress.cc, initcwnd, conn->super.ctx->normalize_cc_mtu,
-                                 conn->super.ctx->random_loss_tolerance, conn->stash.now);
+                                 conn->super.ctx->accel_adaptation, conn->stash.now);
     if (conn->egress.cc.type->enable_rapid_start != NULL &&
         enable_with_ratio255(conn->super.ctx->enable_ratio.rapid_start, conn->super.ctx->tls->random_bytes)) {
         conn->egress.cc.type->enable_rapid_start(&conn->egress.cc, conn->stash.now);

--- a/t/cc.c
+++ b/t/cc.c
@@ -506,58 +506,51 @@ static void test_cubic_undo_loss(void)
 
 static void test_cubic_random_loss_tolerance_accelerated_increase(void)
 {
-    quicly_cc_t cc;
+    quicly_cc_t cc, control;
     quicly_loss_t loss = {.rtt = {.latest = 120, .smoothed = 120, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 100 * mtu;
 
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
 
-    /* The startup loss schedules a full_rtt observation, applies the ordinary slow-start reduction, and sets the acceleration
-     * target using the ordinary loss beta. The smoothed RTT is adopted when recovery exits. */
+    /* The startup loss schedules a full_rtt observation and applies the ordinary slow-start reduction. The smoothed RTT is
+     * adopted when recovery exits. */
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     ok(cc.state.pico.accel.full_rtt == 0);
     ok(cc.cwnd == initcwnd / 2);
     ok(cc.state.pico.cubic.cwnd_prior == initcwnd / 2);
-    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / QUICLY_BETA_LOSS));
-    ok(accel_calc_cwnd_cap(&cc.state.pico.accel) == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
 
     cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
     ok(cc.state.pico.accel.full_rtt == 120);
 
-    /* An ordinary CA packet loss applies the ordinary 0.7 reduction. ACKs then use the smaller of half the current relative
-     * distance to CWNDpre and half the remaining RTT headroom, with a 2.5% minimum until reaching CWNDpre / beta. */
+    /* An ordinary CA packet loss applies the ordinary 0.7 reduction. ACKs then increase at the rate derived from minimum RTT while
+     * the RTT gates remain open. */
     cc.cwnd = 80 * mtu;
     loss.rtt.latest = 101;
     loss.rtt.smoothed = 105;
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 1200, mtu);
     ok(cc.cwnd == (uint32_t)(80 * mtu * QUICLY_BETA_LOSS));
-    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / QUICLY_BETA_LOSS));
 
     cc.type->cc_on_acked(&cc, &loss, mtu, 29, mtu, 1, 30, 1300, mtu);
-    uint32_t cwnd_before = cc.cwnd;
-    uint32_t first_increase = mtu * accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, cc.cwnd);
+    uint32_t accelerated_cwnd = accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu);
+    control = cc;
+    control.random_loss_tolerance = 0;
     cc.type->cc_on_acked(&cc, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
-    ok(cc.cwnd == cwnd_before + first_increase);
+    control.type->cc_on_acked(&control, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
+    ok(cc.cwnd == (control.cwnd < accelerated_cwnd ? accelerated_cwnd : control.cwnd));
 
-    /* An aggregate ACK for one post-reduction flight applies the RTT-limited increase. A subsequent loss starts another accelerated
-     * increase toward its own CWNDpre target. */
+    /* An aggregate ACK for one post-reduction flight applies the accelerated increase. */
     uint32_t bytes_acked = cc.cwnd;
-    uint32_t expected_increase = bytes_acked * accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, cc.cwnd);
+    accelerated_cwnd = accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, bytes_acked);
+    control = cc;
+    control.random_loss_tolerance = 0;
     cc.type->cc_on_acked(&cc, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1500, mtu);
-    ok(cc.cwnd == cwnd_before + first_increase + expected_increase);
+    control.type->cc_on_acked(&control, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1500, mtu);
+    ok(cc.cwnd == (control.cwnd < accelerated_cwnd ? accelerated_cwnd : control.cwnd));
 
-    /* Once CWND reaches the recovery target, acceleration continues at the minimum rate up to target / beta, then stops. */
-    cc.cwnd = cc.state.pico.accel.target_cwnd;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, cc.cwnd) == 1. / 40);
-    uint32_t cwnd_cap = accel_calc_cwnd_cap(&cc.state.pico.accel);
-    ok(accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, (cwnd_cap - cc.cwnd) * 40) == cwnd_cap);
-    cc.cwnd = cwnd_cap;
-    ok(accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu) == cwnd_cap);
-
+    /* There is no CWND-derived cap; acceleration continues while the RTT gates remain open. */
     uint32_t second_cwnd_at_loss = cc.cwnd;
     cc.type->cc_on_lost(&cc, &loss, mtu, 32, 40, 1600, mtu);
     ok(cc.cwnd == (uint32_t)(second_cwnd_at_loss * QUICLY_BETA_LOSS));
-    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / QUICLY_BETA_LOSS));
 }
 
 static void test_smoothed_rtt_before_latest(void)
@@ -632,33 +625,59 @@ static void test_cubic_random_loss_tolerance_guards(void)
     control.type->cc_on_acked(&control, &loss, mtu, 21, mtu, 1, 22, 1300, mtu);
     ok(cc.cwnd == control.cwnd);
 
-    /* Acceleration consumes no more than half of the remaining RTT headroom and stops with five percent still available. */
+    /* The current period's floor plus two milliseconds caps the allowance derived from the preceding period. */
+    cc.state.pico.accel.min_rtt_previous_period = 120;
+    cc.state.pico.accel.min_rtt_current_period = 104;
+    loss.rtt.latest = 105;
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) > 0);
+    loss.rtt.latest = 106;
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) == 0);
+
+    /* Long-RTT paths retain the 2.5% floor, while shorter paths use the rate that adds approximately two milliseconds of flight
+     * per RTT. Acceleration stops with five percent of full_rtt still available. */
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
     cc.cwnd = 70 * mtu;
-    cc.state.pico.accel.target_cwnd = 100 * mtu;
     cc.state.pico.accel.full_rtt = 120;
     cc.state.pico.accel.min_rtt_previous_period = 130;
+    cc.state.pico.accel.min_rtt_current_period = 100;
     loss.rtt.minimum = 80;
     loss.rtt.latest = 100;
-    ok(fabs(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, cc.cwnd) - 0.1) < 0.000001);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) == 1. / 40);
+    loss.rtt.minimum = 10;
+    loss.rtt.latest = 11;
+    loss.rtt.smoothed = 11;
+    cc.state.pico.accel.min_rtt_current_period = 11;
+    ok(fabs(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) - 2. / 13) < 0.000001);
+    /* full_rtt does not limit the increase rate while both RTT gates remain open. */
+    cc.state.pico.accel.min_rtt_previous_period = 200;
+    cc.state.pico.accel.min_rtt_current_period = 100;
+    cc.state.pico.accel.full_rtt = 120;
+    loss.rtt.latest = 100;
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) == 1. / 40);
+    loss.rtt.minimum = 80;
+    loss.rtt.latest = 100;
+    loss.rtt.smoothed = 100;
+    cc.state.pico.accel.min_rtt_current_period = 100;
     cc.state.pico.accel.full_rtt = 105;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, cc.cwnd) == 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) == 0);
 
     /* ECN applies its ordinary reduction, then permits accelerated increase when RTT has drained. */
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
     cc.state.pico.accel.full_rtt = 120;
+    cc.state.pico.accel.min_rtt_current_period = loss.rtt.minimum;
     cc.type->cc_on_lost(&cc, &loss, 0, 10, 20, 1000, mtu);
-    ok(cc.state.pico.accel.target_cwnd > cc.cwnd);
     control = cc;
     control.random_loss_tolerance = 0;
     loss.rtt.latest = 81;
+    uint32_t accelerated_cwnd = accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu);
+    ok(accelerated_cwnd > cc.cwnd);
     cc.type->cc_on_acked(&cc, &loss, mtu, 20, mtu, 1, 21, 1100, mtu);
     control.type->cc_on_acked(&control, &loss, mtu, 20, mtu, 1, 21, 1100, mtu);
-    ok(cc.cwnd > control.cwnd);
+    ok(cc.cwnd == (control.cwnd < accelerated_cwnd ? accelerated_cwnd : control.cwnd));
 
     /* ECN encountered during calibration schedules the same full_rtt observation as packet loss, while retaining ECN's ordinary
      * congestion response. */
@@ -667,7 +686,6 @@ static void test_cubic_random_loss_tolerance_guards(void)
     loss.rtt.smoothed = 125;
     cc.type->cc_on_lost(&cc, &loss, 0, 10, 20, 1000, mtu);
     ok(cc.state.pico.accel.full_rtt == 0);
-    ok(cc.state.pico.accel.target_cwnd != 0);
     loss.rtt.latest = 104;
     loss.rtt.smoothed = 122.375;
     cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
@@ -704,7 +722,7 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 2000, mtu);
     ok(cc.state.pico.accel.last_high_rtt_at == 1000);
     ok(cc.state.pico.accel.high_rtt_interval == 0);
-    double k = fast_cbrt((cc.state.pico.accel.target_cwnd - cc.ssthresh) / (QUICLY_CUBIC_C * mtu));
+    double k = fast_cbrt((cc.ssthresh / QUICLY_BETA_LOSS - cc.ssthresh) / (QUICLY_CUBIC_C * mtu));
     ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 1000));
     ok(cc.state.pico.accel.high_rtt_interval != 0);
     ok(cc.state.pico.accel.high_rtt_interval <
@@ -721,7 +739,6 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     cc.state.pico.cubic.epoch_start = 1000;
     cc.state.pico.cubic.k = 2;
     cc.state.pico.accel.full_rtt = 120;
-    cc.state.pico.accel.target_cwnd = 60 * mtu;
     cc.state.pico.accel.last_high_rtt_at = 1000;
     cc.state.pico.accel.high_rtt_interval = 2000;
     cc.num_loss_episodes = 1;
@@ -735,7 +752,6 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 9999));
     ok(accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 10000));
 
-    cc.state.pico.accel.target_cwnd = 60 * mtu;
     cc.state.pico.accel.high_rtt_interval = 2000;
     cc.state.pico.accel.last_high_rtt_at = 1000;
     cc.type->cc_on_acked(&cc, &loss, 0, 30, 0, 1, 31, 4999, mtu);
@@ -780,8 +796,6 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
     ok(cc.state.pico.accel.full_rtt == 0);
     ok(cc.cwnd == initcwnd / 2);
     ok(cc.state.pico.cuback.cwnd_prior == initcwnd / 2);
-    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / QUICLY_BETA_LOSS));
-    ok(accel_calc_cwnd_cap(&cc.state.pico.accel) == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
     cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
     ok(cc.state.pico.accel.full_rtt == 120);
 
@@ -791,13 +805,12 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
     loss.rtt.smoothed = 105;
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 1200, mtu);
     ok(cc.cwnd == (uint32_t)(80 * mtu * QUICLY_BETA_LOSS));
-    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / QUICLY_BETA_LOSS));
     cc.type->cc_on_acked(&cc, &loss, mtu, 29, mtu, 1, 30, 1300, mtu);
 
     cc.state.pico.bytes_to_mtu_increase = UINT32_MAX;
     control = cc;
     control.random_loss_tolerance = 0;
-    uint32_t accelerated_interval = accel_bytes_per_mtu_increase(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu);
+    uint32_t accelerated_interval = accel_bytes_per_mtu_increase(&cc.state.pico.accel, &loss.rtt, mtu);
     cc.type->cc_on_acked(&cc, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
     control.type->cc_on_acked(&control, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
     ok(cc.cwnd == control.cwnd);
@@ -811,11 +824,10 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
     ok(cc.cwnd > control.cwnd);
 
     /* If ordinary Cuback reaches its next increase first, it wins that increment. Acceleration can shorten the following
-     * interval while the derived cap has not been reached. */
+     * interval. */
     cc = control;
     cc.random_loss_tolerance = 1;
     cc.state.pico.accel.full_rtt = 120;
-    cc.state.pico.accel.target_cwnd = cc.cwnd + 1;
     cc.state.pico.bytes_to_mtu_increase = 1;
     control = cc;
     control.random_loss_tolerance = 0;
@@ -826,12 +838,12 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
 
     /* Cuback uses the same adaptive RTT gate as CUBIC. */
     cc.state.pico.accel.full_rtt = 120;
-    cc.state.pico.accel.target_cwnd = cc.cwnd + mtu;
     cc.state.pico.accel.min_rtt_previous_period = 110;
     loss.rtt.latest = 104;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, cc.cwnd) > 0);
+    cc.state.pico.accel.min_rtt_current_period = 104;
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) > 0);
     loss.rtt.latest = 105;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, cc.cwnd) == 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) == 0);
 }
 
 static void test_cuback_random_loss_tolerance_recalibration(void)
@@ -847,14 +859,17 @@ static void test_cuback_random_loss_tolerance_recalibration(void)
     cc.state.pico.cuback.cwnd_prior = 60 * mtu;
     cc.state.pico.cuback.bandwidth = cc.cwnd * 1000. / loss.rtt.smoothed;
     cc.state.pico.accel.full_rtt = 120;
-    cc.state.pico.accel.target_cwnd = 60 * mtu;
     cc.state.pico.accel.last_high_rtt_at = 1000;
     cc.num_loss_episodes = 1;
 
-    double cuback_k = fast_cbrt((cc.state.pico.cuback.cwnd_prior - cc.ssthresh) / (QUICLY_CUBIC_C * mtu));
     ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 1000));
     uint32_t calculated_interval = cc.state.pico.accel.high_rtt_interval;
-    ok(calculated_interval < cuback_k * fast_cbrt(cc.state.pico.accel.full_rtt / loss.rtt.minimum) * 1000);
+    double cwnd_before_reduction = cc.ssthresh / QUICLY_BETA_LOSS;
+    double k = fast_cbrt((cwnd_before_reduction - cc.ssthresh) / (QUICLY_CUBIC_C * mtu));
+    double reno = QUICLY_CUBIC_C * k * k * k / cubic_friendly_alpha[0] * cc.state.pico.accel.full_rtt / 1000;
+    uint32_t expected_interval = (k < reno ? k : reno) *
+                                 fast_cbrt(cc.state.pico.accel.full_rtt / loss.rtt.minimum) * 1000;
+    ok(calculated_interval == expected_interval);
 
     cc.state.pico.accel.high_rtt_interval = 3000;
     cc.type->cc_on_acked(&cc, &loss, 0, 30, 0, 1, 31, 6999, mtu);

--- a/t/cc.c
+++ b/t/cc.c
@@ -634,7 +634,7 @@ static void test_cubic_random_loss_tolerance_guards(void)
     ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) == 0);
 
     /* Long-RTT paths retain the 2.5% floor, while shorter paths use the rate that adds approximately two milliseconds of flight
-     * per RTT. Acceleration stops with five percent of full_rtt still available. */
+     * per RTT. Acceleration stops once full_rtt is no more than five percent above the latest RTT. */
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
@@ -765,7 +765,8 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     ok(cc.cwnd < cc.ssthresh);
     ok(cc.cwnd == 60 * mtu);
 
-    /* A loss in calibration replaces full_rtt upon recovery exit; undo restores the calibration and preceding observation. */
+    /* A loss in calibration replaces full_rtt upon recovery exit; undo restores the calibration while retaining the
+       high-queue observation. */
     loss.rtt.latest = loss.rtt.smoothed = 130;
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 6100, mtu);
     ok(cc.state.pico.accel.full_rtt == 0);
@@ -775,7 +776,7 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     ok(cc.state.pico.accel.last_high_queue_at == 6150);
     cc.type->cc_on_late_ack(&cc, 20, 6200);
     ok(cc.state.pico.accel.full_rtt == 120);
-    ok(cc.state.pico.accel.last_high_queue_at == 1000);
+    ok(cc.state.pico.accel.last_high_queue_at == 6150);
     ok(cc.cwnd < cc.ssthresh);
     ok(cc.cwnd_exiting_slow_start == initcwnd);
 }
@@ -883,7 +884,8 @@ static void test_cuback_random_loss_tolerance_recalibration(void)
     ok(cc.cwnd == 60 * mtu);
     ok(cc.state.pico.cuback.bandwidth == 0);
 
-    /* A loss in calibration replaces full_rtt upon recovery exit; undo restores the calibration and preceding observation. */
+    /* A loss in calibration replaces full_rtt upon recovery exit; undo restores the calibration while retaining the
+       high-queue observation. */
     loss.rtt.latest = loss.rtt.smoothed = 130;
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 8100, mtu);
     ok(cc.state.pico.accel.full_rtt == 0);
@@ -893,7 +895,7 @@ static void test_cuback_random_loss_tolerance_recalibration(void)
     ok(cc.state.pico.accel.last_high_queue_at == 8150);
     cc.type->cc_on_late_ack(&cc, 20, 8200);
     ok(cc.state.pico.accel.full_rtt == 120);
-    ok(cc.state.pico.accel.last_high_queue_at == 1000);
+    ok(cc.state.pico.accel.last_high_queue_at == 8150);
     ok(cc.cwnd < cc.ssthresh);
     ok(cc.cwnd_exiting_slow_start == initcwnd);
 }

--- a/t/cc.c
+++ b/t/cc.c
@@ -535,24 +535,24 @@ static void test_cubic_random_loss_tolerance_accelerated_increase(void)
 
     cc.type->cc_on_acked(&cc, &loss, mtu, 29, mtu, 1, 30, 1300, mtu);
     uint32_t cwnd_before = cc.cwnd;
-    uint32_t first_increase = mtu * accel_calc_increase_ratio(&cc, &loss.rtt);
+    uint32_t first_increase = mtu * accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, cc.cwnd);
     cc.type->cc_on_acked(&cc, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
     ok(cc.cwnd == cwnd_before + first_increase);
 
     /* An aggregate ACK for one post-reduction flight applies the RTT-limited increase. A subsequent loss starts another accelerated
      * increase toward its own CWNDpre target. */
     uint32_t bytes_acked = cc.cwnd;
-    uint32_t expected_increase = bytes_acked * accel_calc_increase_ratio(&cc, &loss.rtt);
+    uint32_t expected_increase = bytes_acked * accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, cc.cwnd);
     cc.type->cc_on_acked(&cc, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1500, mtu);
     ok(cc.cwnd == cwnd_before + first_increase + expected_increase);
 
     /* Once CWND reaches the recovery target, acceleration continues at the minimum rate up to target / beta, then stops. */
     cc.cwnd = cc.state.pico.accel.target_cwnd;
-    ok(accel_calc_increase_ratio(&cc, &loss.rtt) == 1. / 40);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, cc.cwnd) == 1. / 40);
     uint32_t cwnd_cap = accel_calc_cwnd_cap(&cc.state.pico.accel);
-    ok(accel_calc_cubic_cwnd(&cc, &loss.rtt, (cwnd_cap - cc.cwnd) * 40, 1) == cwnd_cap);
+    ok(accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, (cwnd_cap - cc.cwnd) * 40) == cwnd_cap);
     cc.cwnd = cwnd_cap;
-    ok(accel_calc_increase_ratio(&cc, &loss.rtt) == 0);
+    ok(accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu) == cwnd_cap);
 
     uint32_t second_cwnd_at_loss = cc.cwnd;
     cc.type->cc_on_lost(&cc, &loss, mtu, 32, 40, 1600, mtu);
@@ -612,11 +612,11 @@ static void test_cubic_random_loss_tolerance_guards(void)
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
     cc.state.pico.accel.full_rtt = 120;
-    cc.state.pico.accel.min_rtt_in_ca = 110;
+    cc.state.pico.accel.min_rtt_current_period = 110;
     loss.rtt.latest = 104;
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
-    ok(cc.state.pico.accel.min_rtt_in_previous_ca == 110);
-    ok(cc.state.pico.accel.min_rtt_in_ca == 0);
+    ok(cc.state.pico.accel.min_rtt_previous_period == 110);
+    ok(cc.state.pico.accel.min_rtt_current_period == 0);
     cc.type->cc_on_acked(&cc, &loss, mtu, 19, mtu, 1, 20, 1100, mtu);
     control = cc;
     control.random_loss_tolerance = 0;
@@ -639,20 +639,26 @@ static void test_cubic_random_loss_tolerance_guards(void)
     cc.cwnd = 70 * mtu;
     cc.state.pico.accel.target_cwnd = 100 * mtu;
     cc.state.pico.accel.full_rtt = 120;
-    cc.state.pico.accel.min_rtt_in_previous_ca = 130;
+    cc.state.pico.accel.min_rtt_previous_period = 130;
     loss.rtt.minimum = 80;
     loss.rtt.latest = 100;
-    ok(fabs(accel_calc_increase_ratio(&cc, &loss.rtt) - 0.1) < 0.000001);
+    ok(fabs(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, cc.cwnd) - 0.1) < 0.000001);
     cc.state.pico.accel.full_rtt = 105;
-    ok(accel_calc_increase_ratio(&cc, &loss.rtt) == 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, cc.cwnd) == 0);
 
-    /* ECN is an explicit congestion signal and never opens accelerated increase. */
+    /* ECN applies its ordinary reduction, then permits accelerated increase when RTT has drained. */
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
     cc.state.pico.accel.full_rtt = 120;
     cc.type->cc_on_lost(&cc, &loss, 0, 10, 20, 1000, mtu);
-    ok(cc.state.pico.accel.target_cwnd == 0);
+    ok(cc.state.pico.accel.target_cwnd > cc.cwnd);
+    control = cc;
+    control.random_loss_tolerance = 0;
+    loss.rtt.latest = 81;
+    cc.type->cc_on_acked(&cc, &loss, mtu, 20, mtu, 1, 21, 1100, mtu);
+    control.type->cc_on_acked(&control, &loss, mtu, 20, mtu, 1, 21, 1100, mtu);
+    ok(cc.cwnd > control.cwnd);
 
     /* ECN encountered during calibration schedules the same full_rtt observation as packet loss, while retaining ECN's ordinary
      * congestion response. */
@@ -682,6 +688,8 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     quicly_loss_t loss = {.rtt = {.latest = 109, .smoothed = 109, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 100 * mtu;
 
+    /* A loss starts a new CUBIC epoch but does not restart the time available for deciding whether the path should be
+     * recalibrated. The new epoch's K is used for the decision. */
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
     cc.cwnd = 60 * mtu;
     cc.ssthresh = 50 * mtu;
@@ -691,9 +699,48 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     cc.state.pico.cubic.epoch_start = 1000;
     cc.state.pico.cubic.k = 2;
     cc.state.pico.accel.full_rtt = 120;
+    cc.state.pico.accel.last_high_rtt_at = 1000;
+    cc.num_loss_episodes = 1;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 2000, mtu);
+    ok(cc.state.pico.accel.last_high_rtt_at == 1000);
+    ok(cc.state.pico.accel.high_rtt_interval == 0);
+    double k = fast_cbrt((cc.state.pico.accel.target_cwnd - cc.ssthresh) / (QUICLY_CUBIC_C * mtu));
+    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 1000));
+    ok(cc.state.pico.accel.high_rtt_interval != 0);
+    ok(cc.state.pico.accel.high_rtt_interval <
+       k * fast_cbrt(cc.state.pico.accel.full_rtt / loss.rtt.minimum) * 1000);
+    ok(accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu,
+                         1000 + 2 * (int64_t)cc.state.pico.accel.high_rtt_interval));
 
-    accel_observe_path(&cc, &loss.rtt, 1, 1001, mtu);
-    accel_observe_path(&cc, &loss.rtt, 1, 6000, mtu);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    cc.cwnd = 60 * mtu;
+    cc.ssthresh = 50 * mtu;
+    cc.cwnd_exiting_slow_start = initcwnd;
+    cc.state.pico.cubic.w_est = cc.cwnd;
+    cc.state.pico.cubic.cwnd_prior = initcwnd;
+    cc.state.pico.cubic.epoch_start = 1000;
+    cc.state.pico.cubic.k = 2;
+    cc.state.pico.accel.full_rtt = 120;
+    cc.state.pico.accel.target_cwnd = 60 * mtu;
+    cc.state.pico.accel.last_high_rtt_at = 1000;
+    cc.state.pico.accel.high_rtt_interval = 2000;
+    cc.num_loss_episodes = 1;
+
+    /* Reaching the threshold refreshes the timestamp. Recalibration requires the current interval to pass after the latest such
+     * observation. */
+    loss.rtt.smoothed = 110;
+    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 6000));
+    ok(cc.state.pico.accel.last_high_rtt_at == 6000);
+    loss.rtt.smoothed = 109;
+    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 9999));
+    ok(accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 10000));
+
+    cc.state.pico.accel.target_cwnd = 60 * mtu;
+    cc.state.pico.accel.high_rtt_interval = 2000;
+    cc.state.pico.accel.last_high_rtt_at = 1000;
+    cc.type->cc_on_acked(&cc, &loss, 0, 30, 0, 1, 31, 4999, mtu);
+    ok(cc.ssthresh != UINT32_MAX);
+    cc.type->cc_on_acked(&cc, &loss, 0, 31, 0, 1, 32, 5000, mtu);
     ok(cc.ssthresh == UINT32_MAX);
     ok(cc.cwnd < cc.ssthresh);
     ok(cc.cwnd == 60 * mtu);
@@ -705,8 +752,10 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     ok(cc.cwnd >= cc.ssthresh);
     cc.type->cc_on_acked(&cc, &loss, 0, 30, 0, 1, 31, 6150, mtu);
     ok(cc.state.pico.accel.full_rtt == 130);
+    ok(cc.state.pico.accel.last_high_rtt_at == 6150);
     cc.type->cc_on_late_ack(&cc, 20, 6200);
     ok(cc.state.pico.accel.full_rtt == 120);
+    ok(cc.state.pico.accel.last_high_rtt_at == 1000);
     ok(cc.cwnd < cc.ssthresh);
     ok(cc.cwnd_exiting_slow_start == initcwnd);
 }
@@ -748,12 +797,12 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
     cc.state.pico.bytes_to_mtu_increase = UINT32_MAX;
     control = cc;
     control.random_loss_tolerance = 0;
-    uint32_t accelerated_interval = accel_bytes_per_mtu_increase(&cc, &loss.rtt, mtu);
+    uint32_t accelerated_interval = accel_bytes_per_mtu_increase(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu);
     cc.type->cc_on_acked(&cc, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
     control.type->cc_on_acked(&control, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
     ok(cc.cwnd == control.cwnd);
     ok(cc.state.pico.bytes_to_mtu_increase == accelerated_interval - mtu);
-    ok(cc.state.pico.accel.min_rtt_in_ca == 101);
+    ok(cc.state.pico.accel.min_rtt_current_period == 101);
 
     uint32_t bytes_acked = cc.state.pico.bytes_to_mtu_increase, cwnd_before = cc.cwnd;
     cc.type->cc_on_acked(&cc, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1450, mtu);
@@ -778,11 +827,11 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
     /* Cuback uses the same adaptive RTT gate as CUBIC. */
     cc.state.pico.accel.full_rtt = 120;
     cc.state.pico.accel.target_cwnd = cc.cwnd + mtu;
-    cc.state.pico.accel.min_rtt_in_previous_ca = 110;
+    cc.state.pico.accel.min_rtt_previous_period = 110;
     loss.rtt.latest = 104;
-    ok(accel_calc_increase_ratio(&cc, &loss.rtt) > 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, cc.cwnd) > 0);
     loss.rtt.latest = 105;
-    ok(accel_calc_increase_ratio(&cc, &loss.rtt) == 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, cc.cwnd) == 0);
 }
 
 static void test_cuback_random_loss_tolerance_recalibration(void)
@@ -798,9 +847,19 @@ static void test_cuback_random_loss_tolerance_recalibration(void)
     cc.state.pico.cuback.cwnd_prior = 60 * mtu;
     cc.state.pico.cuback.bandwidth = cc.cwnd * 1000. / loss.rtt.smoothed;
     cc.state.pico.accel.full_rtt = 120;
+    cc.state.pico.accel.target_cwnd = 60 * mtu;
+    cc.state.pico.accel.last_high_rtt_at = 1000;
+    cc.num_loss_episodes = 1;
 
-    accel_observe_path(&cc, &loss.rtt, 1, 1001, mtu);
-    accel_observe_path(&cc, &loss.rtt, 1, 8000, mtu);
+    double cuback_k = fast_cbrt((cc.state.pico.cuback.cwnd_prior - cc.ssthresh) / (QUICLY_CUBIC_C * mtu));
+    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 1000));
+    uint32_t calculated_interval = cc.state.pico.accel.high_rtt_interval;
+    ok(calculated_interval < cuback_k * fast_cbrt(cc.state.pico.accel.full_rtt / loss.rtt.minimum) * 1000);
+
+    cc.state.pico.accel.high_rtt_interval = 3000;
+    cc.type->cc_on_acked(&cc, &loss, 0, 30, 0, 1, 31, 6999, mtu);
+    ok(cc.ssthresh != UINT32_MAX);
+    cc.type->cc_on_acked(&cc, &loss, 0, 31, 0, 1, 32, 7000, mtu);
     ok(cc.ssthresh == UINT32_MAX);
     ok(cc.cwnd == 60 * mtu);
     ok(cc.state.pico.cuback.bandwidth == 0);
@@ -812,8 +871,10 @@ static void test_cuback_random_loss_tolerance_recalibration(void)
     ok(cc.cwnd >= cc.ssthresh);
     cc.type->cc_on_acked(&cc, &loss, 0, 30, 0, 1, 31, 8150, mtu);
     ok(cc.state.pico.accel.full_rtt == 130);
+    ok(cc.state.pico.accel.last_high_rtt_at == 8150);
     cc.type->cc_on_late_ack(&cc, 20, 8200);
     ok(cc.state.pico.accel.full_rtt == 120);
+    ok(cc.state.pico.accel.last_high_rtt_at == 1000);
     ok(cc.cwnd < cc.ssthresh);
     ok(cc.cwnd_exiting_slow_start == initcwnd);
 }

--- a/t/cc.c
+++ b/t/cc.c
@@ -30,7 +30,7 @@ static void test_pico_undo_loss(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 10 * mtu;
 
-    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0);
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0, 0);
     uint32_t bytes_per_mtu_increase = cc.state.pico.bytes_per_mtu_increase;
 
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
@@ -61,7 +61,7 @@ static void test_pico_undo_multiple_losses(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 10 * mtu;
 
-    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0);
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0, 0);
 
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     uint32_t reduced_cwnd = cc.cwnd;
@@ -94,7 +94,7 @@ static void test_pico_undo_rapid_start_loss(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 10 * mtu;
 
-    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0);
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0, 0);
     cc.type->enable_rapid_start(&cc, 900);
     ok(quicly_cc_rapid_start_is_enabled(&cc.rapid_start));
 
@@ -118,7 +118,7 @@ static void test_pico_undo_jumpstart_loss(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 10 * mtu, jumpcwnd = 24 * mtu;
 
-    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0);
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0, 0);
     cc.type->cc_jumpstart(&cc, jumpcwnd, 10);
     ok(quicly_cc_in_jumpstart(&cc));
     ok(cc.cwnd == jumpcwnd);
@@ -173,7 +173,7 @@ static void test_pico_ecn(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 10 * mtu;
 
-    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0);
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0, 0);
 
     /* exit slow start by observing a packet loss */
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
@@ -204,7 +204,7 @@ static void test_pico_ecn_rapid_start(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 10 * mtu;
 
-    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0);
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0, 0);
     cc.type->enable_rapid_start(&cc, 900);
 
     /* upon a CE mark, the silence factor derived from QUICLY_BETA_ECN (i.e., 0.95x) is applied */
@@ -233,7 +233,7 @@ static void test_cubic_fast_convergence(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 100 * mtu;
 
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0, 0);
 
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     ok(!cc.state.pico.cubic.fast_convergence);
@@ -260,7 +260,7 @@ static void test_cubic_target_bounds(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 10 * mtu;
 
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0, 0);
     cc.ssthresh = cc.cwnd;
     cc.state.pico.cubic.w_est = cc.cwnd;
     cc.state.pico.cubic.cwnd_prior = cc.cwnd;
@@ -269,7 +269,7 @@ static void test_cubic_target_bounds(void)
     cc.type->cc_on_acked(&cc, &loss, 2 * mtu, 1, cc.cwnd, 1, 2, 1000000, mtu);
     ok(cc.cwnd == initcwnd + mtu);
 
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0, 0);
     cc.ssthresh = cc.cwnd / 2;
     cc.state.pico.cubic.cwnd_prior = cc.cwnd / 2;
     cc.state.pico.cubic.w_est = cc.state.pico.cubic.cwnd_prior - 1;
@@ -308,7 +308,7 @@ static void test_cubic_mtu_normalization(void)
     uint32_t mtu = 1200, initcwnd = 10 * mtu;
 
     /* In the cubic region, normalization substitutes the reference MTU in W_cubic. */
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 1, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 1, 0, 0);
     cc.ssthresh = cc.cwnd;
     cc.state.pico.cubic.w_est = cc.cwnd;
     cc.state.pico.cubic.cwnd_prior = cc.cwnd;
@@ -319,7 +319,7 @@ static void test_cubic_mtu_normalization(void)
 
     /* In the Reno-friendly region, growth uses the reference MTU but CWND is still exposed in actual-MTU steps. Five windows of
      * ACKs therefore accumulate six 1200-byte steps (floor(5 * 1462 / 1200)). */
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 1, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 1, 0, 0);
     cc.ssthresh = cc.cwnd;
     cc.state.pico.cubic.w_est = cc.cwnd;
     cc.state.pico.cubic.cwnd_prior = cc.cwnd;
@@ -338,7 +338,7 @@ static void test_cubic_cc_limited(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 100 * mtu;
 
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0, 0);
     cc.ssthresh = cc.cwnd;
     cc.state.pico.cubic.cwnd_prior = 50 * mtu;
     cc.state.pico.cubic.epoch_start = 1000;
@@ -386,7 +386,7 @@ static void test_cubic_recovery_epoch(void)
     uint32_t mtu = 1200, initcwnd = 10 * mtu;
 
     /* RFC 9438 starts the epoch when congestion avoidance begins, not when congestion is detected. */
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0, 0);
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     ok(cc.state.pico.cubic.w_est == 0);
     ok(cc.state.pico.cubic.epoch_start == 0);
@@ -397,7 +397,7 @@ static void test_cubic_recovery_epoch(void)
     ok(cc.state.pico.cubic.epoch_start == 1200);
 
     /* If recovery exits while app-limited, initialize W_est but defer the wall-clock epoch until sending resumes. */
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0, 0);
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     cc.type->cc_update_cc_limited(&cc, 0, 1050);
     cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 0, 21, 1200, mtu);
@@ -413,7 +413,7 @@ static void test_cubic_rapid_start_epoch(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 10 * mtu;
 
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0, 0);
     cc.type->enable_rapid_start(&cc, 900);
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     ok(cc.state.pico.cubic.cwnd_prior != 0);
@@ -461,7 +461,7 @@ static void test_cubic_abe(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 100 * mtu;
 
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0, 0);
 
     /* Establish a 50-MTU W_max when leaving ordinary slow start. */
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
@@ -492,7 +492,7 @@ static void test_cubic_undo_loss(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 10 * mtu;
 
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 0, 0);
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     ok(cc.state.pico.cubic.cwnd_prior != 0);
 
@@ -504,11 +504,137 @@ static void test_cubic_undo_loss(void)
     ok(cc.num_loss_episodes_undone == 1);
 }
 
+static void test_cubic_random_loss_tolerance_accelerated_recovery(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 120, .smoothed = 120, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 100 * mtu;
+
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+
+    /* The startup loss obtains the scalar qoRTT observation and uses CWND at loss as W_max. */
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    ok(cc.state.pico.cubic.random_loss.qortt == 120);
+    ok(cc.state.pico.cubic.cwnd_prior == initcwnd);
+    ok(cc.state.pico.cubic.random_loss.recovery_target == 0);
+
+    cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
+
+    /* An ordinary CA packet loss applies the ordinary 0.7 reduction. ACKs then use half the current relative distance to the
+     * pre-loss CWND as the growth coefficient, with a 2.5% minimum. */
+    cc.cwnd = 80 * mtu;
+    loss.rtt.latest = 101;
+    loss.rtt.smoothed = 105;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 1200, mtu);
+    ok(cc.cwnd == (uint32_t)(80 * mtu * QUICLY_BETA_LOSS));
+    ok(cc.state.pico.cubic.random_loss.recovery_target == 80 * mtu);
+
+    cc.type->cc_on_acked(&cc, &loss, mtu, 29, mtu, 1, 30, 1300, mtu);
+    uint32_t cwnd_before = cc.cwnd;
+    cc.type->cc_on_acked(&cc, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
+    ok(cc.cwnd == cwnd_before + mtu * 3 / 14);
+
+    /* An aggregate ACK for one post-reduction flight recovers half the remaining distance. A persistent loss then moves CWND below
+     * the preceding recovery's reduced CWND, rather than returning to the same threshold. */
+    uint32_t bytes_acked = cc.cwnd;
+    uint32_t distance = cc.state.pico.cubic.random_loss.recovery_target - cc.cwnd;
+    uint32_t expected_increase = distance / 2;
+    cc.type->cc_on_acked(&cc, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1500, mtu);
+    ok(cc.cwnd == cwnd_before + mtu * 3 / 14 + expected_increase);
+    uint32_t first_reduced_cwnd = (uint32_t)(80 * mtu * QUICLY_BETA_LOSS);
+    cc.type->cc_on_lost(&cc, &loss, mtu, 32, 40, 1600, mtu);
+    ok(cc.cwnd < first_reduced_cwnd);
+}
+
+static void test_cubic_random_loss_tolerance_guards(void)
+{
+    quicly_cc_t cc, control;
+    quicly_loss_t loss = {.rtt = {.latest = 101, .smoothed = 105, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 100 * mtu;
+
+    /* A qoRTT observation exactly 10ms above minRTT does not enable accelerated recovery. */
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    cc.cwnd_exiting_slow_start = initcwnd;
+    cc.ssthresh = 50 * mtu;
+    cc.state.pico.cubic.random_loss.qortt = 110;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    cc.type->cc_on_acked(&cc, &loss, mtu, 19, mtu, 1, 20, 1100, mtu);
+    control = cc;
+    control.random_loss_tolerance = 0;
+    cc.type->cc_on_acked(&cc, &loss, mtu, 20, mtu, 1, 21, 1200, mtu);
+    control.type->cc_on_acked(&control, &loss, mtu, 20, mtu, 1, 21, 1200, mtu);
+    ok(cc.cwnd == control.cwnd);
+
+    /* A current RTT exactly 2ms above minRTT leaves CUBIC on its ordinary trajectory even if an earlier recovery ACK was below the
+     * threshold. */
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    cc.cwnd_exiting_slow_start = initcwnd;
+    cc.ssthresh = 50 * mtu;
+    cc.state.pico.cubic.random_loss.qortt = 120;
+    loss.rtt.latest = 101;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    cc.type->cc_on_acked(&cc, &loss, mtu, 19, mtu, 1, 20, 1100, mtu);
+    loss.rtt.latest = 102;
+    control = cc;
+    control.random_loss_tolerance = 0;
+    cc.type->cc_on_acked(&cc, &loss, mtu, 20, mtu, 1, 21, 1200, mtu);
+    control.type->cc_on_acked(&control, &loss, mtu, 20, mtu, 1, 21, 1200, mtu);
+    ok(cc.cwnd == control.cwnd);
+
+    /* ECN is an explicit congestion signal and never opens accelerated recovery. */
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    cc.cwnd_exiting_slow_start = initcwnd;
+    cc.ssthresh = 50 * mtu;
+    cc.state.pico.cubic.random_loss.qortt = 120;
+    cc.type->cc_on_lost(&cc, &loss, 0, 10, 20, 1000, mtu);
+    ok(cc.state.pico.cubic.random_loss.recovery_target == 0);
+}
+
+static void test_cubic_random_loss_tolerance_recalibration(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 109, .smoothed = 109, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 100 * mtu;
+
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    cc.cwnd = 60 * mtu;
+    cc.ssthresh = 50 * mtu;
+    cc.cwnd_exiting_slow_start = initcwnd;
+    cc.state.pico.cubic.w_est = cc.cwnd;
+    cc.state.pico.cubic.cwnd_prior = initcwnd;
+    cc.state.pico.cubic.epoch_start = 1000;
+    cc.state.pico.cubic.k = 2;
+    cc.state.pico.cubic.random_loss.qortt = 120;
+
+    cubic_random_loss_observe_path(&cc, &loss, 1001);
+    cubic_random_loss_observe_path(&cc, &loss, 6000);
+    ok(cc.ssthresh == UINT32_MAX);
+    ok(cc.cwnd < cc.ssthresh);
+    ok(cc.cwnd == 60 * mtu);
+
+    /* A loss in calibration replaces qoRTT; undo restores the calibration and the preceding observation. */
+    loss.rtt.latest = loss.rtt.smoothed = 130;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 6100, mtu);
+    ok(cc.state.pico.cubic.random_loss.qortt == 130);
+    ok(cc.cwnd >= cc.ssthresh);
+    cc.type->cc_on_late_ack(&cc, 20, 6200);
+    ok(cc.state.pico.cubic.random_loss.qortt == 120);
+    ok(cc.cwnd < cc.ssthresh);
+    ok(cc.cwnd_exiting_slow_start == initcwnd);
+}
+
+static void test_cubic_random_loss_tolerance(void)
+{
+    subtest("accelerated-recovery", test_cubic_random_loss_tolerance_accelerated_recovery);
+    subtest("guards", test_cubic_random_loss_tolerance_guards);
+    subtest("recalibration", test_cubic_random_loss_tolerance_recalibration);
+}
+
 static void test_cubic_legacy_name(void)
 {
     quicly_cc_t cc;
 
-    quicly_cc_cubic_legacy_init.cb(&quicly_cc_cubic_legacy_init, &cc, 12000, 0, 0);
+    quicly_cc_cubic_legacy_init.cb(&quicly_cc_cubic_legacy_init, &cc, 12000, 0, 0, 0);
     ok(cc.type == &quicly_cc_type_cubic_legacy);
     ok(strcmp(cc.type->name, "cubic-legacy") == 0);
 }
@@ -519,7 +645,7 @@ static void test_pico_ack_countdown(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 10 * mtu;
 
-    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0);
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0, 0);
     cc.type->cc_on_acked(&cc, &loss, mtu - 1, 1, mtu - 1, 1, 2, 100, mtu);
     ok(cc.cwnd == initcwnd);
     ok(cc.state.pico.bytes_to_mtu_increase == 1);
@@ -529,7 +655,7 @@ static void test_pico_ack_countdown(void)
     ok(cc.state.pico.bytes_to_mtu_increase == mtu);
 
     /* The interval switches to Pico's congestion-avoidance rate when an increase reaches ssthresh. */
-    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0);
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0, 0, 0);
     cc.ssthresh = initcwnd + mtu;
     cc.type->cc_on_acked(&cc, &loss, mtu, 1, mtu, 1, 2, 100, mtu);
     ok(cc.cwnd == cc.ssthresh);
@@ -542,7 +668,7 @@ static void test_pico_switch_resets_ack_credit(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 10 * mtu;
 
-    quicly_cc_reno_init.cb(&quicly_cc_reno_init, &cc, initcwnd, 0, 0);
+    quicly_cc_reno_init.cb(&quicly_cc_reno_init, &cc, initcwnd, 0, 0, 0);
     cc.ssthresh = cc.cwnd;
     cc.type->cc_on_acked(&cc, &loss, initcwnd - 1, 1, initcwnd - 1, 1, 2, 100, mtu);
     ok(cc.cwnd == initcwnd);
@@ -565,7 +691,7 @@ static void test_reno(void)
     uint32_t mtu = 1200, initcwnd = 100 * mtu;
 
     /* Reno grows by one MTU for each current-CWND bytes acknowledged. */
-    quicly_cc_reno_init.cb(&quicly_cc_reno_init, &cc, initcwnd, 0, 0);
+    quicly_cc_reno_init.cb(&quicly_cc_reno_init, &cc, initcwnd, 0, 0, 0);
     cc.ssthresh = cc.cwnd;
     cc.type->cc_on_acked(&cc, &loss, initcwnd - 1, 1, initcwnd - 1, 1, 2, 100, mtu);
     ok(cc.cwnd == initcwnd);
@@ -574,7 +700,7 @@ static void test_reno(void)
     ok(cc.cwnd == initcwnd + mtu);
 
     /* Packet-size normalization shortens the ACK deficit so that actual-MTU CWND steps amortize to the reference MTU per RTT. */
-    quicly_cc_reno_init.cb(&quicly_cc_reno_init, &cc, initcwnd, 1, 0);
+    quicly_cc_reno_init.cb(&quicly_cc_reno_init, &cc, initcwnd, 1, 0, 0);
     cc.ssthresh = cc.cwnd;
     uint32_t normalized_deficit = (uint64_t)initcwnd * mtu / QUICLY_CC_REFERENCE_MTU;
     cc.type->cc_on_acked(&cc, &loss, normalized_deficit - 1, 1, normalized_deficit - 1, 1, 2, 100, mtu);
@@ -584,12 +710,12 @@ static void test_reno(void)
     ok(cc.cwnd == initcwnd + mtu);
 
     /* Normalization does not alter slow start. */
-    quicly_cc_reno_init.cb(&quicly_cc_reno_init, &cc, initcwnd, 1, 0);
+    quicly_cc_reno_init.cb(&quicly_cc_reno_init, &cc, initcwnd, 1, 0, 0);
     cc.type->cc_on_acked(&cc, &loss, mtu, 1, mtu, 1, 2, 100, mtu);
     ok(cc.cwnd == initcwnd + mtu);
 
     /* Startup uses the shared 0.5 reduction; subsequent loss uses the policy beta. */
-    quicly_cc_reno_init.cb(&quicly_cc_reno_init, &cc, initcwnd, 0, 0);
+    quicly_cc_reno_init.cb(&quicly_cc_reno_init, &cc, initcwnd, 0, 0, 0);
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     ok(cc.cwnd == initcwnd / 2);
     cc.cwnd = 40 * mtu;
@@ -600,7 +726,7 @@ static void test_reno(void)
     ok(cc.state.pico.bytes_to_mtu_increase == cc.cwnd - mtu);
 
     /* Reno uses the same beta for ECN and packet loss. */
-    quicly_cc_reno_init.cb(&quicly_cc_reno_init, &cc, initcwnd, 0, 0);
+    quicly_cc_reno_init.cb(&quicly_cc_reno_init, &cc, initcwnd, 0, 0, 0);
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     cc.cwnd = 40 * mtu;
     cc.type->cc_on_lost(&cc, &loss, 0, 20, 30, 1100, mtu);
@@ -691,7 +817,7 @@ static void test_cuback_ack_countdown(void)
     quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, w_max = 2 * mtu;
 
-    quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, w_max, 0, 0);
+    quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, w_max, 0, 0, 0);
     cc.ssthresh = cc.cwnd;
     cc.state.pico.cuback.cwnd_prior = w_max;
     cc.state.pico.cuback.bandwidth = w_max * 1000. / loss.rtt.smoothed;
@@ -709,7 +835,7 @@ static void test_cuback_ack_countdown(void)
     ok(cc.state.pico.bytes_to_mtu_increase == 3 * mtu);
 
     /* The policy-level option selects the normalized ACK threshold while retaining actual-MTU CWND steps. */
-    quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, w_max, 1, 0);
+    quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, w_max, 1, 0, 0);
     cc.ssthresh = cc.cwnd;
     cc.state.pico.cuback.cwnd_prior = w_max;
     cc.state.pico.cuback.bandwidth = w_max * 1000. / loss.rtt.smoothed;
@@ -726,13 +852,13 @@ static void test_cuback_deferred_bdp_estimate(void)
     uint32_t mtu = 1200, initcwnd = 10 * mtu;
 
     /* An ordinary first loss retains the estimated BDP as W_max, matching HEAD's special 0.5 startup reduction. */
-    quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, initcwnd, 0, 0);
+    quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, initcwnd, 0, 0, 0);
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     ok(cc.state.pico.cuback.cwnd_prior == initcwnd / 2);
 
     /* Rapid Start continues adjusting CWND throughout recovery, so W_max is derived from the final CWND afterward, using twice
      * the BDP estimate. */
-    quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, initcwnd, 0, 0);
+    quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, initcwnd, 0, 0, 0);
     cc.type->enable_rapid_start(&cc, 900);
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     ok(cc.state.pico.cuback.bandwidth > 0);
@@ -767,7 +893,7 @@ static void test_zero_byte_ack_exits_rapid_start_recovery(void)
     for (size_t i = 0; i != PTLS_ELEMENTSOF(policies); ++i) {
         for (int second_by_ecn = 0; second_by_ecn != 2; ++second_by_ecn) {
             quicly_cc_t cc;
-            policies[i]->cb(policies[i], &cc, initcwnd, 0, 0);
+            policies[i]->cb(policies[i], &cc, initcwnd, 0, 0, 0);
             cc.type->enable_rapid_start(&cc, 900);
 
             cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
@@ -832,6 +958,7 @@ void test_cc(void)
     subtest("cubic-rapid-start-epoch", test_cubic_rapid_start_epoch);
     subtest("cubic-abe", test_cubic_abe);
     subtest("cubic-undo-loss", test_cubic_undo_loss);
+    subtest("cubic-random-loss-tolerance", test_cubic_random_loss_tolerance);
     subtest("cubic-legacy-name", test_cubic_legacy_name);
     subtest("pico-ack-countdown", test_pico_ack_countdown);
     subtest("pico-switch-resets-ack-credit", test_pico_switch_resets_ack_credit);

--- a/t/cc.c
+++ b/t/cc.c
@@ -512,24 +512,25 @@ static void test_cubic_random_loss_tolerance_accelerated_increase(void)
 
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
 
-    /* The startup loss obtains the scalar qoRTT observation, applies the ordinary slow-start reduction, and opens accelerated
-     * increase toward reduced CWND / beta^2. */
+    /* The startup loss obtains the scalar qoRTT observation, applies the ordinary slow-start reduction, and sets the acceleration
+     * target using the ordinary loss beta. */
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     ok(cc.state.pico.accel.qortt == 120);
     ok(cc.cwnd == initcwnd / 2);
     ok(cc.state.pico.cubic.cwnd_prior == initcwnd / 2);
-    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
+    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / QUICLY_BETA_LOSS));
+    ok(accel_calc_cwnd_cap(&cc.state.pico.accel) == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
 
     cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
 
-    /* An ordinary CA packet loss applies the ordinary 0.7 reduction. ACKs then use half the current relative distance to
-     * CWNDpre / beta as the growth coefficient, with a 2.5% minimum. */
+    /* An ordinary CA packet loss applies the ordinary 0.7 reduction. ACKs then use half the current relative distance to CWNDpre
+     * as the growth coefficient, with a 2.5% minimum until reaching CWNDpre / beta. */
     cc.cwnd = 80 * mtu;
     loss.rtt.latest = 101;
     loss.rtt.smoothed = 105;
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 1200, mtu);
     ok(cc.cwnd == (uint32_t)(80 * mtu * QUICLY_BETA_LOSS));
-    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
+    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / QUICLY_BETA_LOSS));
 
     cc.type->cc_on_acked(&cc, &loss, mtu, 29, mtu, 1, 30, 1300, mtu);
     uint32_t cwnd_before = cc.cwnd;
@@ -539,16 +540,25 @@ static void test_cubic_random_loss_tolerance_accelerated_increase(void)
     ok(cc.cwnd == cwnd_before + first_increase);
 
     /* An aggregate ACK for one post-reduction flight recovers half the remaining distance. A subsequent loss starts another
-     * accelerated increase toward its own CWNDpre / beta target. */
+     * accelerated increase toward its own CWNDpre target. */
     uint32_t bytes_acked = cc.cwnd;
     uint32_t distance = cc.state.pico.accel.target_cwnd - cc.cwnd;
     uint32_t expected_increase = distance / 2;
     cc.type->cc_on_acked(&cc, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1500, mtu);
     ok(cc.cwnd == cwnd_before + first_increase + expected_increase);
+
+    /* Once CWND reaches the recovery target, acceleration continues at the minimum rate up to target / beta, then stops. */
+    cc.cwnd = cc.state.pico.accel.target_cwnd;
+    ok(accel_calc_increase_ratio(&cc, &loss.rtt) == 1. / 40);
+    uint32_t cwnd_cap = accel_calc_cwnd_cap(&cc.state.pico.accel);
+    ok(accel_calc_cubic_cwnd(&cc, &loss.rtt, (cwnd_cap - cc.cwnd) * 40, 1) == cwnd_cap);
+    cc.cwnd = cwnd_cap;
+    ok(accel_calc_increase_ratio(&cc, &loss.rtt) == 0);
+
     uint32_t second_cwnd_at_loss = cc.cwnd;
     cc.type->cc_on_lost(&cc, &loss, mtu, 32, 40, 1600, mtu);
     ok(cc.cwnd == (uint32_t)(second_cwnd_at_loss * QUICLY_BETA_LOSS));
-    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
+    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / QUICLY_BETA_LOSS));
 }
 
 static void test_cubic_random_loss_tolerance_guards(void)
@@ -648,7 +658,8 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
     ok(cc.state.pico.accel.qortt == 120);
     ok(cc.cwnd == initcwnd / 2);
     ok(cc.state.pico.cuback.cwnd_prior == initcwnd / 2);
-    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
+    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / QUICLY_BETA_LOSS));
+    ok(accel_calc_cwnd_cap(&cc.state.pico.accel) == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
     cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
 
     /* After an ordinary CA loss, Cuback reduces its ACK interval when accelerated increase is faster than the ordinary curve. */
@@ -657,7 +668,7 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
     loss.rtt.smoothed = 105;
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 1200, mtu);
     ok(cc.cwnd == (uint32_t)(80 * mtu * QUICLY_BETA_LOSS));
-    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
+    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / QUICLY_BETA_LOSS));
     cc.type->cc_on_acked(&cc, &loss, mtu, 29, mtu, 1, 30, 1300, mtu);
 
     cc.state.pico.bytes_to_mtu_increase = UINT32_MAX;
@@ -675,7 +686,8 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
     ok(cc.cwnd == cwnd_before + mtu);
     ok(cc.cwnd > control.cwnd);
 
-    /* If ordinary Cuback grows farther, it wins and retains its byte-counter state. */
+    /* If ordinary Cuback reaches its next increase first, it wins that increment. Acceleration can shorten the following
+     * interval while the derived cap has not been reached. */
     cc = control;
     cc.random_loss_tolerance = 1;
     cc.state.pico.accel.qortt = 120;
@@ -683,10 +695,10 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
     cc.state.pico.bytes_to_mtu_increase = 1;
     control = cc;
     control.random_loss_tolerance = 0;
-    cc.type->cc_on_acked(&cc, &loss, mtu, 32, mtu, 1, 33, 1500, mtu);
-    control.type->cc_on_acked(&control, &loss, mtu, 32, mtu, 1, 33, 1500, mtu);
+    cc.type->cc_on_acked(&cc, &loss, 1, 32, 1, 1, 33, 1500, mtu);
+    control.type->cc_on_acked(&control, &loss, 1, 32, 1, 1, 33, 1500, mtu);
     ok(cc.cwnd == control.cwnd);
-    ok(cc.state.pico.bytes_to_mtu_increase == control.state.pico.bytes_to_mtu_increase);
+    ok(cc.state.pico.bytes_to_mtu_increase <= control.state.pico.bytes_to_mtu_increase);
 }
 
 static void test_cuback_random_loss_tolerance_recalibration(void)

--- a/t/cc.c
+++ b/t/cc.c
@@ -504,13 +504,13 @@ static void test_cubic_undo_loss(void)
     ok(cc.num_loss_episodes_undone == 1);
 }
 
-static void test_cubic_random_loss_tolerance_accelerated_increase(void)
+static void test_cubic_accel_adaptation_accelerated_increase(void)
 {
     quicly_cc_t cc, control;
     quicly_loss_t loss = {.rtt = {.latest = 120, .smoothed = 120, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 100 * mtu;
 
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
 
     /* The startup loss schedules a full_rtt observation and applies the ordinary slow-start reduction. The smoothed RTT is
      * adopted when recovery exits. */
@@ -531,18 +531,20 @@ static void test_cubic_random_loss_tolerance_accelerated_increase(void)
     ok(cc.cwnd == (uint32_t)(80 * mtu * QUICLY_BETA_LOSS));
 
     cc.type->cc_on_acked(&cc, &loss, mtu, 29, mtu, 1, 30, 1300, mtu);
-    uint32_t accelerated_cwnd = accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu);
+    uint32_t accelerated_cwnd =
+        accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON);
     control = cc;
-    control.random_loss_tolerance = 0;
+    control.accel_adaptation = 0;
     cc.type->cc_on_acked(&cc, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
     control.type->cc_on_acked(&control, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
     ok(cc.cwnd == (control.cwnd < accelerated_cwnd ? accelerated_cwnd : control.cwnd));
 
     /* An aggregate ACK for one post-reduction flight applies the accelerated increase. */
     uint32_t bytes_acked = cc.cwnd;
-    accelerated_cwnd = accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, bytes_acked);
+    accelerated_cwnd =
+        accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, bytes_acked, QUICLY_CC_ACCEL_ADAPTATION_ON);
     control = cc;
-    control.random_loss_tolerance = 0;
+    control.accel_adaptation = 0;
     cc.type->cc_on_acked(&cc, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1500, mtu);
     control.type->cc_on_acked(&control, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1500, mtu);
     ok(cc.cwnd == (control.cwnd < accelerated_cwnd ? accelerated_cwnd : control.cwnd));
@@ -551,6 +553,46 @@ static void test_cubic_random_loss_tolerance_accelerated_increase(void)
     uint32_t second_cwnd_at_loss = cc.cwnd;
     cc.type->cc_on_lost(&cc, &loss, mtu, 32, 40, 1600, mtu);
     ok(cc.cwnd == (uint32_t)(second_cwnd_at_loss * QUICLY_BETA_LOSS));
+}
+
+static void test_cubic_accel_adaptation_increase_always(void)
+{
+    quicly_cc_t cc, control;
+    quicly_loss_t loss = {.rtt = {.latest = 120, .smoothed = 120, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 100 * mtu;
+
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, QUICLY_CC_ACCEL_ADAPTATION_INCREASE_ALWAYS, 0);
+
+    /* Supply an RTT during initial slow start, then exit it through an ordinary loss. */
+    cc.type->cc_on_acked(&cc, &loss, mtu, 9, mtu, 1, 10, 900, mtu);
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
+    ok(cc.state.pico.accel.full_rtt == 120);
+
+    /* The adaptive RTT gate alone permits accelerated increase, even without a usable full_rtt observation. */
+    cc.state.pico.accel.full_rtt = 0;
+    loss.rtt.latest = 101;
+    control = cc;
+    control.accel_adaptation = 0;
+    cc.type->cc_on_acked(&cc, &loss, mtu, 21, mtu, 1, 22, 1200, mtu);
+    control.type->cc_on_acked(&control, &loss, mtu, 21, mtu, 1, 22, 1200, mtu);
+    ok(cc.cwnd > control.cwnd);
+
+    /* The flags are composable: adding RECALIBRATE observes full_rtt, while INCREASE_ALWAYS continues to bypass its guard. */
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0,
+                            QUICLY_CC_ACCEL_ADAPTATION_INCREASE_ALWAYS | QUICLY_CC_ACCEL_ADAPTATION_RECALIBRATE, 0);
+    loss.rtt.latest = loss.rtt.smoothed = 120;
+    cc.type->cc_on_acked(&cc, &loss, mtu, 9, mtu, 1, 10, 900, mtu);
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
+    ok(cc.state.pico.accel.full_rtt == 120);
+    cc.state.pico.accel.full_rtt = 110;
+    loss.rtt.latest = 101;
+    control = cc;
+    control.accel_adaptation = QUICLY_CC_ACCEL_ADAPTATION_RECALIBRATE;
+    cc.type->cc_on_acked(&cc, &loss, mtu, 21, mtu, 1, 22, 1200, mtu);
+    control.type->cc_on_acked(&control, &loss, mtu, 21, mtu, 1, 22, 1200, mtu);
+    ok(cc.cwnd > control.cwnd);
 }
 
 static void test_smoothed_rtt_before_latest(void)
@@ -564,28 +606,28 @@ static void test_smoothed_rtt_before_latest(void)
     ok(calc_smoothed_rtt_before_latest(&rtt) == preceding);
 }
 
-static void test_cubic_random_loss_tolerance_guards(void)
+static void test_cubic_accel_adaptation_guards(void)
 {
     quicly_cc_t cc, control;
     quicly_loss_t loss = {.rtt = {.latest = 101, .smoothed = 105, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 100 * mtu;
 
     /* A full_rtt observation exactly 10ms above minRTT does not enable accelerated increase. */
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
     cc.state.pico.accel.full_rtt = 110;
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     cc.type->cc_on_acked(&cc, &loss, mtu, 19, mtu, 1, 20, 1100, mtu);
     control = cc;
-    control.random_loss_tolerance = 0;
+    control.accel_adaptation = 0;
     cc.type->cc_on_acked(&cc, &loss, mtu, 20, mtu, 1, 21, 1200, mtu);
     control.type->cc_on_acked(&control, &loss, mtu, 20, mtu, 1, 21, 1200, mtu);
     ok(cc.cwnd == control.cwnd);
 
     /* A current RTT exactly 2ms above minRTT leaves CUBIC on its ordinary trajectory even if an earlier recovery ACK was below the
      * threshold. */
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
     cc.state.pico.accel.full_rtt = 120;
@@ -594,14 +636,14 @@ static void test_cubic_random_loss_tolerance_guards(void)
     cc.type->cc_on_acked(&cc, &loss, mtu, 19, mtu, 1, 20, 1100, mtu);
     loss.rtt.latest = 102;
     control = cc;
-    control.random_loss_tolerance = 0;
+    control.accel_adaptation = 0;
     cc.type->cc_on_acked(&cc, &loss, mtu, 20, mtu, 1, 21, 1200, mtu);
     control.type->cc_on_acked(&control, &loss, mtu, 20, mtu, 1, 21, 1200, mtu);
     ok(cc.cwnd == control.cwnd);
 
     /* A raised minimum throughout the preceding CA period raises the gate halfway toward that observation. The existing 2ms
      * allowance remains the lower bound. */
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
     cc.state.pico.accel.full_rtt = 120;
@@ -612,7 +654,7 @@ static void test_cubic_random_loss_tolerance_guards(void)
     ok(cc.state.pico.accel.min_rtt_current_period == 0);
     cc.type->cc_on_acked(&cc, &loss, mtu, 19, mtu, 1, 20, 1100, mtu);
     control = cc;
-    control.random_loss_tolerance = 0;
+    control.accel_adaptation = 0;
     cc.type->cc_on_acked(&cc, &loss, mtu, 20, mtu, 1, 21, 1200, mtu);
     control.type->cc_on_acked(&control, &loss, mtu, 20, mtu, 1, 21, 1200, mtu);
     ok(cc.cwnd > control.cwnd);
@@ -620,7 +662,7 @@ static void test_cubic_random_loss_tolerance_guards(void)
     /* Reaching the adaptive threshold leaves CUBIC on its ordinary trajectory. */
     loss.rtt.latest = 105;
     control = cc;
-    control.random_loss_tolerance = 0;
+    control.accel_adaptation = 0;
     cc.type->cc_on_acked(&cc, &loss, mtu, 21, mtu, 1, 22, 1300, mtu);
     control.type->cc_on_acked(&control, &loss, mtu, 21, mtu, 1, 22, 1300, mtu);
     ok(cc.cwnd == control.cwnd);
@@ -629,13 +671,13 @@ static void test_cubic_random_loss_tolerance_guards(void)
     cc.state.pico.accel.min_rtt_previous_period = 120;
     cc.state.pico.accel.min_rtt_current_period = 104;
     loss.rtt.latest = 105;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) > 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) > 0);
     loss.rtt.latest = 106;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) == 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) == 0);
 
     /* Long-RTT paths retain the 2.5% floor, while shorter paths use the rate that adds approximately two milliseconds of flight
      * per RTT. Acceleration stops once full_rtt is no more than five percent above the latest RTT. */
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
     cc.cwnd = 70 * mtu;
@@ -644,28 +686,29 @@ static void test_cubic_random_loss_tolerance_guards(void)
     cc.state.pico.accel.min_rtt_current_period = 100;
     loss.rtt.minimum = 80;
     loss.rtt.latest = 100;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) == 1. / 40);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) == 1. / 40);
     loss.rtt.minimum = 10;
     loss.rtt.latest = 11;
     loss.rtt.smoothed = 11;
     cc.state.pico.accel.min_rtt_current_period = 11;
-    ok(fabs(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) - 2. / 13) < 0.000001);
+    ok(fabs(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) - 2. / 13) <
+       0.000001);
     /* full_rtt does not limit the increase rate while both RTT gates remain open. */
     cc.state.pico.accel.min_rtt_previous_period = 200;
     cc.state.pico.accel.min_rtt_current_period = 100;
     cc.state.pico.accel.full_rtt = 120;
     loss.rtt.latest = 100;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) == 1. / 40);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) == 1. / 40);
     loss.rtt.minimum = 80;
     loss.rtt.latest = 100;
     loss.rtt.smoothed = 100;
     cc.state.pico.accel.min_rtt_current_period = 100;
     cc.state.pico.accel.full_rtt = 105;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) == 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) == 0);
 
     /* ECN records a high-queue observation, applies its ordinary reduction, then permits accelerated increase when RTT has
      * drained. A subsequent CE inside recovery refreshes the observation. */
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
     cc.state.pico.accel.full_rtt = 120;
@@ -675,9 +718,10 @@ static void test_cubic_random_loss_tolerance_guards(void)
     cc.type->cc_on_lost(&cc, &loss, 0, 11, 20, 1050, mtu);
     ok(cc.state.pico.accel.last_high_queue_at == 1050);
     control = cc;
-    control.random_loss_tolerance = 0;
+    control.accel_adaptation = 0;
     loss.rtt.latest = 81;
-    uint32_t accelerated_cwnd = accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu);
+    uint32_t accelerated_cwnd =
+        accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON);
     ok(accelerated_cwnd > cc.cwnd);
     cc.type->cc_on_acked(&cc, &loss, mtu, 20, mtu, 1, 21, 1100, mtu);
     control.type->cc_on_acked(&control, &loss, mtu, 20, mtu, 1, 21, 1100, mtu);
@@ -685,7 +729,7 @@ static void test_cubic_random_loss_tolerance_guards(void)
 
     /* ECN encountered during calibration schedules the same full_rtt observation as packet loss, while retaining ECN's ordinary
      * congestion response. */
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
     loss.rtt.latest = 130;
     loss.rtt.smoothed = 125;
     cc.type->cc_on_lost(&cc, &loss, 0, 10, 20, 1000, mtu);
@@ -696,7 +740,7 @@ static void test_cubic_random_loss_tolerance_guards(void)
     ok(cc.state.pico.accel.full_rtt == 125);
 
     /* A new loss beyond recovery_end closes the preceding recovery even if no intervening ACK reached congestion control. */
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
     loss.rtt.latest = loss.rtt.smoothed = 120;
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     loss.rtt.smoothed = 115;
@@ -704,7 +748,7 @@ static void test_cubic_random_loss_tolerance_guards(void)
     ok(cc.state.pico.accel.full_rtt == 115);
 }
 
-static void test_cubic_random_loss_tolerance_recalibration(void)
+static void test_cubic_accel_adaptation_recalibration(void)
 {
     quicly_cc_t cc;
     quicly_loss_t loss = {.rtt = {.latest = 109, .smoothed = 109, .minimum = 100, .variance = 0}};
@@ -712,7 +756,7 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
 
     /* A loss starts a new CUBIC epoch but does not restart the time available for deciding whether the path should be
      * recalibrated. The new epoch's K is used for the decision. */
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
     cc.cwnd = 60 * mtu;
     cc.ssthresh = 50 * mtu;
     cc.cwnd_exiting_slow_start = initcwnd;
@@ -726,15 +770,18 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 2000, mtu);
     ok(cc.state.pico.accel.last_high_queue_at == 1000);
     ok(cc.state.pico.accel.high_rtt_interval == 0);
+    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu,
+                          QUICLY_CC_ACCEL_ADAPTATION_INCREASE_ALWAYS, INT64_MAX));
+    ok(cc.state.pico.accel.high_rtt_interval == 0);
     double k = fast_cbrt((cc.ssthresh / QUICLY_BETA_LOSS - cc.ssthresh) / (QUICLY_CUBIC_C * mtu));
-    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 1000));
+    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON, 1000));
     ok(cc.state.pico.accel.high_rtt_interval != 0);
     ok(cc.state.pico.accel.high_rtt_interval <
        k * fast_cbrt(cc.state.pico.accel.full_rtt / loss.rtt.minimum) * 1000);
-    ok(accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu,
+    ok(accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON,
                          1000 + 2 * (int64_t)cc.state.pico.accel.high_rtt_interval));
 
-    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
     cc.cwnd = 60 * mtu;
     cc.ssthresh = 50 * mtu;
     cc.cwnd_exiting_slow_start = initcwnd;
@@ -750,11 +797,11 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     /* Reaching the threshold refreshes the timestamp. Recalibration requires the current interval to pass after the latest such
      * observation. */
     loss.rtt.smoothed = 110;
-    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 6000));
+    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON, 6000));
     ok(cc.state.pico.accel.last_high_queue_at == 6000);
     loss.rtt.smoothed = 109;
-    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 9999));
-    ok(accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 10000));
+    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON, 9999));
+    ok(accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON, 10000));
 
     cc.state.pico.accel.high_rtt_interval = 2000;
     cc.state.pico.accel.last_high_queue_at = 1000;
@@ -781,20 +828,21 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     ok(cc.cwnd_exiting_slow_start == initcwnd);
 }
 
-static void test_cubic_random_loss_tolerance(void)
+static void test_cubic_accel_adaptation(void)
 {
-    subtest("accelerated-increase", test_cubic_random_loss_tolerance_accelerated_increase);
-    subtest("guards", test_cubic_random_loss_tolerance_guards);
-    subtest("recalibration", test_cubic_random_loss_tolerance_recalibration);
+    subtest("accelerated-increase", test_cubic_accel_adaptation_accelerated_increase);
+    subtest("increase-always", test_cubic_accel_adaptation_increase_always);
+    subtest("guards", test_cubic_accel_adaptation_guards);
+    subtest("recalibration", test_cubic_accel_adaptation_recalibration);
 }
 
-static void test_cuback_random_loss_tolerance_accelerated_increase(void)
+static void test_cuback_accel_adaptation_accelerated_increase(void)
 {
     quicly_cc_t cc, control;
     quicly_loss_t loss = {.rtt = {.latest = 120, .smoothed = 120, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 100 * mtu;
 
-    quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, initcwnd, 0, 1, 0);
+    quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, initcwnd, 0, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
 
     /* The startup loss schedules full_rtt and opens accelerated increase after the ordinary slow-start reduction. */
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
@@ -814,8 +862,9 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
 
     cc.state.pico.bytes_to_mtu_increase = UINT32_MAX;
     control = cc;
-    control.random_loss_tolerance = 0;
-    uint32_t accelerated_interval = accel_bytes_per_mtu_increase(&cc.state.pico.accel, &loss.rtt, mtu);
+    control.accel_adaptation = 0;
+    uint32_t accelerated_interval =
+        accel_bytes_per_mtu_increase(&cc.state.pico.accel, &loss.rtt, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON);
     cc.type->cc_on_acked(&cc, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
     control.type->cc_on_acked(&control, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
     ok(cc.cwnd == control.cwnd);
@@ -831,11 +880,11 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
     /* If ordinary Cuback reaches its next increase first, it wins that increment. Acceleration can shorten the following
      * interval. */
     cc = control;
-    cc.random_loss_tolerance = 1;
+    cc.accel_adaptation = QUICLY_CC_ACCEL_ADAPTATION_ON;
     cc.state.pico.accel.full_rtt = 120;
     cc.state.pico.bytes_to_mtu_increase = 1;
     control = cc;
-    control.random_loss_tolerance = 0;
+    control.accel_adaptation = 0;
     cc.type->cc_on_acked(&cc, &loss, 1, 32, 1, 1, 33, 1500, mtu);
     control.type->cc_on_acked(&control, &loss, 1, 32, 1, 1, 33, 1500, mtu);
     ok(cc.cwnd == control.cwnd);
@@ -846,18 +895,18 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
     cc.state.pico.accel.min_rtt_previous_period = 110;
     loss.rtt.latest = 104;
     cc.state.pico.accel.min_rtt_current_period = 104;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) > 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) > 0);
     loss.rtt.latest = 105;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) == 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) == 0);
 }
 
-static void test_cuback_random_loss_tolerance_recalibration(void)
+static void test_cuback_accel_adaptation_recalibration(void)
 {
     quicly_cc_t cc;
     quicly_loss_t loss = {.rtt = {.latest = 109, .smoothed = 109, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 100 * mtu;
 
-    quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, initcwnd, 0, 1, 0);
+    quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, initcwnd, 0, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
     cc.cwnd = 60 * mtu;
     cc.ssthresh = 50 * mtu;
     cc.cwnd_exiting_slow_start = initcwnd;
@@ -867,7 +916,7 @@ static void test_cuback_random_loss_tolerance_recalibration(void)
     cc.state.pico.accel.last_high_queue_at = 1000;
     cc.num_loss_episodes = 1;
 
-    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 1000));
+    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON, 1000));
     uint32_t calculated_interval = cc.state.pico.accel.high_rtt_interval;
     double cwnd_before_reduction = cc.ssthresh / QUICLY_BETA_LOSS;
     double k = fast_cbrt((cwnd_before_reduction - cc.ssthresh) / (QUICLY_CUBIC_C * mtu));
@@ -900,17 +949,17 @@ static void test_cuback_random_loss_tolerance_recalibration(void)
     ok(cc.cwnd_exiting_slow_start == initcwnd);
 }
 
-static void test_cuback_random_loss_tolerance(void)
+static void test_cuback_accel_adaptation(void)
 {
-    subtest("accelerated-increase", test_cuback_random_loss_tolerance_accelerated_increase);
-    subtest("recalibration", test_cuback_random_loss_tolerance_recalibration);
+    subtest("accelerated-increase", test_cuback_accel_adaptation_accelerated_increase);
+    subtest("recalibration", test_cuback_accel_adaptation_recalibration);
 }
 
-static void test_random_loss_tolerance(void)
+static void test_accel_adaptation(void)
 {
     subtest("smoothed-rtt-before-latest", test_smoothed_rtt_before_latest);
-    subtest("cubic", test_cubic_random_loss_tolerance);
-    subtest("cuback", test_cuback_random_loss_tolerance);
+    subtest("cubic", test_cubic_accel_adaptation);
+    subtest("cuback", test_cuback_accel_adaptation);
 }
 
 static void test_cubic_legacy_name(void)
@@ -1241,7 +1290,7 @@ void test_cc(void)
     subtest("cubic-rapid-start-epoch", test_cubic_rapid_start_epoch);
     subtest("cubic-abe", test_cubic_abe);
     subtest("cubic-undo-loss", test_cubic_undo_loss);
-    subtest("random-loss-tolerance", test_random_loss_tolerance);
+    subtest("accel-adaptation", test_accel_adaptation);
     subtest("cubic-legacy-name", test_cubic_legacy_name);
     subtest("pico-ack-countdown", test_pico_ack_countdown);
     subtest("pico-switch-resets-ack-credit", test_pico_switch_resets_ack_credit);

--- a/t/cc.c
+++ b/t/cc.c
@@ -504,7 +504,7 @@ static void test_cubic_undo_loss(void)
     ok(cc.num_loss_episodes_undone == 1);
 }
 
-static void test_cubic_random_loss_tolerance_accelerated_recovery(void)
+static void test_cubic_random_loss_tolerance_accelerated_increase(void)
 {
     quicly_cc_t cc;
     quicly_loss_t loss = {.rtt = {.latest = 120, .smoothed = 120, .minimum = 100, .variance = 0}};
@@ -513,12 +513,12 @@ static void test_cubic_random_loss_tolerance_accelerated_recovery(void)
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
 
     /* The startup loss obtains the scalar qoRTT observation, applies the ordinary slow-start reduction, and opens accelerated
-     * recovery toward reduced CWND / beta^2. */
+     * increase toward reduced CWND / beta^2. */
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
-    ok(cc.state.pico.cubic.random_loss.qortt == 120);
+    ok(cc.state.pico.accel.qortt == 120);
     ok(cc.cwnd == initcwnd / 2);
     ok(cc.state.pico.cubic.cwnd_prior == initcwnd / 2);
-    ok(cc.state.pico.cubic.random_loss.recovery_target == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
+    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
 
     cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
 
@@ -529,28 +529,26 @@ static void test_cubic_random_loss_tolerance_accelerated_recovery(void)
     loss.rtt.smoothed = 105;
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 1200, mtu);
     ok(cc.cwnd == (uint32_t)(80 * mtu * QUICLY_BETA_LOSS));
-    ok(cc.state.pico.cubic.random_loss.recovery_target ==
-       (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
+    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
 
     cc.type->cc_on_acked(&cc, &loss, mtu, 29, mtu, 1, 30, 1300, mtu);
     uint32_t cwnd_before = cc.cwnd;
     uint32_t first_increase =
-        (uint64_t)mtu * (cc.state.pico.cubic.random_loss.recovery_target - cwnd_before) / ((uint64_t)cwnd_before * 2);
+        (uint64_t)mtu * (cc.state.pico.accel.target_cwnd - cwnd_before) / ((uint64_t)cwnd_before * 2);
     cc.type->cc_on_acked(&cc, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
     ok(cc.cwnd == cwnd_before + first_increase);
 
     /* An aggregate ACK for one post-reduction flight recovers half the remaining distance. A subsequent loss starts another
-     * accelerated recovery toward its own CWNDpre / beta target. */
+     * accelerated increase toward its own CWNDpre / beta target. */
     uint32_t bytes_acked = cc.cwnd;
-    uint32_t distance = cc.state.pico.cubic.random_loss.recovery_target - cc.cwnd;
+    uint32_t distance = cc.state.pico.accel.target_cwnd - cc.cwnd;
     uint32_t expected_increase = distance / 2;
     cc.type->cc_on_acked(&cc, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1500, mtu);
     ok(cc.cwnd == cwnd_before + first_increase + expected_increase);
     uint32_t second_cwnd_at_loss = cc.cwnd;
     cc.type->cc_on_lost(&cc, &loss, mtu, 32, 40, 1600, mtu);
     ok(cc.cwnd == (uint32_t)(second_cwnd_at_loss * QUICLY_BETA_LOSS));
-    ok(cc.state.pico.cubic.random_loss.recovery_target ==
-       (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
+    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
 }
 
 static void test_cubic_random_loss_tolerance_guards(void)
@@ -559,11 +557,11 @@ static void test_cubic_random_loss_tolerance_guards(void)
     quicly_loss_t loss = {.rtt = {.latest = 101, .smoothed = 105, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 100 * mtu;
 
-    /* A qoRTT observation exactly 10ms above minRTT does not enable accelerated recovery. */
+    /* A qoRTT observation exactly 10ms above minRTT does not enable accelerated increase. */
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
-    cc.state.pico.cubic.random_loss.qortt = 110;
+    cc.state.pico.accel.qortt = 110;
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     cc.type->cc_on_acked(&cc, &loss, mtu, 19, mtu, 1, 20, 1100, mtu);
     control = cc;
@@ -577,7 +575,7 @@ static void test_cubic_random_loss_tolerance_guards(void)
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
-    cc.state.pico.cubic.random_loss.qortt = 120;
+    cc.state.pico.accel.qortt = 120;
     loss.rtt.latest = 101;
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     cc.type->cc_on_acked(&cc, &loss, mtu, 19, mtu, 1, 20, 1100, mtu);
@@ -588,13 +586,13 @@ static void test_cubic_random_loss_tolerance_guards(void)
     control.type->cc_on_acked(&control, &loss, mtu, 20, mtu, 1, 21, 1200, mtu);
     ok(cc.cwnd == control.cwnd);
 
-    /* ECN is an explicit congestion signal and never opens accelerated recovery. */
+    /* ECN is an explicit congestion signal and never opens accelerated increase. */
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
-    cc.state.pico.cubic.random_loss.qortt = 120;
+    cc.state.pico.accel.qortt = 120;
     cc.type->cc_on_lost(&cc, &loss, 0, 10, 20, 1000, mtu);
-    ok(cc.state.pico.cubic.random_loss.recovery_target == 0);
+    ok(cc.state.pico.accel.target_cwnd == 0);
 }
 
 static void test_cubic_random_loss_tolerance_recalibration(void)
@@ -611,10 +609,10 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     cc.state.pico.cubic.cwnd_prior = initcwnd;
     cc.state.pico.cubic.epoch_start = 1000;
     cc.state.pico.cubic.k = 2;
-    cc.state.pico.cubic.random_loss.qortt = 120;
+    cc.state.pico.accel.qortt = 120;
 
-    cubic_random_loss_observe_path(&cc, &loss, 1001);
-    cubic_random_loss_observe_path(&cc, &loss, 6000);
+    accel_observe_path(&cc, &loss.rtt, 1, 1001, mtu);
+    accel_observe_path(&cc, &loss.rtt, 1, 6000, mtu);
     ok(cc.ssthresh == UINT32_MAX);
     ok(cc.cwnd < cc.ssthresh);
     ok(cc.cwnd == 60 * mtu);
@@ -622,19 +620,116 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     /* A loss in calibration replaces qoRTT; undo restores the calibration and the preceding observation. */
     loss.rtt.latest = loss.rtt.smoothed = 130;
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 6100, mtu);
-    ok(cc.state.pico.cubic.random_loss.qortt == 130);
+    ok(cc.state.pico.accel.qortt == 130);
     ok(cc.cwnd >= cc.ssthresh);
     cc.type->cc_on_late_ack(&cc, 20, 6200);
-    ok(cc.state.pico.cubic.random_loss.qortt == 120);
+    ok(cc.state.pico.accel.qortt == 120);
     ok(cc.cwnd < cc.ssthresh);
     ok(cc.cwnd_exiting_slow_start == initcwnd);
 }
 
 static void test_cubic_random_loss_tolerance(void)
 {
-    subtest("accelerated-recovery", test_cubic_random_loss_tolerance_accelerated_recovery);
+    subtest("accelerated-increase", test_cubic_random_loss_tolerance_accelerated_increase);
     subtest("guards", test_cubic_random_loss_tolerance_guards);
     subtest("recalibration", test_cubic_random_loss_tolerance_recalibration);
+}
+
+static void test_cuback_random_loss_tolerance_accelerated_increase(void)
+{
+    quicly_cc_t cc, control;
+    quicly_loss_t loss = {.rtt = {.latest = 120, .smoothed = 120, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 100 * mtu;
+
+    quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, initcwnd, 0, 1, 0);
+
+    /* The startup loss obtains qoRTT and opens accelerated increase after the ordinary slow-start reduction. */
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    ok(cc.state.pico.accel.qortt == 120);
+    ok(cc.cwnd == initcwnd / 2);
+    ok(cc.state.pico.cuback.cwnd_prior == initcwnd / 2);
+    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
+    cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
+
+    /* After an ordinary CA loss, Cuback reduces its ACK interval when accelerated increase is faster than the ordinary curve. */
+    cc.cwnd = 80 * mtu;
+    loss.rtt.latest = 101;
+    loss.rtt.smoothed = 105;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 1200, mtu);
+    ok(cc.cwnd == (uint32_t)(80 * mtu * QUICLY_BETA_LOSS));
+    ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
+    cc.type->cc_on_acked(&cc, &loss, mtu, 29, mtu, 1, 30, 1300, mtu);
+
+    cc.state.pico.bytes_to_mtu_increase = UINT32_MAX;
+    control = cc;
+    control.random_loss_tolerance = 0;
+    uint32_t accelerated_interval = accel_bytes_per_mtu_increase(&cc, &loss.rtt, mtu);
+    cc.type->cc_on_acked(&cc, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
+    control.type->cc_on_acked(&control, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
+    ok(cc.cwnd == control.cwnd);
+    ok(cc.state.pico.bytes_to_mtu_increase == accelerated_interval - mtu);
+
+    uint32_t bytes_acked = cc.state.pico.bytes_to_mtu_increase, cwnd_before = cc.cwnd;
+    cc.type->cc_on_acked(&cc, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1450, mtu);
+    control.type->cc_on_acked(&control, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1450, mtu);
+    ok(cc.cwnd == cwnd_before + mtu);
+    ok(cc.cwnd > control.cwnd);
+
+    /* If ordinary Cuback grows farther, it wins and retains its byte-counter state. */
+    cc = control;
+    cc.random_loss_tolerance = 1;
+    cc.state.pico.accel.qortt = 120;
+    cc.state.pico.accel.target_cwnd = cc.cwnd + 1;
+    cc.state.pico.bytes_to_mtu_increase = 1;
+    control = cc;
+    control.random_loss_tolerance = 0;
+    cc.type->cc_on_acked(&cc, &loss, mtu, 32, mtu, 1, 33, 1500, mtu);
+    control.type->cc_on_acked(&control, &loss, mtu, 32, mtu, 1, 33, 1500, mtu);
+    ok(cc.cwnd == control.cwnd);
+    ok(cc.state.pico.bytes_to_mtu_increase == control.state.pico.bytes_to_mtu_increase);
+}
+
+static void test_cuback_random_loss_tolerance_recalibration(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 109, .smoothed = 109, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 100 * mtu;
+
+    quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, initcwnd, 0, 1, 0);
+    cc.cwnd = 60 * mtu;
+    cc.ssthresh = 50 * mtu;
+    cc.cwnd_exiting_slow_start = initcwnd;
+    cc.state.pico.cuback.cwnd_prior = 60 * mtu;
+    cc.state.pico.cuback.bandwidth = cc.cwnd * 1000. / loss.rtt.smoothed;
+    cc.state.pico.accel.qortt = 120;
+
+    accel_observe_path(&cc, &loss.rtt, 1, 1001, mtu);
+    accel_observe_path(&cc, &loss.rtt, 1, 8000, mtu);
+    ok(cc.ssthresh == UINT32_MAX);
+    ok(cc.cwnd == 60 * mtu);
+    ok(cc.state.pico.cuback.bandwidth == 0);
+
+    /* A loss in calibration replaces qoRTT; undo restores the calibration and the preceding observation. */
+    loss.rtt.latest = loss.rtt.smoothed = 130;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 8100, mtu);
+    ok(cc.state.pico.accel.qortt == 130);
+    ok(cc.cwnd >= cc.ssthresh);
+    cc.type->cc_on_late_ack(&cc, 20, 8200);
+    ok(cc.state.pico.accel.qortt == 120);
+    ok(cc.cwnd < cc.ssthresh);
+    ok(cc.cwnd_exiting_slow_start == initcwnd);
+}
+
+static void test_cuback_random_loss_tolerance(void)
+{
+    subtest("accelerated-increase", test_cuback_random_loss_tolerance_accelerated_increase);
+    subtest("recalibration", test_cuback_random_loss_tolerance_recalibration);
+}
+
+static void test_random_loss_tolerance(void)
+{
+    subtest("cubic", test_cubic_random_loss_tolerance);
+    subtest("cuback", test_cuback_random_loss_tolerance);
 }
 
 static void test_cubic_legacy_name(void)
@@ -965,7 +1060,7 @@ void test_cc(void)
     subtest("cubic-rapid-start-epoch", test_cubic_rapid_start_epoch);
     subtest("cubic-abe", test_cubic_abe);
     subtest("cubic-undo-loss", test_cubic_undo_loss);
-    subtest("cubic-random-loss-tolerance", test_cubic_random_loss_tolerance);
+    subtest("random-loss-tolerance", test_random_loss_tolerance);
     subtest("cubic-legacy-name", test_cubic_legacy_name);
     subtest("pico-ack-countdown", test_pico_ack_countdown);
     subtest("pico-switch-resets-ack-credit", test_pico_switch_resets_ack_credit);

--- a/t/cc.c
+++ b/t/cc.c
@@ -512,16 +512,17 @@ static void test_cubic_random_loss_tolerance_accelerated_increase(void)
 
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
 
-    /* The startup loss obtains the scalar qoRTT observation, applies the ordinary slow-start reduction, and sets the acceleration
-     * target using the ordinary loss beta. */
+    /* The startup loss schedules a full_rtt observation, applies the ordinary slow-start reduction, and sets the acceleration
+     * target using the ordinary loss beta. The smoothed RTT is adopted when recovery exits. */
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
-    ok(cc.state.pico.accel.qortt == 120);
+    ok(cc.state.pico.accel.full_rtt == 0);
     ok(cc.cwnd == initcwnd / 2);
     ok(cc.state.pico.cubic.cwnd_prior == initcwnd / 2);
     ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / QUICLY_BETA_LOSS));
     ok(accel_calc_cwnd_cap(&cc.state.pico.accel) == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
 
     cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
+    ok(cc.state.pico.accel.full_rtt == 120);
 
     /* An ordinary CA packet loss applies the ordinary 0.7 reduction. ACKs then use half the current relative distance to CWNDpre
      * as the growth coefficient, with a 2.5% minimum until reaching CWNDpre / beta. */
@@ -561,17 +562,28 @@ static void test_cubic_random_loss_tolerance_accelerated_increase(void)
     ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / QUICLY_BETA_LOSS));
 }
 
+static void test_smoothed_rtt_before_latest(void)
+{
+    quicly_rtt_t rtt;
+
+    quicly_rtt_init(&rtt, NULL, 100);
+    quicly_rtt_update(&rtt, 80, 0);
+    float preceding = rtt.smoothed;
+    quicly_rtt_update(&rtt, 88, 0);
+    ok(calc_smoothed_rtt_before_latest(&rtt) == preceding);
+}
+
 static void test_cubic_random_loss_tolerance_guards(void)
 {
     quicly_cc_t cc, control;
     quicly_loss_t loss = {.rtt = {.latest = 101, .smoothed = 105, .minimum = 100, .variance = 0}};
     uint32_t mtu = 1200, initcwnd = 100 * mtu;
 
-    /* A qoRTT observation exactly 10ms above minRTT does not enable accelerated increase. */
+    /* A full_rtt observation exactly 10ms above minRTT does not enable accelerated increase. */
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
-    cc.state.pico.accel.qortt = 110;
+    cc.state.pico.accel.full_rtt = 110;
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     cc.type->cc_on_acked(&cc, &loss, mtu, 19, mtu, 1, 20, 1100, mtu);
     control = cc;
@@ -585,7 +597,7 @@ static void test_cubic_random_loss_tolerance_guards(void)
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
-    cc.state.pico.accel.qortt = 120;
+    cc.state.pico.accel.full_rtt = 120;
     loss.rtt.latest = 101;
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     cc.type->cc_on_acked(&cc, &loss, mtu, 19, mtu, 1, 20, 1100, mtu);
@@ -601,7 +613,7 @@ static void test_cubic_random_loss_tolerance_guards(void)
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
-    cc.state.pico.accel.qortt = 120;
+    cc.state.pico.accel.full_rtt = 120;
     cc.state.pico.accel.min_rtt_in_ca = 110;
     loss.rtt.latest = 104;
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
@@ -626,9 +638,30 @@ static void test_cubic_random_loss_tolerance_guards(void)
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
-    cc.state.pico.accel.qortt = 120;
+    cc.state.pico.accel.full_rtt = 120;
     cc.type->cc_on_lost(&cc, &loss, 0, 10, 20, 1000, mtu);
     ok(cc.state.pico.accel.target_cwnd == 0);
+
+    /* ECN encountered during calibration schedules the same full_rtt observation as packet loss, while retaining ECN's ordinary
+     * congestion response. */
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    loss.rtt.latest = 130;
+    loss.rtt.smoothed = 125;
+    cc.type->cc_on_lost(&cc, &loss, 0, 10, 20, 1000, mtu);
+    ok(cc.state.pico.accel.full_rtt == 0);
+    ok(cc.state.pico.accel.target_cwnd != 0);
+    loss.rtt.latest = 104;
+    loss.rtt.smoothed = 122.375;
+    cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
+    ok(cc.state.pico.accel.full_rtt == 125);
+
+    /* A new loss beyond recovery_end closes the preceding recovery even if no intervening ACK reached congestion control. */
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    loss.rtt.latest = loss.rtt.smoothed = 120;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    loss.rtt.smoothed = 115;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 1100, mtu);
+    ok(cc.state.pico.accel.full_rtt == 115);
 }
 
 static void test_cubic_random_loss_tolerance_recalibration(void)
@@ -645,7 +678,7 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     cc.state.pico.cubic.cwnd_prior = initcwnd;
     cc.state.pico.cubic.epoch_start = 1000;
     cc.state.pico.cubic.k = 2;
-    cc.state.pico.accel.qortt = 120;
+    cc.state.pico.accel.full_rtt = 120;
 
     accel_observe_path(&cc, &loss.rtt, 1, 1001, mtu);
     accel_observe_path(&cc, &loss.rtt, 1, 6000, mtu);
@@ -653,13 +686,15 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     ok(cc.cwnd < cc.ssthresh);
     ok(cc.cwnd == 60 * mtu);
 
-    /* A loss in calibration replaces qoRTT; undo restores the calibration and the preceding observation. */
+    /* A loss in calibration replaces full_rtt upon recovery exit; undo restores the calibration and preceding observation. */
     loss.rtt.latest = loss.rtt.smoothed = 130;
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 6100, mtu);
-    ok(cc.state.pico.accel.qortt == 130);
+    ok(cc.state.pico.accel.full_rtt == 0);
     ok(cc.cwnd >= cc.ssthresh);
+    cc.type->cc_on_acked(&cc, &loss, 0, 30, 0, 1, 31, 6150, mtu);
+    ok(cc.state.pico.accel.full_rtt == 130);
     cc.type->cc_on_late_ack(&cc, 20, 6200);
-    ok(cc.state.pico.accel.qortt == 120);
+    ok(cc.state.pico.accel.full_rtt == 120);
     ok(cc.cwnd < cc.ssthresh);
     ok(cc.cwnd_exiting_slow_start == initcwnd);
 }
@@ -679,14 +714,15 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
 
     quicly_cc_cuback_init.cb(&quicly_cc_cuback_init, &cc, initcwnd, 0, 1, 0);
 
-    /* The startup loss obtains qoRTT and opens accelerated increase after the ordinary slow-start reduction. */
+    /* The startup loss schedules full_rtt and opens accelerated increase after the ordinary slow-start reduction. */
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
-    ok(cc.state.pico.accel.qortt == 120);
+    ok(cc.state.pico.accel.full_rtt == 0);
     ok(cc.cwnd == initcwnd / 2);
     ok(cc.state.pico.cuback.cwnd_prior == initcwnd / 2);
     ok(cc.state.pico.accel.target_cwnd == (uint32_t)(cc.cwnd / QUICLY_BETA_LOSS));
     ok(accel_calc_cwnd_cap(&cc.state.pico.accel) == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
     cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
+    ok(cc.state.pico.accel.full_rtt == 120);
 
     /* After an ordinary CA loss, Cuback reduces its ACK interval when accelerated increase is faster than the ordinary curve. */
     cc.cwnd = 80 * mtu;
@@ -717,7 +753,7 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
      * interval while the derived cap has not been reached. */
     cc = control;
     cc.random_loss_tolerance = 1;
-    cc.state.pico.accel.qortt = 120;
+    cc.state.pico.accel.full_rtt = 120;
     cc.state.pico.accel.target_cwnd = cc.cwnd + 1;
     cc.state.pico.bytes_to_mtu_increase = 1;
     control = cc;
@@ -728,7 +764,7 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
     ok(cc.state.pico.bytes_to_mtu_increase <= control.state.pico.bytes_to_mtu_increase);
 
     /* Cuback uses the same adaptive RTT gate as CUBIC. */
-    cc.state.pico.accel.qortt = 120;
+    cc.state.pico.accel.full_rtt = 120;
     cc.state.pico.accel.target_cwnd = cc.cwnd + mtu;
     cc.state.pico.accel.min_rtt_in_previous_ca = 110;
     loss.rtt.latest = 104;
@@ -749,7 +785,7 @@ static void test_cuback_random_loss_tolerance_recalibration(void)
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.state.pico.cuback.cwnd_prior = 60 * mtu;
     cc.state.pico.cuback.bandwidth = cc.cwnd * 1000. / loss.rtt.smoothed;
-    cc.state.pico.accel.qortt = 120;
+    cc.state.pico.accel.full_rtt = 120;
 
     accel_observe_path(&cc, &loss.rtt, 1, 1001, mtu);
     accel_observe_path(&cc, &loss.rtt, 1, 8000, mtu);
@@ -757,13 +793,15 @@ static void test_cuback_random_loss_tolerance_recalibration(void)
     ok(cc.cwnd == 60 * mtu);
     ok(cc.state.pico.cuback.bandwidth == 0);
 
-    /* A loss in calibration replaces qoRTT; undo restores the calibration and the preceding observation. */
+    /* A loss in calibration replaces full_rtt upon recovery exit; undo restores the calibration and preceding observation. */
     loss.rtt.latest = loss.rtt.smoothed = 130;
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 8100, mtu);
-    ok(cc.state.pico.accel.qortt == 130);
+    ok(cc.state.pico.accel.full_rtt == 0);
     ok(cc.cwnd >= cc.ssthresh);
+    cc.type->cc_on_acked(&cc, &loss, 0, 30, 0, 1, 31, 8150, mtu);
+    ok(cc.state.pico.accel.full_rtt == 130);
     cc.type->cc_on_late_ack(&cc, 20, 8200);
-    ok(cc.state.pico.accel.qortt == 120);
+    ok(cc.state.pico.accel.full_rtt == 120);
     ok(cc.cwnd < cc.ssthresh);
     ok(cc.cwnd_exiting_slow_start == initcwnd);
 }
@@ -776,6 +814,7 @@ static void test_cuback_random_loss_tolerance(void)
 
 static void test_random_loss_tolerance(void)
 {
+    subtest("smoothed-rtt-before-latest", test_smoothed_rtt_before_latest);
     subtest("cubic", test_cubic_random_loss_tolerance);
     subtest("cuback", test_cuback_random_loss_tolerance);
 }

--- a/t/cc.c
+++ b/t/cc.c
@@ -512,38 +512,45 @@ static void test_cubic_random_loss_tolerance_accelerated_recovery(void)
 
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
 
-    /* The startup loss obtains the scalar qoRTT observation and uses CWND at loss as W_max. */
+    /* The startup loss obtains the scalar qoRTT observation, applies the ordinary slow-start reduction, and opens accelerated
+     * recovery toward reduced CWND / beta^2. */
     cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
     ok(cc.state.pico.cubic.random_loss.qortt == 120);
-    ok(cc.state.pico.cubic.cwnd_prior == initcwnd);
-    ok(cc.state.pico.cubic.random_loss.recovery_target == 0);
+    ok(cc.cwnd == initcwnd / 2);
+    ok(cc.state.pico.cubic.cwnd_prior == initcwnd / 2);
+    ok(cc.state.pico.cubic.random_loss.recovery_target == (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
 
     cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
 
-    /* An ordinary CA packet loss applies the ordinary 0.7 reduction. ACKs then use half the current relative distance to the
-     * pre-loss CWND as the growth coefficient, with a 2.5% minimum. */
+    /* An ordinary CA packet loss applies the ordinary 0.7 reduction. ACKs then use half the current relative distance to
+     * CWNDpre / beta as the growth coefficient, with a 2.5% minimum. */
     cc.cwnd = 80 * mtu;
     loss.rtt.latest = 101;
     loss.rtt.smoothed = 105;
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 1200, mtu);
     ok(cc.cwnd == (uint32_t)(80 * mtu * QUICLY_BETA_LOSS));
-    ok(cc.state.pico.cubic.random_loss.recovery_target == 80 * mtu);
+    ok(cc.state.pico.cubic.random_loss.recovery_target ==
+       (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
 
     cc.type->cc_on_acked(&cc, &loss, mtu, 29, mtu, 1, 30, 1300, mtu);
     uint32_t cwnd_before = cc.cwnd;
+    uint32_t first_increase =
+        (uint64_t)mtu * (cc.state.pico.cubic.random_loss.recovery_target - cwnd_before) / ((uint64_t)cwnd_before * 2);
     cc.type->cc_on_acked(&cc, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
-    ok(cc.cwnd == cwnd_before + mtu * 3 / 14);
+    ok(cc.cwnd == cwnd_before + first_increase);
 
-    /* An aggregate ACK for one post-reduction flight recovers half the remaining distance. A persistent loss then moves CWND below
-     * the preceding recovery's reduced CWND, rather than returning to the same threshold. */
+    /* An aggregate ACK for one post-reduction flight recovers half the remaining distance. A subsequent loss starts another
+     * accelerated recovery toward its own CWNDpre / beta target. */
     uint32_t bytes_acked = cc.cwnd;
     uint32_t distance = cc.state.pico.cubic.random_loss.recovery_target - cc.cwnd;
     uint32_t expected_increase = distance / 2;
     cc.type->cc_on_acked(&cc, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1500, mtu);
-    ok(cc.cwnd == cwnd_before + mtu * 3 / 14 + expected_increase);
-    uint32_t first_reduced_cwnd = (uint32_t)(80 * mtu * QUICLY_BETA_LOSS);
+    ok(cc.cwnd == cwnd_before + first_increase + expected_increase);
+    uint32_t second_cwnd_at_loss = cc.cwnd;
     cc.type->cc_on_lost(&cc, &loss, mtu, 32, 40, 1600, mtu);
-    ok(cc.cwnd < first_reduced_cwnd);
+    ok(cc.cwnd == (uint32_t)(second_cwnd_at_loss * QUICLY_BETA_LOSS));
+    ok(cc.state.pico.cubic.random_loss.recovery_target ==
+       (uint32_t)(cc.cwnd / (QUICLY_BETA_LOSS * QUICLY_BETA_LOSS)));
 }
 
 static void test_cubic_random_loss_tolerance_guards(void)

--- a/t/cc.c
+++ b/t/cc.c
@@ -663,13 +663,17 @@ static void test_cubic_random_loss_tolerance_guards(void)
     cc.state.pico.accel.full_rtt = 105;
     ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt) == 0);
 
-    /* ECN applies its ordinary reduction, then permits accelerated increase when RTT has drained. */
+    /* ECN records a high-queue observation, applies its ordinary reduction, then permits accelerated increase when RTT has
+     * drained. A subsequent CE inside recovery refreshes the observation. */
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
     cc.ssthresh = 50 * mtu;
     cc.state.pico.accel.full_rtt = 120;
     cc.state.pico.accel.min_rtt_current_period = loss.rtt.minimum;
     cc.type->cc_on_lost(&cc, &loss, 0, 10, 20, 1000, mtu);
+    ok(cc.state.pico.accel.last_high_queue_at == 1000);
+    cc.type->cc_on_lost(&cc, &loss, 0, 11, 20, 1050, mtu);
+    ok(cc.state.pico.accel.last_high_queue_at == 1050);
     control = cc;
     control.random_loss_tolerance = 0;
     loss.rtt.latest = 81;
@@ -717,10 +721,10 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     cc.state.pico.cubic.epoch_start = 1000;
     cc.state.pico.cubic.k = 2;
     cc.state.pico.accel.full_rtt = 120;
-    cc.state.pico.accel.last_high_rtt_at = 1000;
+    cc.state.pico.accel.last_high_queue_at = 1000;
     cc.num_loss_episodes = 1;
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 2000, mtu);
-    ok(cc.state.pico.accel.last_high_rtt_at == 1000);
+    ok(cc.state.pico.accel.last_high_queue_at == 1000);
     ok(cc.state.pico.accel.high_rtt_interval == 0);
     double k = fast_cbrt((cc.ssthresh / QUICLY_BETA_LOSS - cc.ssthresh) / (QUICLY_CUBIC_C * mtu));
     ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 1000));
@@ -739,7 +743,7 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     cc.state.pico.cubic.epoch_start = 1000;
     cc.state.pico.cubic.k = 2;
     cc.state.pico.accel.full_rtt = 120;
-    cc.state.pico.accel.last_high_rtt_at = 1000;
+    cc.state.pico.accel.last_high_queue_at = 1000;
     cc.state.pico.accel.high_rtt_interval = 2000;
     cc.num_loss_episodes = 1;
 
@@ -747,13 +751,13 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
      * observation. */
     loss.rtt.smoothed = 110;
     ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 6000));
-    ok(cc.state.pico.accel.last_high_rtt_at == 6000);
+    ok(cc.state.pico.accel.last_high_queue_at == 6000);
     loss.rtt.smoothed = 109;
     ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 9999));
     ok(accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 10000));
 
     cc.state.pico.accel.high_rtt_interval = 2000;
-    cc.state.pico.accel.last_high_rtt_at = 1000;
+    cc.state.pico.accel.last_high_queue_at = 1000;
     cc.type->cc_on_acked(&cc, &loss, 0, 30, 0, 1, 31, 4999, mtu);
     ok(cc.ssthresh != UINT32_MAX);
     cc.type->cc_on_acked(&cc, &loss, 0, 31, 0, 1, 32, 5000, mtu);
@@ -768,10 +772,10 @@ static void test_cubic_random_loss_tolerance_recalibration(void)
     ok(cc.cwnd >= cc.ssthresh);
     cc.type->cc_on_acked(&cc, &loss, 0, 30, 0, 1, 31, 6150, mtu);
     ok(cc.state.pico.accel.full_rtt == 130);
-    ok(cc.state.pico.accel.last_high_rtt_at == 6150);
+    ok(cc.state.pico.accel.last_high_queue_at == 6150);
     cc.type->cc_on_late_ack(&cc, 20, 6200);
     ok(cc.state.pico.accel.full_rtt == 120);
-    ok(cc.state.pico.accel.last_high_rtt_at == 1000);
+    ok(cc.state.pico.accel.last_high_queue_at == 1000);
     ok(cc.cwnd < cc.ssthresh);
     ok(cc.cwnd_exiting_slow_start == initcwnd);
 }
@@ -859,7 +863,7 @@ static void test_cuback_random_loss_tolerance_recalibration(void)
     cc.state.pico.cuback.cwnd_prior = 60 * mtu;
     cc.state.pico.cuback.bandwidth = cc.cwnd * 1000. / loss.rtt.smoothed;
     cc.state.pico.accel.full_rtt = 120;
-    cc.state.pico.accel.last_high_rtt_at = 1000;
+    cc.state.pico.accel.last_high_queue_at = 1000;
     cc.num_loss_episodes = 1;
 
     ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, 1000));
@@ -886,10 +890,10 @@ static void test_cuback_random_loss_tolerance_recalibration(void)
     ok(cc.cwnd >= cc.ssthresh);
     cc.type->cc_on_acked(&cc, &loss, 0, 30, 0, 1, 31, 8150, mtu);
     ok(cc.state.pico.accel.full_rtt == 130);
-    ok(cc.state.pico.accel.last_high_rtt_at == 8150);
+    ok(cc.state.pico.accel.last_high_queue_at == 8150);
     cc.type->cc_on_late_ack(&cc, 20, 8200);
     ok(cc.state.pico.accel.full_rtt == 120);
-    ok(cc.state.pico.accel.last_high_rtt_at == 1000);
+    ok(cc.state.pico.accel.last_high_queue_at == 1000);
     ok(cc.cwnd < cc.ssthresh);
     ok(cc.cwnd_exiting_slow_start == initcwnd);
 }

--- a/t/cc.c
+++ b/t/cc.c
@@ -531,7 +531,8 @@ static void test_cubic_accel_adaptation_accelerated_increase(void)
     ok(cc.cwnd == (uint32_t)(80 * mtu * QUICLY_BETA_LOSS));
 
     cc.type->cc_on_acked(&cc, &loss, mtu, 29, mtu, 1, 30, 1300, mtu);
-    uint32_t accelerated_cwnd = accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON);
+    uint32_t accelerated_cwnd =
+        accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
     control = cc;
     control.accel_adaptation = 0;
     cc.type->cc_on_acked(&cc, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
@@ -540,7 +541,8 @@ static void test_cubic_accel_adaptation_accelerated_increase(void)
 
     /* An aggregate ACK for one post-reduction flight applies the accelerated increase. */
     uint32_t bytes_acked = cc.cwnd;
-    accelerated_cwnd = accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, bytes_acked, QUICLY_CC_ACCEL_ADAPTATION_ON);
+    accelerated_cwnd =
+        accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, bytes_acked, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
     control = cc;
     control.accel_adaptation = 0;
     cc.type->cc_on_acked(&cc, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1500, mtu);
@@ -669,9 +671,9 @@ static void test_cubic_accel_adaptation_guards(void)
     cc.state.pico.accel.min_rtt_previous_period = 120;
     cc.state.pico.accel.min_rtt_current_period = 104;
     loss.rtt.latest = 105;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) > 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON, 0) > 0);
     loss.rtt.latest = 106;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) == 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON, 0) == 0);
 
     /* Long-RTT paths retain the 2.5% floor, while shorter paths use the rate that adds approximately two milliseconds of flight
      * per RTT. Acceleration stops once full_rtt is no more than five percent above the latest RTT. */
@@ -684,24 +686,41 @@ static void test_cubic_accel_adaptation_guards(void)
     cc.state.pico.accel.min_rtt_current_period = 100;
     loss.rtt.minimum = 80;
     loss.rtt.latest = 100;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) == 1. / 40);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON, 0) == 1. / 40);
     loss.rtt.minimum = 10;
     loss.rtt.latest = 11;
     loss.rtt.smoothed = 11;
     cc.state.pico.accel.min_rtt_current_period = 11;
-    ok(fabs(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) - 2. / 13) < 0.000001);
+    ok(fabs(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON, 0) - 2. / 13) <
+       0.000001);
+
+    /* Cap accelerated increase at half the growth needed to reverse the reduction that opened the current recovery. The ECN cap
+     * is lower because ABE applies a smaller reduction. */
+    loss.rtt.minimum = loss.rtt.latest = 1;
+    cc.state.pico.accel.full_rtt = 20;
+    cc.state.pico.accel.min_rtt_previous_period = 1;
+    cc.state.pico.accel.min_rtt_current_period = 1;
+    double loss_ratio_limit = (1. / QUICLY_BETA_LOSS - 1) / 2;
+    double ecn_ratio_limit = (1. / QUICLY_BETA_ECN - 1) / 2;
+    ok(fabs(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON, 0) -
+            loss_ratio_limit) < 0.000001);
+    ok(fabs(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON, 1) -
+            ecn_ratio_limit) < 0.000001);
+    ok(fabs(QUICLY_BETA_LOSS * (1 + loss_ratio_limit) - (1 + QUICLY_BETA_LOSS) / 2) < 0.000001);
+    ok(fabs(QUICLY_BETA_ECN * (1 + ecn_ratio_limit) - (1 + QUICLY_BETA_ECN) / 2) < 0.000001);
     /* full_rtt does not limit the increase rate while both RTT gates remain open. */
+    loss.rtt.minimum = 10;
     cc.state.pico.accel.min_rtt_previous_period = 200;
     cc.state.pico.accel.min_rtt_current_period = 100;
     cc.state.pico.accel.full_rtt = 120;
     loss.rtt.latest = 100;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) == 1. / 40);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON, 0) == 1. / 40);
     loss.rtt.minimum = 80;
     loss.rtt.latest = 100;
     loss.rtt.smoothed = 100;
     cc.state.pico.accel.min_rtt_current_period = 100;
     cc.state.pico.accel.full_rtt = 105;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) == 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON, 0) == 0);
 
     /* ECN records a high-queue observation, applies its ordinary reduction, then permits accelerated increase when RTT has
      * drained. A subsequent CE inside recovery refreshes the observation. */
@@ -717,7 +736,8 @@ static void test_cubic_accel_adaptation_guards(void)
     control = cc;
     control.accel_adaptation = 0;
     loss.rtt.latest = 81;
-    uint32_t accelerated_cwnd = accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON);
+    uint32_t accelerated_cwnd =
+        accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON, 1);
     ok(accelerated_cwnd > cc.cwnd);
     cc.type->cc_on_acked(&cc, &loss, mtu, 20, mtu, 1, 21, 1100, mtu);
     control.type->cc_on_acked(&control, &loss, mtu, 20, mtu, 1, 21, 1100, mtu);
@@ -859,7 +879,7 @@ static void test_cuback_accel_adaptation_accelerated_increase(void)
     control = cc;
     control.accel_adaptation = 0;
     uint32_t accelerated_interval =
-        accel_bytes_per_mtu_increase(&cc.state.pico.accel, &loss.rtt, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON);
+        accel_bytes_per_mtu_increase(&cc.state.pico.accel, &loss.rtt, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON, 0);
     cc.type->cc_on_acked(&cc, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
     control.type->cc_on_acked(&control, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
     ok(cc.cwnd == control.cwnd);
@@ -890,9 +910,9 @@ static void test_cuback_accel_adaptation_accelerated_increase(void)
     cc.state.pico.accel.min_rtt_previous_period = 110;
     loss.rtt.latest = 104;
     cc.state.pico.accel.min_rtt_current_period = 104;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) > 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON, 0) > 0);
     loss.rtt.latest = 105;
-    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) == 0);
+    ok(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON, 0) == 0);
 }
 
 static void test_cuback_accel_adaptation_recalibration(void)

--- a/t/cc.c
+++ b/t/cc.c
@@ -596,6 +596,32 @@ static void test_cubic_random_loss_tolerance_guards(void)
     control.type->cc_on_acked(&control, &loss, mtu, 20, mtu, 1, 21, 1200, mtu);
     ok(cc.cwnd == control.cwnd);
 
+    /* A raised minimum throughout the preceding CA period raises the gate halfway toward that observation. The existing 2ms
+     * allowance remains the lower bound. */
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    cc.cwnd_exiting_slow_start = initcwnd;
+    cc.ssthresh = 50 * mtu;
+    cc.state.pico.accel.qortt = 120;
+    cc.state.pico.accel.min_rtt_in_ca = 110;
+    loss.rtt.latest = 104;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    ok(cc.state.pico.accel.min_rtt_in_previous_ca == 110);
+    ok(cc.state.pico.accel.min_rtt_in_ca == 0);
+    cc.type->cc_on_acked(&cc, &loss, mtu, 19, mtu, 1, 20, 1100, mtu);
+    control = cc;
+    control.random_loss_tolerance = 0;
+    cc.type->cc_on_acked(&cc, &loss, mtu, 20, mtu, 1, 21, 1200, mtu);
+    control.type->cc_on_acked(&control, &loss, mtu, 20, mtu, 1, 21, 1200, mtu);
+    ok(cc.cwnd > control.cwnd);
+
+    /* Reaching the adaptive threshold leaves CUBIC on its ordinary trajectory. */
+    loss.rtt.latest = 105;
+    control = cc;
+    control.random_loss_tolerance = 0;
+    cc.type->cc_on_acked(&cc, &loss, mtu, 21, mtu, 1, 22, 1300, mtu);
+    control.type->cc_on_acked(&control, &loss, mtu, 21, mtu, 1, 22, 1300, mtu);
+    ok(cc.cwnd == control.cwnd);
+
     /* ECN is an explicit congestion signal and never opens accelerated increase. */
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
     cc.cwnd_exiting_slow_start = initcwnd;
@@ -679,6 +705,7 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
     control.type->cc_on_acked(&control, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
     ok(cc.cwnd == control.cwnd);
     ok(cc.state.pico.bytes_to_mtu_increase == accelerated_interval - mtu);
+    ok(cc.state.pico.accel.min_rtt_in_ca == 101);
 
     uint32_t bytes_acked = cc.state.pico.bytes_to_mtu_increase, cwnd_before = cc.cwnd;
     cc.type->cc_on_acked(&cc, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1450, mtu);
@@ -699,6 +726,15 @@ static void test_cuback_random_loss_tolerance_accelerated_increase(void)
     control.type->cc_on_acked(&control, &loss, 1, 32, 1, 1, 33, 1500, mtu);
     ok(cc.cwnd == control.cwnd);
     ok(cc.state.pico.bytes_to_mtu_increase <= control.state.pico.bytes_to_mtu_increase);
+
+    /* Cuback uses the same adaptive RTT gate as CUBIC. */
+    cc.state.pico.accel.qortt = 120;
+    cc.state.pico.accel.target_cwnd = cc.cwnd + mtu;
+    cc.state.pico.accel.min_rtt_in_previous_ca = 110;
+    loss.rtt.latest = 104;
+    ok(accel_calc_increase_ratio(&cc, &loss.rtt) > 0);
+    loss.rtt.latest = 105;
+    ok(accel_calc_increase_ratio(&cc, &loss.rtt) == 0);
 }
 
 static void test_cuback_random_loss_tolerance_recalibration(void)

--- a/t/cc.c
+++ b/t/cc.c
@@ -524,8 +524,8 @@ static void test_cubic_random_loss_tolerance_accelerated_increase(void)
     cc.type->cc_on_acked(&cc, &loss, 0, 20, 0, 1, 21, 1100, mtu);
     ok(cc.state.pico.accel.full_rtt == 120);
 
-    /* An ordinary CA packet loss applies the ordinary 0.7 reduction. ACKs then use half the current relative distance to CWNDpre
-     * as the growth coefficient, with a 2.5% minimum until reaching CWNDpre / beta. */
+    /* An ordinary CA packet loss applies the ordinary 0.7 reduction. ACKs then use the smaller of half the current relative
+     * distance to CWNDpre and half the remaining RTT headroom, with a 2.5% minimum until reaching CWNDpre / beta. */
     cc.cwnd = 80 * mtu;
     loss.rtt.latest = 101;
     loss.rtt.smoothed = 105;
@@ -535,16 +535,14 @@ static void test_cubic_random_loss_tolerance_accelerated_increase(void)
 
     cc.type->cc_on_acked(&cc, &loss, mtu, 29, mtu, 1, 30, 1300, mtu);
     uint32_t cwnd_before = cc.cwnd;
-    uint32_t first_increase =
-        (uint64_t)mtu * (cc.state.pico.accel.target_cwnd - cwnd_before) / ((uint64_t)cwnd_before * 2);
+    uint32_t first_increase = mtu * accel_calc_increase_ratio(&cc, &loss.rtt);
     cc.type->cc_on_acked(&cc, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
     ok(cc.cwnd == cwnd_before + first_increase);
 
-    /* An aggregate ACK for one post-reduction flight recovers half the remaining distance. A subsequent loss starts another
-     * accelerated increase toward its own CWNDpre target. */
+    /* An aggregate ACK for one post-reduction flight applies the RTT-limited increase. A subsequent loss starts another accelerated
+     * increase toward its own CWNDpre target. */
     uint32_t bytes_acked = cc.cwnd;
-    uint32_t distance = cc.state.pico.accel.target_cwnd - cc.cwnd;
-    uint32_t expected_increase = distance / 2;
+    uint32_t expected_increase = bytes_acked * accel_calc_increase_ratio(&cc, &loss.rtt);
     cc.type->cc_on_acked(&cc, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1500, mtu);
     ok(cc.cwnd == cwnd_before + first_increase + expected_increase);
 
@@ -633,6 +631,20 @@ static void test_cubic_random_loss_tolerance_guards(void)
     cc.type->cc_on_acked(&cc, &loss, mtu, 21, mtu, 1, 22, 1300, mtu);
     control.type->cc_on_acked(&control, &loss, mtu, 21, mtu, 1, 22, 1300, mtu);
     ok(cc.cwnd == control.cwnd);
+
+    /* Acceleration consumes no more than half of the remaining RTT headroom and stops with five percent still available. */
+    quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);
+    cc.cwnd_exiting_slow_start = initcwnd;
+    cc.ssthresh = 50 * mtu;
+    cc.cwnd = 70 * mtu;
+    cc.state.pico.accel.target_cwnd = 100 * mtu;
+    cc.state.pico.accel.full_rtt = 120;
+    cc.state.pico.accel.min_rtt_in_previous_ca = 130;
+    loss.rtt.minimum = 80;
+    loss.rtt.latest = 100;
+    ok(fabs(accel_calc_increase_ratio(&cc, &loss.rtt) - 0.1) < 0.000001);
+    cc.state.pico.accel.full_rtt = 105;
+    ok(accel_calc_increase_ratio(&cc, &loss.rtt) == 0);
 
     /* ECN is an explicit congestion signal and never opens accelerated increase. */
     quicly_cc_cubic_init.cb(&quicly_cc_cubic_init, &cc, initcwnd, 0, 1, 0);

--- a/t/cc.c
+++ b/t/cc.c
@@ -531,8 +531,7 @@ static void test_cubic_accel_adaptation_accelerated_increase(void)
     ok(cc.cwnd == (uint32_t)(80 * mtu * QUICLY_BETA_LOSS));
 
     cc.type->cc_on_acked(&cc, &loss, mtu, 29, mtu, 1, 30, 1300, mtu);
-    uint32_t accelerated_cwnd =
-        accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON);
+    uint32_t accelerated_cwnd = accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON);
     control = cc;
     control.accel_adaptation = 0;
     cc.type->cc_on_acked(&cc, &loss, mtu, 30, mtu, 1, 31, 1400, mtu);
@@ -541,8 +540,7 @@ static void test_cubic_accel_adaptation_accelerated_increase(void)
 
     /* An aggregate ACK for one post-reduction flight applies the accelerated increase. */
     uint32_t bytes_acked = cc.cwnd;
-    accelerated_cwnd =
-        accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, bytes_acked, QUICLY_CC_ACCEL_ADAPTATION_ON);
+    accelerated_cwnd = accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, bytes_acked, QUICLY_CC_ACCEL_ADAPTATION_ON);
     control = cc;
     control.accel_adaptation = 0;
     cc.type->cc_on_acked(&cc, &loss, bytes_acked, 31, bytes_acked, 1, 32, 1500, mtu);
@@ -691,8 +689,7 @@ static void test_cubic_accel_adaptation_guards(void)
     loss.rtt.latest = 11;
     loss.rtt.smoothed = 11;
     cc.state.pico.accel.min_rtt_current_period = 11;
-    ok(fabs(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) - 2. / 13) <
-       0.000001);
+    ok(fabs(accel_calc_increase_ratio(&cc.state.pico.accel, &loss.rtt, QUICLY_CC_ACCEL_ADAPTATION_ON) - 2. / 13) < 0.000001);
     /* full_rtt does not limit the increase rate while both RTT gates remain open. */
     cc.state.pico.accel.min_rtt_previous_period = 200;
     cc.state.pico.accel.min_rtt_current_period = 100;
@@ -720,8 +717,7 @@ static void test_cubic_accel_adaptation_guards(void)
     control = cc;
     control.accel_adaptation = 0;
     loss.rtt.latest = 81;
-    uint32_t accelerated_cwnd =
-        accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON);
+    uint32_t accelerated_cwnd = accel_calc_cubic_cwnd(&cc.state.pico.accel, &loss.rtt, cc.cwnd, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON);
     ok(accelerated_cwnd > cc.cwnd);
     cc.type->cc_on_acked(&cc, &loss, mtu, 20, mtu, 1, 21, 1100, mtu);
     control.type->cc_on_acked(&control, &loss, mtu, 20, mtu, 1, 21, 1100, mtu);
@@ -770,14 +766,13 @@ static void test_cubic_accel_adaptation_recalibration(void)
     cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 2000, mtu);
     ok(cc.state.pico.accel.last_high_queue_at == 1000);
     ok(cc.state.pico.accel.high_rtt_interval == 0);
-    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu,
-                          QUICLY_CC_ACCEL_ADAPTATION_INCREASE_ALWAYS, INT64_MAX));
+    ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, QUICLY_CC_ACCEL_ADAPTATION_INCREASE_ALWAYS,
+                          INT64_MAX));
     ok(cc.state.pico.accel.high_rtt_interval == 0);
     double k = fast_cbrt((cc.ssthresh / QUICLY_BETA_LOSS - cc.ssthresh) / (QUICLY_CUBIC_C * mtu));
     ok(!accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON, 1000));
     ok(cc.state.pico.accel.high_rtt_interval != 0);
-    ok(cc.state.pico.accel.high_rtt_interval <
-       k * fast_cbrt(cc.state.pico.accel.full_rtt / loss.rtt.minimum) * 1000);
+    ok(cc.state.pico.accel.high_rtt_interval < k * fast_cbrt(cc.state.pico.accel.full_rtt / loss.rtt.minimum) * 1000);
     ok(accel_recalibrate(&cc.state.pico.accel, &loss.rtt, cc.ssthresh, mtu, QUICLY_CC_ACCEL_ADAPTATION_ON,
                          1000 + 2 * (int64_t)cc.state.pico.accel.high_rtt_interval));
 
@@ -921,8 +916,7 @@ static void test_cuback_accel_adaptation_recalibration(void)
     double cwnd_before_reduction = cc.ssthresh / QUICLY_BETA_LOSS;
     double k = fast_cbrt((cwnd_before_reduction - cc.ssthresh) / (QUICLY_CUBIC_C * mtu));
     double reno = QUICLY_CUBIC_C * k * k * k / cubic_friendly_alpha[0] * cc.state.pico.accel.full_rtt / 1000;
-    uint32_t expected_interval = (k < reno ? k : reno) *
-                                 fast_cbrt(cc.state.pico.accel.full_rtt / loss.rtt.minimum) * 1000;
+    uint32_t expected_interval = (k < reno ? k : reno) * fast_cbrt(cc.state.pico.accel.full_rtt / loss.rtt.minimum) * 1000;
     ok(calculated_interval == expected_interval);
 
     cc.state.pico.accel.high_rtt_interval = 3000;

--- a/t/jumpstart.c
+++ b/t/jumpstart.c
@@ -37,7 +37,7 @@ static void test_jumpstart_pattern(quicly_init_cc_t *init, const struct test_jum
     uint32_t packets_acked = 0, packets_inflight = 0;
     size_t ackcnt = 0;
 
-    init->cb(init, &cc, 10 * mtu, 0, now);
+    init->cb(init, &cc, 10 * mtu, 0, 0, now);
     ok(cc.cwnd == 10 * mtu);
     ok(cc.num_loss_episodes == 0);
 

--- a/t/simulator.c
+++ b/t/simulator.c
@@ -151,12 +151,6 @@ struct net_delay {
     struct net_queue queue;
 };
 
-struct net_random_loss {
-    struct net_node super;
-    struct net_node *next_node;
-    double loss_ratio;
-};
-
 /**
  * The discipline the queues of the bottleneck run. It is orthogonal to whether the flows are isolated; fq_codel (RFC 8290) is
  * `NET_AQM_CODEL` combined with isolation.
@@ -176,6 +170,13 @@ struct net_aqm {
  * given addresses sequentially, the address is used as the index.
  */
 #define NET_BOTTLENECK_MAX_QUEUES 20
+
+struct net_random_loss {
+    struct net_node super;
+    struct net_node *next_node;
+    double loss_ratios[NET_BOTTLENECK_MAX_QUEUES];
+};
+
 /**
  * Number of bytes a queue is allowed to send in one round of deficit round robin.
  */
@@ -301,8 +302,10 @@ static void net_delay_init(struct net_delay *self, double delay)
 static void net_random_loss_forward(struct net_node *_self, struct net_packet *packet)
 {
     struct net_random_loss *self = (struct net_random_loss *)_self;
+    uint32_t index = ntohl(packet->src->addr.sin.sin_addr.s_addr);
+    assert(index < PTLS_ELEMENTSOF(self->loss_ratios) && "the endpoints are given addresses sequentially, starting from one");
 
-    if (rand() % 65536 < self->loss_ratio * 65536) {
+    if (rand() % 65536 < self->loss_ratios[index] * 65536) {
         printf("{\"random-loss\": \"drop\", \"at\": %f, \"packet-src\": %" PRIu32 "}\n", now,
                ntohl(packet->src->addr.sin.sin_addr.s_addr));
         net_packet_destroy(packet);
@@ -317,11 +320,10 @@ static double net_random_loss_next_run_at(struct net_node *self)
     return INFINITY;
 }
 
-static void net_random_loss_init(struct net_random_loss *self, double loss_ratio)
+static void net_random_loss_init(struct net_random_loss *self)
 {
     *self = (struct net_random_loss){
         .super = {net_random_loss_forward, net_random_loss_next_run_at, NULL},
-        .loss_ratio = loss_ratio,
     };
 }
 
@@ -1207,6 +1209,7 @@ int main(int argc, char **argv)
     struct net_node *nodes[20] = {}, **node_insert_at = nodes;
 
     net_endpoint_init(&server_node.node, 0, 0);
+    net_random_loss_init(&random_loss_node);
     server_node.accept_ctx = quicctx;
     server_node.node.accept_ctx = &server_node.accept_ctx;
     *node_insert_at++ = &server_node.node.super;
@@ -1239,7 +1242,7 @@ int main(int argc, char **argv)
             /* the context is retained by the connection being created below, therefore it has to be allocated on heap */
             quicly_context_t *flow_ctx = malloc(sizeof(*flow_ctx));
             *flow_ctx = quicctx;
-            double flow_delay = delay, flow_start = start;
+            double flow_delay = delay, flow_start = start, flow_random_loss = random_loss;
             double flow_ack_scheduler_probability = ack_scheduler_probability, flow_ack_scheduler_delay = ack_scheduler_delay;
 
             int flow_argc = seg_end - seg_start + 1;
@@ -1250,7 +1253,8 @@ int main(int argc, char **argv)
             if (seg_end < argc)
                 argv[seg_end] = NULL;
 
-            if (!parse_options(flow_argc, flow_argv, flow_ctx, &flow_delay, &flow_start, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+            if (!parse_options(flow_argc, flow_argv, flow_ctx, &flow_delay, &flow_start, NULL, NULL, NULL, &flow_random_loss, NULL,
+                               NULL, NULL,
                                &flow_ack_scheduler_probability, &flow_ack_scheduler_delay, NULL))
                 exit(1);
             flow_argv[0] = saved_argv0;
@@ -1267,6 +1271,9 @@ int main(int argc, char **argv)
 
             struct net_endpoint *client_node = malloc(sizeof(*client_node));
             net_endpoint_init(client_node, flow_ack_scheduler_probability, flow_ack_scheduler_delay);
+            uint32_t client_index = ntohl(client_node->addr.sin.sin_addr.s_addr);
+            assert(client_index < PTLS_ELEMENTSOF(random_loss_node.loss_ratios));
+            random_loss_node.loss_ratios[client_index] = flow_random_loss;
             client_node->start_at = now + flow_start;
             int ret = quicly_connect(&client_node->conns[0].quic, flow_ctx, "hello.example.com", &server_node.node.addr.sa,
                                      &client_node->addr.sa, &next_quic_cid, ptls_iovec_init(NULL, 0), NULL, NULL, NULL);
@@ -1294,8 +1301,10 @@ int main(int argc, char **argv)
     *node_insert_at++ = &bottleneck_node.super;
 
     /* setup random loss */
-    if (random_loss != 0) {
-        net_random_loss_init(&random_loss_node, random_loss);
+    int has_random_loss = 0;
+    for (size_t i = 0; i < PTLS_ELEMENTSOF(random_loss_node.loss_ratios); ++i)
+        has_random_loss |= random_loss_node.loss_ratios[i] != 0;
+    if (has_random_loss) {
         random_loss_node.next_node = &server_node.node.super;
         bottleneck_node.next_node = &random_loss_node.super;
         *node_insert_at++ = &random_loss_node.super;

--- a/t/simulator.c
+++ b/t/simulator.c
@@ -1258,8 +1258,7 @@ int main(int argc, char **argv)
                 argv[seg_end] = NULL;
 
             if (!parse_options(flow_argc, flow_argv, flow_ctx, &flow_delay, &flow_start, NULL, NULL, NULL, &flow_random_loss, NULL,
-                               NULL, NULL,
-                               &flow_ack_scheduler_probability, &flow_ack_scheduler_delay, NULL))
+                               NULL, NULL, &flow_ack_scheduler_probability, &flow_ack_scheduler_delay, NULL))
                 exit(1);
             flow_argv[0] = saved_argv0;
             if (seg_end < argc)

--- a/t/simulator.c
+++ b/t/simulator.c
@@ -872,6 +872,7 @@ static void usage(const char *cmd)
            "                      fq_codel\n"
            "  -r <probability>    adds random loss at given probability (default: 0)\n"
            "  -R                  turns on rapid start\n"
+           "  -T                  turns on random loss tolerance\n"
            "  -s <seconds>        delay until the sender is added to the simulation\n"
            "                      (default: 0)\n"
            "  -t                  emits trace as well\n"
@@ -931,7 +932,7 @@ static int parse_options(int argc, char **argv, quicly_context_t *quicctx, doubl
 {
     reset_getopt_state();
     int ch;
-    while ((ch = getopt(argc, argv, "A:Ba:b:c:d:EFi:j:l:m:Mpq:r:Rs:th")) != -1) {
+    while ((ch = getopt(argc, argv, "A:Ba:b:c:d:EFi:j:l:m:Mpq:r:RTs:th")) != -1) {
 
         switch (ch) {
         case 'a': {
@@ -1070,6 +1071,9 @@ static int parse_options(int argc, char **argv, quicly_context_t *quicctx, doubl
             break;
         case 'R':
             quicctx->enable_ratio.rapid_start = 255;
+            break;
+        case 'T':
+            quicctx->random_loss_tolerance = 1;
             break;
         case 's':
             if (sscanf(optarg, "%lf", start) != 1) {

--- a/t/simulator.c
+++ b/t/simulator.c
@@ -174,6 +174,7 @@ struct net_aqm {
 struct net_random_loss {
     struct net_node super;
     struct net_node *next_node;
+    void (*random_bytes)(void *buf, size_t len);
     double loss_ratios[NET_BOTTLENECK_MAX_QUEUES];
 };
 
@@ -305,7 +306,9 @@ static void net_random_loss_forward(struct net_node *_self, struct net_packet *p
     uint32_t index = ntohl(packet->src->addr.sin.sin_addr.s_addr);
     assert(index < PTLS_ELEMENTSOF(self->loss_ratios) && "the endpoints are given addresses sequentially, starting from one");
 
-    if (rand() % 65536 < self->loss_ratios[index] * 65536) {
+    uint32_t random_value;
+    self->random_bytes(&random_value, sizeof(random_value));
+    if ((double)random_value / ((double)UINT32_MAX + 1) < self->loss_ratios[index]) {
         printf("{\"random-loss\": \"drop\", \"at\": %f, \"packet-src\": %" PRIu32 "}\n", now,
                ntohl(packet->src->addr.sin.sin_addr.s_addr));
         net_packet_destroy(packet);
@@ -320,10 +323,11 @@ static double net_random_loss_next_run_at(struct net_node *self)
     return INFINITY;
 }
 
-static void net_random_loss_init(struct net_random_loss *self)
+static void net_random_loss_init(struct net_random_loss *self, void (*random_bytes)(void *buf, size_t len))
 {
     *self = (struct net_random_loss){
         .super = {net_random_loss_forward, net_random_loss_next_run_at, NULL},
+        .random_bytes = random_bytes,
     };
 }
 
@@ -1209,7 +1213,7 @@ int main(int argc, char **argv)
     struct net_node *nodes[20] = {}, **node_insert_at = nodes;
 
     net_endpoint_init(&server_node.node, 0, 0);
-    net_random_loss_init(&random_loss_node);
+    net_random_loss_init(&random_loss_node, tlsctx.random_bytes);
     server_node.accept_ctx = quicctx;
     server_node.node.accept_ctx = &server_node.accept_ctx;
     *node_insert_at++ = &server_node.node.super;

--- a/t/simulator.c
+++ b/t/simulator.c
@@ -878,7 +878,7 @@ static void usage(const char *cmd)
            "                      fq_codel\n"
            "  -r <probability>    adds random loss at given probability (default: 0)\n"
            "  -R                  turns on rapid start\n"
-           "  -T                  turns on random loss tolerance\n"
+           "  -T                  turns on accelerated bottleneck bandwidth adaptation\n"
            "  -s <seconds>        delay until the sender is added to the simulation\n"
            "                      (default: 0)\n"
            "  -t                  emits trace as well\n"
@@ -1079,7 +1079,7 @@ static int parse_options(int argc, char **argv, quicly_context_t *quicctx, doubl
             quicctx->enable_ratio.rapid_start = 255;
             break;
         case 'T':
-            quicctx->random_loss_tolerance = 1;
+            quicctx->accel_adaptation = QUICLY_CC_ACCEL_ADAPTATION_ON;
             break;
         case 's':
             if (sscanf(optarg, "%lf", start) != 1) {


### PR DESCRIPTION
## Problem

Radio paths violate an assumption CUBIC depends on: that available bandwidth is roughly stable. Radio quality varies, and handover between stations or satellites moves capacity in steps. When capacity drops the queue overflows; when it recovers the flow is left well under the pipe, and CUBIC's cubic-curve recovery is too slow to climb back before the next disturbance.

What's needed is to increase CWND faster whenever the flow is demonstrably below the pipe.

The same condition — an empty queue while the flow is not the constraint — is what random loss also produces, so the mechanism additionally mitigates underutilization on lossy paths. On a lossy Corporate_WiFi profile CUBIC holds **46.7%** of link goodput at 5% loss-per-RTT and **34.3%** at 10%.

## Approach

ABBA combines two ideas.

**1. Increase rapidly while RTT sits at the floor.** When the latest RTT is at its minimum and being driven down, the bottleneck queue is empty and the flow is not the constraint. ABBA adds a second growth term alongside the CUBIC/Cuback curve and takes the larger of the two, at `max(2ms / rtt_threshold, 2.5%)` per RTT — about 2 ms of additional queue per round. RTT feedback lags a round, so this self-limits near 4.5 ms of standing queue and stops. The threshold adapts: `(minRTT + previous_period_min) / 2`, floored at `minRTT + 2ms`, capped at `current_period_min + 2ms`.

**2. Gate on confirmed queue existence.** Acceleration requires prior evidence that this path *has* a queue to refill: `full_rtt` — the smoothed RTT captured when the first recovery exits — must exceed `minRTT + 10ms` and sit more than 5% above the latest RTT.

The gate is not only a safety guard. Because `full_rtt` is a live estimate of what a full queue looks like, it also drives the second recovery mechanism: if smoothed RTT stays below `(minRTT + full_rtt) / 2` for twice the time a non-losing CUBIC flow would need to rebuild the queue, the path characteristics may have changed. The controller retains CWND, discards the CA trajectory, and re-enters slow start to re-learn `full_rtt`.

That second path is what carries the design under frequent loss, where the flow never rebuilds a queue on its own and the RTT gate alone has nothing to work with. It is directly visible in the policy comparison: LTE CUBIC standalone at 10% loss/RTT reaches **90.6%** with recalibration enabled and **80.6%** without.

ECN-CE counts as a high-queue observation, including marks received inside a recovery period.

## Safety: increase-side only

**ABBA never suppresses, defers, or scales a congestion response.** Every loss and every CE mark produces the same multiplicative decrease as stock CUBIC/Cuback. `beta` is derived solely from the controller type and whether the signal was ECN; nothing on the reduction path is conditioned on ABBA state or policy.

This is deliberately not a random-loss classifier. A classifier decides a loss was non-congestive and withholds the reduction, which stakes correctness on the classification being right — and it is wrong precisely when real congestion resembles random loss. ABBA declines that trade: it buys recovery entirely on the increase side and pays full price on every signal. The consequence is that a misfiring RTT gate on some path nobody simulated costs one round of over-growth followed by a normal decrease, rather than a missed congestion response. The bound holds by construction, not by calibration.

The same invariant covers the capacity *drop* described above: the reduction path is untouched, so the resulting queue overflow produces the standard response, with ABBA contributing at most its ~4.5 ms of extra queue at the moment of the drop.

Recalibration re-enters slow start from a large CWND, which needs its own argument. It is gated on the *absence* of queue pressure from any source: `last_high_queue_at` is refreshed whenever smoothed RTT reaches the midpoint between `minRTT` and `full_rtt`, and whenever a CE mark arrives, so the timer matures only after sustained evidence that neither the flow itself nor any competitor is queueing at the bottleneck. The wait is measured in CUBIC's own units — `high_rtt_interval` is how long a flow at this window scale takes to climb back from a reduction and refill the queue — and recalibration needs twice that to pass untouched. CUBIC would have filled the pipe twice over; nothing did.

## Design criteria and results

Simulator, 18 network profiles × {tail-drop, CoDel}. Loss probability is set so a full pipe sees at least one loss per RTT with the stated probability. Standalone: 7×100 s runs measuring the last 50 s. Competition: 7×160 s per flow order measuring the last 80 s. Self-competition: 5×320 s, final 40 s window. Full tables are in the commit messages of `2766165` (0x2) and `2a2cde1` (0x1).

**On par with stock when the network is stable and lossless.** Clean-path competition against stock sits at parity on every profile; the widest deviations are Corporate_WiFi 58.1/44.1 and WiFi@Office 53.3/45.3, both inside the stock-vs-stock baseline spread. On the shallow synthetic queues the gate correctly keeps acceleration off entirely: `queue5ms` 49.6/49.6, `queue2.5ms` 51.0/50.8.

**Recovers quickly under random loss** (standalone goodput, stock → ABBA, tail-drop):

| Profile | CUBIC 5% | CUBIC 10% | Cuback 5% | Cuback 10% |
|---|---|---|---|---|
| Corporate_WiFi | 46.7 → **97.5** | 34.3 → **97.1** | 55.1 → **97.6** | 34.4 → **97.3** |
| WiFi@Office | 72.5 → **97.7** | 51.6 → **97.7** | 72.4 → **97.7** | 50.0 → **97.7** |
| 5G | 60.6 → **95.0** | 39.9 → **90.7** | 64.7 → **96.7** | 43.3 → **93.5** |
| Home_WiFi | 51.7 → **93.8** | 36.5 → **88.4** | 51.9 → **95.6** | 35.9 → **91.0** |
| LTE | 89.0 → **95.1** | 62.9 → **90.6** | 89.6 → **97.3** | 67.6 → **94.4** |
| LEO | 80.1 → **95.8** | 53.4 → **91.3** | 75.3 → **97.5** | 56.9 → **94.7** |

**Stays below a competing stock flow that is not experiencing loss.** This was a design criterion, and it is met with margin: a lossy ABBA flow against a clean stock flow takes **17–49%** across all profiles — never parity. Ten clean CUBIC flows against one ABBA flow on DSL (15 repetitions, mean of flow-order medians): the ABBA flow takes **10.21%** with no loss and **9.62%** at 5% loss/RTT, against a 10% fair share.

**Self-converges.** When loss is rare the gates stay shut and behavior reduces to stock, which converges; acceleration is additionally self-limiting, since a flow that opens its gate builds queue and closes it again. When loss is frequent, recalibration is the convergence driver — both flows re-probe symmetrically. Self-competition at 5% loss gives medians near 50% with 85–98% utilization across all profiles.

## Policy flags

`quicly_context_t::accel_adaptation` replaces the earlier boolean. **Default is 0 (off).**

| Flag | Value | Behavior |
|---|---|---|
| `QUICLY_CC_ACCEL_ADAPTATION_INCREASE_ALWAYS` | `0x1` | Bypasses the `full_rtt` guard; adaptive RTT gate still applies |
| `QUICLY_CC_ACCEL_ADAPTATION_RECALIBRATE` | `0x2` | Observes `full_rtt`, enables recalibration, and (unless `0x1`) uses `full_rtt` as the increase guard |
| `QUICLY_CC_ACCEL_ADAPTATION_ON` | `= 0x2` | Recommended setting; what simulator `-T` selects |

`full_rtt` and high-queue observations are maintained regardless of policy; the flags govern only how they are consumed. `0x1` drops both roles of the gate at once — it is weaker standalone under heavy loss (LTE CUBIC 80.6% vs 90.6% at 10%/RTT, for the reason above) and on the synthetic `queue5ms`/`queue2.5ms` profiles takes 63–77% share against stock. Those profiles are stress cases rather than representative access-network queues, but they show what the gate is buying.

## Open items

- All results are from the simulator, which is not a real network. Its bottleneck rate is fixed, so the bandwidth-step case that motivates the design is argued from mechanism rather than demonstrated; beyond that it does not model correlated radio loss, ACK aggregation, or real cross traffic. Real-network validation is pending.
- `0x3` has unit coverage but no benchmark run.
- `-T` takes no argument, so `0x1`/`0x3` aren't selectable from the simulator; the `0x1` figures come from a separate always-increase build.
- Competition between *lossy* ABBA flows at different RTTs is untested. The increase rate targets an absolute queue depth (2 ms per round), so in wall-clock terms a short-RTT flow builds queue faster than a long-RTT one; whether this compounds CUBIC's existing RTT bias is an open question. Flows not experiencing non-congestive loss are unaffected, the gates keeping them on the stock trajectory.
- If the path's idle RTT rises during a connection, ABBA as implemented becomes less effective: the increase gate cannot rise above `(rtt->minimum + min_rtt_previous_period) / 2`, and `rtt->minimum` only ever moves down.
- All competition data is against stock CUBIC/Cuback. Behavior against BBR — a realistic peer on these paths, and one that deliberately drains the queue — is untested.

Closes #687.
