### PR TITLE
Fix ubsan findings in pacer/frame

### DIFF
--- a/include/quicly/frame.h
+++ b/include/quicly/frame.h
@@ -516,7 +516,12 @@ Error:
 
 inline size_t quicly_close_frame_capacity(uint64_t error_code, uint64_t offending_frame_type, const char *reason_phrase)
 {
-    return quicly_encode_close_frame(NULL, error_code, offending_frame_type, reason_phrase) - (uint8_t *)NULL;
+    size_t reason_phrase_len = strlen(reason_phrase);
+    return quicly_encodev_capacity(offending_frame_type == UINT64_MAX ? QUICLY_FRAME_TYPE_APPLICATION_CLOSE
+                                                                      : QUICLY_FRAME_TYPE_TRANSPORT_CLOSE) +
+           quicly_encodev_capacity(error_code) +
+           (offending_frame_type == UINT64_MAX ? 0 : quicly_encodev_capacity(offending_frame_type)) +
+           quicly_encodev_capacity(reason_phrase_len) + reason_phrase_len;
 }
 
 inline uint8_t *quicly_encode_max_data_frame(uint8_t *dst, uint64_t max_data)

--- a/include/quicly/pacer.h
+++ b/include/quicly/pacer.h
@@ -110,7 +110,7 @@ inline uint64_t quicly_pacer_get_window(quicly_pacer_t *pacer, int64_t now, uint
      * `bytes_per_msec`. Adjust `bytes_sent` by that amount before setting `restricted_at` to `now`. `uint64_t` is used to store
      * window and delta so that the multiplication would not overflow assuming that the quiescence period is shorter than 2**32
      * milliseconds. */
-    uint64_t window, delta = (now - pacer->at) * bytes_per_msec;
+    uint64_t window, delta = pacer->at == INT64_MIN ? UINT64_MAX : ((uint64_t)now - (uint64_t)pacer->at) * bytes_per_msec;
     if (pacer->bytes_sent > delta) {
         pacer->bytes_sent -= delta;
         if (burst_window > pacer->bytes_sent) {

--- a/lib/frame.c
+++ b/lib/frame.c
@@ -151,5 +151,5 @@ uint8_t *quicly_encode_close_frame(uint8_t *const base, uint64_t error_code, uin
 
 #undef PUSHV
 
-    return base + offset;
+    return base != NULL ? base + offset : NULL;
 }

--- a/t/frame.c
+++ b/t/frame.c
@@ -180,9 +180,21 @@ static void test_mozquic(void)
     quicly_decode_stream_frame(type_flags, &p, p + 9, &frame);
 }
 
+static void test_close_encode(void)
+{
+    uint8_t buf[64], *end;
+
+    end = quicly_encode_close_frame(buf, 0x1234, 0x3fff, "hello");
+    ok(end - buf == quicly_close_frame_capacity(0x1234, 0x3fff, "hello"));
+
+    end = quicly_encode_close_frame(buf, 0x1234, UINT64_MAX, "hello");
+    ok(end - buf == quicly_close_frame_capacity(0x1234, UINT64_MAX, "hello"));
+}
+
 void test_frame(void)
 {
     subtest("ack-decode", test_ack_decode);
     subtest("ack-encode", test_ack_encode);
+    subtest("close-encode", test_close_encode);
     subtest("mozquic", test_mozquic);
 }


### PR DESCRIPTION
This PR fixes two undefined-behavior reports found via ubsan:

 - Avoid signed overflow when calculating the initial pacer window from the `INT64_MIN` reset sentinel.
 - Avoid null-pointer arithmetic when calculating `CONNECTION_CLOSE` frame capacity.
